### PR TITLE
remove appliances

### DIFF
--- a/datasets/_defaults/graph/excel_ids.yml
+++ b/datasets/_defaults/graph/excel_ids.yml
@@ -352,14 +352,6 @@ energy_import_biogenic_waste: {excel_id: 521}
 energy_import_non_biogenic_waste: {excel_id: 522}
 energy_production_biogenic_waste: {excel_id: 523}
 energy_production_non_biogenic_waste: {excel_id: 524}
-households_useful_demand_dishwasher: {excel_id: 525}
-households_useful_demand_fridge_freezer: {excel_id: 526}
-households_useful_demand_washing_machine: {excel_id: 527}
-households_useful_demand_clothes_dryer: {excel_id: 528}
-households_useful_demand_television: {excel_id: 529}
-households_useful_demand_computer_media: {excel_id: 530}
-households_useful_demand_vacuum_cleaner: {excel_id: 531}
-households_useful_demand_other_appliances: {excel_id: 532}
 households_final_demand_for_hot_water_solar_thermal: {excel_id: 534}
 households_final_demand_solar_thermal: {excel_id: 535}
 energy_production_solar_thermal: {excel_id: 536}

--- a/datasets/ame/graph/energy.yml
+++ b/datasets/ame/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 0.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/ame/graph/households.yml
+++ b/datasets/ame/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 1896644.49929809
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0663377225970293}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.132675445194059}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 24141857.1489875
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/ams/graph/energy.yml
+++ b/datasets/ams/graph/energy.yml
@@ -1155,7 +1155,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 0.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/ams/graph/households.yml
+++ b/datasets/ams/graph/households.yml
@@ -920,18 +920,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 383611037.619064
@@ -942,12 +930,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.095449098000597}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.190898196001194}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1046,12 +1028,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 3948713931.63937
@@ -1069,30 +1045,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.2}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/be-vlg/graph/energy.yml
+++ b/datasets/be-vlg/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 9400000000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/be-vlg/graph/households.yml
+++ b/datasets/be-vlg/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 2736616996.50757
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.173543977804568}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.347087955609136}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 25236029278.6301
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.2}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/be/graph/energy.yml
+++ b/datasets/be/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 15323688000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/be/graph/households.yml
+++ b/datasets/be/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 4026866135.99729
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.117675535067694}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.235351070135388}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 35605622540.4347
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.2}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/br/graph/energy.yml
+++ b/datasets/br/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 4087135443.77928
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/br/graph/households.yml
+++ b/datasets/br/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 549115664.905115
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0156654335023626}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.0313308670047253}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.238190254547921}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 8779881261.47806
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.15}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/de/graph/energy.yml
+++ b/datasets/de/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 108425000000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/de/graph/households.yml
+++ b/datasets/de/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 74739923618.0346
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.174505165915548}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.349010331831096}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0210294362832236}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 282845549342.524
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.2}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/grs/graph/energy.yml
+++ b/datasets/grs/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 0.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/grs/graph/households.yml
+++ b/datasets/grs/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 111497093.145951
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0961192648777086}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.192238529755417}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 1183544798.8148
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-drenthe/graph/energy.yml
+++ b/datasets/nl-drenthe/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 320333651.478271
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-drenthe/graph/households.yml
+++ b/datasets/nl-drenthe/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 215130712.433844
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 2440613220.51033
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-flevoland/graph/energy.yml
+++ b/datasets/nl-flevoland/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 246277703.581725
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-flevoland/graph/households.yml
+++ b/datasets/nl-flevoland/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 129019267.22098
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 1476579203.31235
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-friesland/graph/energy.yml
+++ b/datasets/nl-friesland/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 445526335.72877
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-friesland/graph/households.yml
+++ b/datasets/nl-friesland/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 296862054.325395
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 3355611147.44006
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-gelderland/graph/energy.yml
+++ b/datasets/nl-gelderland/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 1761629963.64008
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-gelderland/graph/households.yml
+++ b/datasets/nl-gelderland/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 813550084.319633
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 9140031975.14956
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-groningen/graph/energy.yml
+++ b/datasets/nl-groningen/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 1273170285.42825
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-groningen/graph/households.yml
+++ b/datasets/nl-groningen/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 256397302.409869
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 2902600548.81854
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-limburg/graph/energy.yml
+++ b/datasets/nl-limburg/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 1627220357.67112
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-limburg/graph/households.yml
+++ b/datasets/nl-limburg/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 497046675.668225
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 5596716080.90546
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-noord-brabant/graph/energy.yml
+++ b/datasets/nl-noord-brabant/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 2573170586.85991
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-noord-brabant/graph/households.yml
+++ b/datasets/nl-noord-brabant/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 1007199202.78403
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 11307970710.1063
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-noord-holland/graph/energy.yml
+++ b/datasets/nl-noord-holland/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 3550287076.64738
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-noord-holland/graph/households.yml
+++ b/datasets/nl-noord-holland/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 1049246336.23179
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 11778696371.1274
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-noord/graph/energy.yml
+++ b/datasets/nl-noord/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 2039030272.63529
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-noord/graph/households.yml
+++ b/datasets/nl-noord/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 768390069.169107
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 8669634157.9496
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-overijssel/graph/energy.yml
+++ b/datasets/nl-overijssel/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 588992958.219334
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-overijssel/graph/households.yml
+++ b/datasets/nl-overijssel/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 458309882.837206
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 5163050313.08631
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-utrecht/graph/energy.yml
+++ b/datasets/nl-utrecht/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 759047330.129057
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-utrecht/graph/households.yml
+++ b/datasets/nl-utrecht/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 451503357.919971
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 5086849971.27461
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-zeeland/graph/energy.yml
+++ b/datasets/nl-zeeland/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 1524162274.64556
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-zeeland/graph/households.yml
+++ b/datasets/nl-zeeland/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 177000234.621049
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 2013735264.70921
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl-zuid-holland/graph/energy.yml
+++ b/datasets/nl-zuid-holland/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 4960181475.97055
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl-zuid-holland/graph/households.yml
+++ b/datasets/nl-zuid-holland/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 1318224094.50831
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0881809420413242}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.176361884082648}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 14789953564.7238
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.05}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.95}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/nl/graph/energy.yml
+++ b/datasets/nl/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 16070400000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/nl/graph/households.yml
+++ b/datasets/nl/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 7245062374.85448
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0801633505581188}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.160326701116238}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.0}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 83766529627.5323
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.2}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/pl/graph/energy.yml
+++ b/datasets/pl/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 51898000000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/pl/graph/households.yml
+++ b/datasets/pl/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 9165782865.78471
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0682255495590342}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.136451099118068}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.166925184940982}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 101383994832.552
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.143}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.857}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/ro/graph/energy.yml
+++ b/datasets/ro/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 25980000000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/ro/graph/households.yml
+++ b/datasets/ro/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 5321293316.23102
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0463975993379511}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.0927951986759022}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.23414178959082}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 29904782059.0571
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.005}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.085}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.91}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/tr/graph/energy.yml
+++ b/datasets/tr/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 0.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/tr/graph/households.yml
+++ b/datasets/tr/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 16520491541.6949
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0580047554832424}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.116009510966485}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.023928838860653}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 109253976914.181
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.001}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.085}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.914}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/uk/graph/energy.yml
+++ b/datasets/uk/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 97352587850.9312
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/uk/graph/households.yml
+++ b/datasets/uk/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 24528097863.5688
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.107377209037459}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.107377209037459}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: -2.48306697879018e-17}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 282057615372.015
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.2}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.8}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/ut/graph/energy.yml
+++ b/datasets/ut/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 16760000000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/ut/graph/households.yml
+++ b/datasets/ut/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 13660645161.2903
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.158968546330405}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.163785775007084}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.298668177954095}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 97130022931.4331
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.34}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.33}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.33}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/datasets/za/graph/energy.yml
+++ b/datasets/za/graph/energy.yml
@@ -1156,7 +1156,7 @@ energy_power_hv_network_electricity-(electricity) <-- f -- (electricity)-energy_
   :co2_free: 0.0
   :demand_expected_value: 33645600000.0
 energy_power_hv_network_loss-(loss): {conversion: 1.0}
-(electricity)-energy_power_hv_network_loss: {conversion: 1.0}
+(loss)-energy_power_hv_network_loss: {}
 energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity: {}
 
 :energy_power_hydro_mountain:

--- a/datasets/za/graph/households.yml
+++ b/datasets/za/graph/households.yml
@@ -921,18 +921,6 @@ households_space_heater_wood_pellets-(wood_pellets): {conversion: 1.0}
 (useable_heat)-households_space_heater_wood_pellets: {conversion: 0.82}
 households_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-households_final_demand_for_space_heating_wood_pellets: {share: 1.0}
 
-:households_useful_demand_clothes_dryer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_clothes_dryer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_clothes_dryer: {}
-
-:households_useful_demand_computer_media:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_computer_media-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_computer_media: {}
-
 :households_useful_demand_cooking_useable_heat:
   :co2_free: 0.0
   :preset_demand: 29836697493.1811
@@ -943,12 +931,6 @@ households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_h
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_halogen_electricity: {share: 0.0315309527420464}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_induction_electricity: {share: 0.0630619054840927}
 households_useful_demand_cooking_useable_heat-(useable_heat) -- s --> (useable_heat)-households_cooker_wood_pellets: {share: 0.842345236289768}
-
-:households_useful_demand_dishwasher:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_dishwasher-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_dishwasher: {}
 
 :households_useful_demand_for_cooling_after_insulation:
   :co2_free: 0.0
@@ -1047,12 +1029,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_water_heater_solar_thermal: {share: 0.15}
 households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat) -- s --> (useable_heat)-households_useful_demand_for_space_heating_after_insulation_and_solar_heater: {share: 0.85}
 
-:households_useful_demand_fridge_freezer:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_fridge_freezer-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_fridge_freezer: {}
-
 :households_useful_demand_hot_water:
   :co2_free: 0.0
   :demand_expected_value: 66169830954.1356
@@ -1070,30 +1046,6 @@ households_useful_demand_light-(light): {conversion: 1.0}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_led_electricity: {share: 0.001}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_efficient_fluorescent_electricity: {share: 0.01}
 households_useful_demand_light-(light) -- s --> (light)-households_lighting_incandescent_electricity: {share: 0.989}
-
-:households_useful_demand_other_appliances:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_other_appliances-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_other_appliances: {}
-
-:households_useful_demand_television:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_television-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_television: {}
-
-:households_useful_demand_vacuum_cleaner:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_vacuum_cleaner-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_vacuum_cleaner: {}
-
-:households_useful_demand_washing_machine:
-  :co2_free: 0.0
-  :preset_demand: 0.0
-households_useful_demand_washing_machine-(not_defined): {conversion: 1.0}
-(loss)-households_useful_demand_washing_machine: {}
 
 :households_water_heater_coal:
   :availability: 0.0

--- a/topology/export.graph
+++ b/topology/export.graph
@@ -2052,7 +2052,7 @@ energy_power_hv_network_loss:
   - energy_power_hv_network_loss-(loss) -- d --> (loss)-energy_power_hv_network_electricity
   slots:
   - energy_power_hv_network_loss-(loss)
-  - (electricity)-energy_power_hv_network_loss
+  - ! '(loss)-energy_power_hv_network_loss: {type: :loss}'
 energy_power_hydro_mountain:
   sector: energy
   use: undefined
@@ -3356,22 +3356,6 @@ households_space_heater_wood_pellets:
   - households_space_heater_wood_pellets-(wood_pellets)
   - ! '(loss)-households_space_heater_wood_pellets: {type: :loss}'
   - (useable_heat)-households_space_heater_wood_pellets
-households_useful_demand_clothes_dryer:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_clothes_dryer-(not_defined)
-  - ! '(loss)-households_useful_demand_clothes_dryer: {type: :loss}'
-households_useful_demand_computer_media:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_computer_media-(not_defined)
-  - ! '(loss)-households_useful_demand_computer_media: {type: :loss}'
 households_useful_demand_cooking_useable_heat:
   sector: households
   use: energetic
@@ -3385,14 +3369,6 @@ households_useful_demand_cooking_useable_heat:
   slots:
   - households_useful_demand_cooking_useable_heat-(useable_heat)
   - ! '(loss)-households_useful_demand_cooking_useable_heat: {type: :loss}'
-households_useful_demand_dishwasher:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_dishwasher-(not_defined)
-  - ! '(loss)-households_useful_demand_dishwasher: {type: :loss}'
 households_useful_demand_for_cooling_after_insulation:
   sector: households
   use: energetic
@@ -3546,14 +3522,6 @@ households_useful_demand_for_space_heating_after_insulation_for_houses_with_sola
   slots:
   - households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater-(useable_heat)
   - (useable_heat)-households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater
-households_useful_demand_fridge_freezer:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_fridge_freezer-(not_defined)
-  - ! '(loss)-households_useful_demand_fridge_freezer: {type: :loss}'
 households_useful_demand_hot_water:
   sector: households
   use: energetic
@@ -3575,38 +3543,6 @@ households_useful_demand_light:
   slots:
   - households_useful_demand_light-(light)
   - ! '(loss)-households_useful_demand_light: {type: :loss}'
-households_useful_demand_other_appliances:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_other_appliances-(not_defined)
-  - ! '(loss)-households_useful_demand_other_appliances: {type: :loss}'
-households_useful_demand_television:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_television-(not_defined)
-  - ! '(loss)-households_useful_demand_television: {type: :loss}'
-households_useful_demand_vacuum_cleaner:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_vacuum_cleaner-(not_defined)
-  - ! '(loss)-households_useful_demand_vacuum_cleaner: {type: :loss}'
-households_useful_demand_washing_machine:
-  sector: households
-  use: energetic
-  energy_balance_group: useful consumption
-  links: 
-  slots:
-  - households_useful_demand_washing_machine-(not_defined)
-  - ! '(loss)-households_useful_demand_washing_machine: {type: :loss}'
 households_water_heater_coal:
   sector: households
   use: energetic


### PR DESCRIPTION
This removes the unconnected useful demand nodes for appliances in the household sector.
![](https://f.cloud.github.com/assets/2749265/892861/b8dcd158-fa8e-11e2-8e8c-c7233261aaa6.png)
Associated Input Excel: IE_v1987

Closes https://github.com/quintel/etsource/issues/349
