### PR TITLE
number households hack

### DIFF
--- a/data/inputs/households/households_misc/households_number_of_new_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_new_houses.ad
@@ -1,3 +1,5 @@
+# Update statement for number of old households
+# DEBT: remove the ugly + 1 to prevent division by zero in other queries- factor = 0.000001
 - factor = 0.000001
 - id = 640
 - max_value_gql = present:Q(number_of_new_residences) * 0.000001 * 10
@@ -10,5 +12,5 @@
 EACH(
   UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_heating), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { Q(number_of_new_residences) })),
   UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { Q(number_of_new_residences) })),
-  UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_old_houses) * 1_000_000)
+  UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_old_houses) * 1_000_000 + 1)
 )

--- a/data/inputs/households/households_misc/households_number_of_old_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_old_houses.ad
@@ -1,7 +1,9 @@
+# Update statement for number of old households
+# DEBT: remove the ugly + 1 to prevent division by zero in other queries
 - factor = 0.000001
 - id = 639
 - max_value_gql = present:Q(number_of_old_residences) * 0.000001
-- min_value = 0
+- min_value = 0.0
 - start_value_gql = present:Q(number_of_old_residences)
 - unit = #
 - update_period = future
@@ -10,5 +12,5 @@
 EACH(
   UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_heating), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { Q(number_of_old_residences) })),
   UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { Q(number_of_old_residences) })),
-  UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_new_houses) * 1_000_000)
+  UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_new_houses) * 1_000_000 + 1)
 )


### PR DESCRIPTION
Made inputs for houses robust against division by zero by adding 1 to the number of households.

If this + 1 would be not there, the total number of houses could become 0.0 and many queries would fail as they include a division by AREA(number_households). 
Another possible fix would be to set the min_value for one of the two sliders to a value larger than 0. This will be visible in the front-end though and the limit is quite arbitrary.
