### PR TITLE
industry_transformation_generic_coal

### DIFF
--- a/datasets/_defaults/graph/excel_ids.yml
+++ b/datasets/_defaults/graph/excel_ids.yml
@@ -512,3 +512,4 @@ industry_final_demand_for_other_crude_oil: {excel_id: 682}
 industry_final_demand_for_metal_steam_hot_water: {excel_id: 683}
 industry_final_demand_for_other_steam_hot_water: {excel_id: 684}
 industry_final_demand_for_heat_steam_hot_water: {excel_id: 685}
+industry_transformation_generic_losses_coal: {excel_id: 686}

--- a/datasets/ame/graph/industry.yml
+++ b/datasets/ame/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 0.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/ams/graph/industry.yml
+++ b/datasets/ams/graph/industry.yml
@@ -648,8 +648,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 0.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/be-vlg/graph/industry.yml
+++ b/datasets/be-vlg/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 75000000000.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.86}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 10500000000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/be/graph/industry.yml
+++ b/datasets/be/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 123967032000.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.603499162583807}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 49153032000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/br/graph/industry.yml
+++ b/datasets/br/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 28246896615.6
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/de/graph/industry.yml
+++ b/datasets/de/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 620991544800.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.955586116701665}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 27580646000.0001
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/grs/graph/industry.yml
+++ b/datasets/grs/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 0.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-drenthe/graph/industry.yml
+++ b/datasets/nl-drenthe/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 296417727.740559
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-flevoland/graph/industry.yml
+++ b/datasets/nl-flevoland/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 114341525.561518
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-friesland/graph/industry.yml
+++ b/datasets/nl-friesland/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 280465636.773679
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-gelderland/graph/industry.yml
+++ b/datasets/nl-gelderland/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 1136813100.00389
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-groningen/graph/industry.yml
+++ b/datasets/nl-groningen/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 954182321.402089
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-limburg/graph/industry.yml
+++ b/datasets/nl-limburg/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 4008674089.23158
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-noord-brabant/graph/industry.yml
+++ b/datasets/nl-noord-brabant/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 3200226711.83399
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-noord-holland/graph/industry.yml
+++ b/datasets/nl-noord-holland/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 23639246773.5474
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.196251886449224}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 19000000000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-noord/graph/industry.yml
+++ b/datasets/nl-noord/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 0.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-overijssel/graph/industry.yml
+++ b/datasets/nl-overijssel/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 590817968.746176
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-utrecht/graph/industry.yml
+++ b/datasets/nl-utrecht/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 166491117.151616
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-zeeland/graph/industry.yml
+++ b/datasets/nl-zeeland/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 4248248895.78581
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl-zuid-holland/graph/industry.yml
+++ b/datasets/nl-zuid-holland/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 2804074132.22169
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/nl/graph/industry.yml
+++ b/datasets/nl/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 2811838946.31612
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.972890002673878}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 76228946.3161163
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/pl/graph/industry.yml
+++ b/datasets/pl/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 399654000000.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.488782797119508}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 204310000000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/ro/graph/industry.yml
+++ b/datasets/ro/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 178530000000.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.555480871562202}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 79360000000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/tr/graph/industry.yml
+++ b/datasets/tr/graph/industry.yml
@@ -650,8 +650,14 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :demand_expected_value: 391970000000.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
 (coal)-industry_transformation_generic_coal: {conversion: 1.0}
-(loss)-industry_transformation_generic_coal: {}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 0.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/uk/graph/industry.yml
+++ b/datasets/uk/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 184437042254.722
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.529921308099709}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 86699923561.0584
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/ut/graph/industry.yml
+++ b/datasets/ut/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 36040000000.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.574084350721421}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 15350000000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/datasets/za/graph/industry.yml
+++ b/datasets/za/graph/industry.yml
@@ -649,9 +649,15 @@ industry_steel_production-(not_defined) -- s --> (not_defined)-industry_steel_el
   :co2_free: 0.0
   :demand_expected_value: 1458271967100.0
 industry_transformation_generic_coal-(coal): {conversion: 1.0}
-(coal)-industry_transformation_generic_coal: {conversion: 0.34284680387449}
-(loss)-industry_transformation_generic_coal: {}
+(coal)-industry_transformation_generic_coal: {conversion: 1.0}
 industry_transformation_generic_coal-(coal) -- s --> (coal)-energy_distribution_coal: {share: 1.0}
+
+:industry_transformation_generic_losses_coal:
+  :co2_free: 0.0
+  :preset_demand: 958308084000.0
+industry_transformation_generic_losses_coal-(coal): {conversion: 1.0}
+(loss)-industry_transformation_generic_losses_coal: {}
+industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal: {share: 1.0}
 
 :industry_unused_local_production_steam_hot_water:
   :co2_free: 0.0

--- a/topology/export.graph
+++ b/topology/export.graph
@@ -4360,7 +4360,15 @@ industry_transformation_generic_coal:
   slots:
   - industry_transformation_generic_coal-(coal)
   - (coal)-industry_transformation_generic_coal
-  - ! '(loss)-industry_transformation_generic_coal: {type: :loss}'
+industry_transformation_generic_losses_coal:
+  sector: industry
+  use: energetic
+  energy_balance_group: distribution
+  links:
+  - industry_transformation_generic_losses_coal-(coal) -- s --> (coal)-industry_transformation_generic_coal
+  slots:
+  - industry_transformation_generic_losses_coal-(coal)
+  - ! '(loss)-industry_transformation_generic_losses_coal: {type: :loss}'
 industry_unused_local_production_steam_hot_water:
   sector: industry
   use: energetic


### PR DESCRIPTION
This commit removes the need for an efficiency in the industry_transformation_generic_coal converter by adding (instead of the loss slot) an explicit converter for the loss with a preset demand.

IE_v1985: Created loss converter for generic transformations of coal in industry. 

Fixes https://github.com/quintel/rdr/issues/64
