### PR TITLE
Industry restructure

### DIFF
--- a/datasets/_defaults/graph/excel_ids.yml
+++ b/datasets/_defaults/graph/excel_ids.yml
@@ -511,3 +511,4 @@ industry_final_demand_for_metal_crude_oil: {excel_id: 681}
 industry_final_demand_for_other_crude_oil: {excel_id: 682}
 industry_final_demand_for_metal_steam_hot_water: {excel_id: 683}
 industry_final_demand_for_other_steam_hot_water: {excel_id: 684}
+industry_final_demand_for_heat_steam_hot_water: {excel_id: 685}

--- a/datasets/ame/graph/industry.yml
+++ b/datasets/ame/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 0.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 15300000.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0}

--- a/datasets/ams/graph/industry.yml
+++ b/datasets/ams/graph/industry.yml
@@ -336,6 +336,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 0.0
@@ -691,7 +697,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 0.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0}

--- a/datasets/be-vlg/graph/industry.yml
+++ b/datasets/be-vlg/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 3896000000.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 253559800000.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.160120019025098}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.160120019025098}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.203502290189533}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.282166179339154}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0122921693423011}

--- a/datasets/be/graph/industry.yml
+++ b/datasets/be/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 21470000000.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 377787878680.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0623833037797453}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0623833037797453}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.158425411130504}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.209906124455544}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0454646667331238}

--- a/datasets/br/graph/industry.yml
+++ b/datasets/br/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 5979447448.61568
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 53368201941.1469
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.108377029572372}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.108377029572372}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.365232540147691}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.0104701512305624}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0896331108207043}

--- a/datasets/de/graph/industry.yml
+++ b/datasets/de/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 156342762.914494
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 1695973419755.89
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.237744881672754}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.237744881672754}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.260242371524624}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.208774209474912}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 7.37477420781735e-05}

--- a/datasets/grs/graph/industry.yml
+++ b/datasets/grs/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 0.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 1807760000.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.813105721998495}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.813105721998495}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0}

--- a/datasets/nl-drenthe/graph/industry.yml
+++ b/datasets/nl-drenthe/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 198140192.339946
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 4724927069.61768
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.264190196292994}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.264190196292994}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.050187903156701}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.229896459986251}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0335480636074205}

--- a/datasets/nl-flevoland/graph/industry.yml
+++ b/datasets/nl-flevoland/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 76431501.0437958
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 2597397358.88935
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.235620173151829}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.235620173151829}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0352172609000915}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.32910407875037}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0235409497995264}

--- a/datasets/nl-friesland/graph/industry.yml
+++ b/datasets/nl-friesland/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 187477029.92893
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 6273622415.95198
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.236664386287691}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.236664386287691}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0357644267605952}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.325478113934756}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.023906702380077}

--- a/datasets/nl-gelderland/graph/industry.yml
+++ b/datasets/nl-gelderland/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 759901804.815436
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 25852735857.5961
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.235545464398699}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.235545464398699}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0351781136438562}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.329363500223789}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0235147818474975}

--- a/datasets/nl-groningen/graph/industry.yml
+++ b/datasets/nl-groningen/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 637822407.354338
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 29851564141.7662
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.217211952842112}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.217211952842112}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0255713855895964}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.393025472638954}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0170931721855591}

--- a/datasets/nl-limburg/graph/industry.yml
+++ b/datasets/nl-limburg/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 2679594979.43288
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 71197723893.0763
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.25437111522789}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.25437111522789}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.045042721817925}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.26399260495987}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0301087712686664}

--- a/datasets/nl-noord-brabant/graph/industry.yml
+++ b/datasets/nl-noord-brabant/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 2139188978.49865
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 65293285352.5311
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.243240854735774}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.243240854735774}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0392104847480759}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.30264173850069}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0262102170775909}

--- a/datasets/nl-noord-holland/graph/industry.yml
+++ b/datasets/nl-noord-holland/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 3101100784.45682
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 99114469285.0315
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.2398726783064}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.2398726783064}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0374455661782817}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.314337520526645}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.025030458675322}

--- a/datasets/nl-noord/graph/industry.yml
+++ b/datasets/nl-noord/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 1062218711.62328
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 42287546730.5657
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.217963435197973}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.217963435197973}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: -2.99492306862077e-16}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0200951588587759}

--- a/datasets/nl-overijssel/graph/industry.yml
+++ b/datasets/nl-overijssel/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 394931797.290225
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 9656345095.3928
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.261823090496171}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.261823090496171}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0489475438509807}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.238116086841478}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0327189464244523}

--- a/datasets/nl-utrecht/graph/industry.yml
+++ b/datasets/nl-utrecht/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 111290853.710973
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 5080097513.35195
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.218447042257746}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.218447042257746}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0262185702875237}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.38873670187806}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0175257822777565}

--- a/datasets/nl-zeeland/graph/industry.yml
+++ b/datasets/nl-zeeland/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 2839738566.70175
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 78298778245.1664
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.251246672200941}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.251246672200941}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0434055191255612}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.274842037987495}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0290143844422201}

--- a/datasets/nl-zuid-holland/graph/industry.yml
+++ b/datasets/nl-zuid-holland/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 1874381104.42626
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 89082653771.6287
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.216468417893782}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.216468417893782}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0251817745745221}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.395607351250924}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0168327370150549}

--- a/datasets/nl/graph/industry.yml
+++ b/datasets/nl/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 3330000000.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 503179235704.396
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.30154066232005}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.30154066232005}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.00434932096698377}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.315205176894811}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.00529433611518307}

--- a/datasets/pl/graph/industry.yml
+++ b/datasets/pl/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 44667043664.4
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 636436754931.52
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.24029253309931}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.24029253309931}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.207368287543671}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.122659194955514}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0561464036365482}

--- a/datasets/ro/graph/industry.yml
+++ b/datasets/ro/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 8990000000.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 407346900000.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0557755564115009}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0557755564115009}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.17838358411467}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.1987247233255}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0176557131034997}

--- a/datasets/tr/graph/industry.yml
+++ b/datasets/tr/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 0.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 557484200000.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0857602780491357}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0857602780491357}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.555452513273022}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: -0.0980544381347489}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0}

--- a/datasets/uk/graph/industry.yml
+++ b/datasets/uk/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 17456781132.5319
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 1002161866730.34
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0390157820089168}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0390157820089168}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0563990732990334}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.333656934488354}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0139352986475022}

--- a/datasets/ut/graph/industry.yml
+++ b/datasets/ut/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 4320000000.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 493769700000.0
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.29406421657708}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.29406421657708}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.0335217005012661}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.30541100436094}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.00699921441109084}

--- a/datasets/za/graph/industry.yml
+++ b/datasets/za/graph/industry.yml
@@ -338,6 +338,12 @@ industry_final_demand_for_heat_network_gas-(network_gas): {conversion: 1.0}
 (network_gas)-industry_final_demand_for_heat_network_gas: {conversion: 1.0}
 industry_final_demand_for_heat_network_gas-(network_gas) -- s --> (network_gas)-industry_final_demand_for_other_network_gas: {share: 1.0}
 
+:industry_final_demand_for_heat_steam_hot_water:
+  :co2_free: 0.0
+industry_final_demand_for_heat_steam_hot_water-(useable_heat): {conversion: 1.0}
+(useable_heat)-industry_final_demand_for_heat_steam_hot_water: {conversion: 1.0}
+industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 1.0}
+
 :industry_final_demand_for_heat_wood_pellets:
   :co2_free: 0.0
   :demand_expected_value: 0.0
@@ -693,7 +699,7 @@ industry_useful_demand_network_gas_non_energetic-(network_gas) -- s --> (network
   :preset_demand: 521191063483.69
 industry_useful_demand_useable_heat-(useable_heat): {conversion: 1.0}
 (useable_heat)-industry_useful_demand_useable_heat: {conversion: 1.0}
-industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water: {share: 0.0}
+industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water: {share: 0.0}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal: {share: 0.767417430004566}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil: {share: 0.0515773099101328}
 industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets: {share: 0.0}

--- a/topology/export.graph
+++ b/topology/export.graph
@@ -3986,6 +3986,15 @@ industry_final_demand_for_heat_network_gas:
   slots:
   - industry_final_demand_for_heat_network_gas-(network_gas)
   - (network_gas)-industry_final_demand_for_heat_network_gas
+industry_final_demand_for_heat_steam_hot_water:
+  sector: industry
+  use: energetic
+  energy_balance_group: application
+  links:
+  - industry_final_demand_for_heat_steam_hot_water-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water
+  slots:
+  - industry_final_demand_for_heat_steam_hot_water-(useable_heat)
+  - (useable_heat)-industry_final_demand_for_heat_steam_hot_water
 industry_final_demand_for_heat_wood_pellets:
   sector: industry
   use: undefined
@@ -4411,7 +4420,7 @@ industry_useful_demand_useable_heat:
   use: energetic
   energy_balance_group: useful consumption
   links:
-  - industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_other_steam_hot_water
+  - industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_final_demand_for_heat_steam_hot_water
   - industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_coal
   - industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_crude_oil
   - industry_useful_demand_useable_heat-(useable_heat) -- s --> (useable_heat)-industry_burner_wood_pellets


### PR DESCRIPTION
Restructure of the Final Demand part of the Industry sector. Helps to separate different sub-sectors more easily. 
The changes do not affect charts or gqueries (as far as I can see).

The graph looked like this:
![snapshot 7 24 13 6 59 pm-2](https://f.cloud.github.com/assets/1303760/850189/6fa7deae-f482-11e2-978d-d03cbb7ab879.png)

The graph will look like this:
![snapshot 7 24 13 6 50 pm](https://f.cloud.github.com/assets/1303760/850171/ebfb6814-f481-11e2-940c-45f72c8afcc0.png)

See https://github.com/quintel/inputexcel/issues/298 for more background.
