### PR TITLE
Updated queries in nodes of industry

### DIFF
--- a/data/nodes/energy/energy_distribution_coal_gas.ad
+++ b/data/nodes/energy/energy_distribution_coal_gas.ad
@@ -2,4 +2,4 @@
 - energy_balance_group = distribution
 - co2_free = 0.0
 
-~ demand = EB(total_primary_energy_supply, coke_oven_gas) + EB(total_primary_energy_supply, blast_furnace_gas) + EB(transformation_processes, coke_oven_gas) + EB(transformation_processes, blast_furnace_gas) + EB(energy_industry_own_use, coke_oven_gas) + EB(energy_industry_own_use, blast_furnace_gas) + EB(industry, coke_oven_gas) + EB(industry, blast_furnace_gas)
+~ demand = EB(blast_furnaces_transformation, coke_oven_gas) + EB(blast_furnaces_transformation, blast_furnace_gas) + EB(blast_furnaces_transformation, other_recovered_gases) + EB(coke_ovens_transformation, coke_oven_gas) + EB(coke_ovens_transformation, blast_furnace_gas) + EB(coke_ovens_transformation, other_recovered_gases)

--- a/data/nodes/industry/industry_final_demand_coal.final_demand.ad
+++ b/data/nodes/industry/industry_final_demand_coal.final_demand.ad
@@ -13,6 +13,7 @@
       EB(industry, peat) +
       EB(industry, lignite) +
       EB(industry, patent_fuel) +
+      EB(industry, coke_oven_coke) +
       EB(industry, gas_coke) +
       EB(industry, coal_tar) +
       EB(industry, "bkb/peat_briquettes")
@@ -26,6 +27,7 @@
       EB(energy_industry_own_use, peat) +
       EB(energy_industry_own_use, lignite) +
       EB(energy_industry_own_use, patent_fuel) +
+      EB(energy_industry_own_use, coke_oven_coke) +
       EB(energy_industry_own_use, gas_coke) +
       EB(energy_industry_own_use, coal_tar) +
       EB(energy_industry_own_use, "bkb/peat_briquettes")
@@ -39,20 +41,8 @@
       EB("own_use_in_electricity,_CHP_and_heat_plants", peat) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", lignite) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", patent_fuel) +
+      EB("own_use_in_electricity,_CHP_and_heat_plants", coke_oven_coke) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", gas_coke) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", coal_tar) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", "bkb/peat_briquettes")
-    ) - (
-      EB(losses, "hard_coal_(if_no_detail)") +
-      EB(losses, "brown_coal_(if_no_detail)") +
-      EB(losses, anthracite) +
-      EB(losses, coking_coal) +
-      EB(losses, other_bituminous_coal) +
-      EB(losses, subbituminous_coal) +
-      EB(losses, peat) +
-      EB(losses, lignite) +
-      EB(losses, patent_fuel) +
-      EB(losses, gas_coke) +
-      EB(losses, coal_tar) +
-      EB(losses, "bkb/peat_briquettes")
     )

--- a/data/nodes/industry/industry_final_demand_crude_oil.final_demand.ad
+++ b/data/nodes/industry/industry_final_demand_crude_oil.final_demand.ad
@@ -72,26 +72,5 @@
       EB("own_use_in_electricity,_CHP_and_heat_plants", bitumen) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", paraffin_waxes) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", petroleum_coke) +
-      EB("own_use_in_electricity,_CHP_and_heat_plants", "non-specified_oil_products") ) - ( EB(losses, "crude/ngl/feedstocks_(if_no_detail)") +
-      EB(losses, crude_oil) +
-      EB(losses, natural_gas_liquids) +
-      EB(losses, "additives/blending_components") +
-      EB(losses, other_hydrocarbons) +
-      EB(losses, refinery_gas) +
-      EB(losses, ethane) +
-      EB(losses, "liquefied_petroleum_gases_(lpg)") +
-      EB(losses, motor_gasoline) +
-      EB(losses, aviation_gasoline) +
-      EB(losses, gasoline_type_jet_fuel) +
-      EB(losses, kerosene_type_jet_fuel) +
-      EB(losses, other_kerosene) +
-      EB(losses, "gas/diesel_oil") +
-      EB(losses, fuel_oil) +
-      EB(losses, naphtha) +
-      EB(losses, "white_spirit_&_sbp") +
-      EB(losses, lubricants) +
-      EB(losses, bitumen) +
-      EB(losses, paraffin_waxes) +
-      EB(losses, petroleum_coke) +
-      EB(losses, "non-specified_oil_products")
+      EB("own_use_in_electricity,_CHP_and_heat_plants", "non-specified_oil_products")
     )

--- a/data/nodes/industry/industry_final_demand_electricity.final_demand.ad
+++ b/data/nodes/industry/industry_final_demand_electricity.final_demand.ad
@@ -13,5 +13,4 @@
 ~ demand =
     EB(industry, electricity) +
     EB(energy_industry_own_use, electricity) -
-    EB("own_use_in_electricity,_CHP_and_heat_plants", electricity) -
-    EB(losses, electricity)
+    EB("own_use_in_electricity,_CHP_and_heat_plants", electricity)

--- a/data/nodes/industry/industry_final_demand_network_gas.final_demand.ad
+++ b/data/nodes/industry/industry_final_demand_network_gas.final_demand.ad
@@ -6,5 +6,4 @@
 ~ demand =
     EB(industry, natural_gas) +
     EB(energy_industry_own_use, natural_gas) -
-    EB("own_use_in_electricity,_CHP_and_heat_plants", natural_gas) -
-    EB(losses, natural_gas)
+    EB("own_use_in_electricity,_CHP_and_heat_plants", natural_gas)

--- a/data/nodes/industry/industry_final_demand_steam_hot_water.final_demand.ad
+++ b/data/nodes/industry/industry_final_demand_steam_hot_water.final_demand.ad
@@ -6,5 +6,4 @@
 ~ demand =
     EB(industry, heat) +
     EB(energy_industry_own_use, heat) -
-    EB("own_use_in_electricity,_CHP_and_heat_plants", heat) -
-    EB(losses, heat)
+    EB("own_use_in_electricity,_CHP_and_heat_plants", heat)

--- a/data/nodes/industry/industry_final_demand_wood_pellets.final_demand.ad
+++ b/data/nodes/industry/industry_final_demand_wood_pellets.final_demand.ad
@@ -13,7 +13,4 @@
     ) - (
       EB("own_use_in_electricity,_CHP_and_heat_plants", primary_solid_biofuels) +
       EB("own_use_in_electricity,_CHP_and_heat_plants", nonspecified_primary_biofuels_and_waste)
-    ) - (
-      EB(losses, primary_solid_biofuels) +
-      EB(losses, nonspecified_primary_biofuels_and_waste)
     )


### PR DESCRIPTION
Several changes of queries in nodes of industry:
- demand of  `energy_distribution_coal_gas` demand is now calculated from the energy balance from the `blast_furnace_transformation` and `coke_oven_transformation`
- `coke_oven_coke` in also aggregated in the final demand of `coal`
- `losses` are removed from the final demand queries because the do not need to be subtracted from the `own use`
