### PR TITLE
Included primary production of non-timecurve nodes

### DIFF
--- a/data/nodes/energy/energy_production_algae_diesel.ad
+++ b/data/nodes/energy/energy_production_algae_diesel.ad
@@ -2,3 +2,5 @@
 - energy_balance_group = growth and production
 - co2_free = 0.0
 - preset_demand = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_algae_diesel)

--- a/data/nodes/energy/energy_production_bio_ethanol.ad
+++ b/data/nodes/energy/energy_production_bio_ethanol.ad
@@ -2,3 +2,5 @@
 - energy_balance_group = growth and production
 - co2_free = 0.0
 - preset_demand = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_bio_ethanol)

--- a/data/nodes/energy/energy_production_bio_oil.ad
+++ b/data/nodes/energy/energy_production_bio_oil.ad
@@ -2,3 +2,5 @@
 - energy_balance_group = growth and production
 - co2_free = 0.0
 - preset_demand = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_bio_oil)

--- a/data/nodes/energy/energy_production_bio_residues_for_firing.ad
+++ b/data/nodes/energy/energy_production_bio_residues_for_firing.ad
@@ -1,3 +1,5 @@
 - use = undefined
 - energy_balance_group = growth and production
 - co2_free = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_bio_residues_for_firing)

--- a/data/nodes/energy/energy_production_biodiesel.ad
+++ b/data/nodes/energy/energy_production_biodiesel.ad
@@ -2,3 +2,5 @@
 - energy_balance_group = growth and production
 - co2_free = 0.0
 - preset_demand = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_biodiesel)

--- a/data/nodes/energy/energy_production_biogenic_waste.ad
+++ b/data/nodes/energy/energy_production_biogenic_waste.ad
@@ -1,3 +1,5 @@
 - use = undefined
 - energy_balance_group = growth and production
 - co2_free = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_biogenic_waste)

--- a/data/nodes/energy/energy_production_corn.ad
+++ b/data/nodes/energy/energy_production_corn.ad
@@ -1,3 +1,5 @@
 - use = undefined
 - energy_balance_group = growth and production
 - co2_free = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_bio_residues_for_firing)

--- a/data/nodes/energy/energy_production_manure.ad
+++ b/data/nodes/energy/energy_production_manure.ad
@@ -1,3 +1,5 @@
 - use = undefined
 - energy_balance_group = growth and production
 - co2_free = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_manure)

--- a/data/nodes/energy/energy_production_non_biogenic_waste.ad
+++ b/data/nodes/energy/energy_production_non_biogenic_waste.ad
@@ -2,3 +2,5 @@
 - energy_balance_group = growth and production
 - co2_free = 0.0
 - demand_expected_value = 20000000000.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_non_biogenic_waste)

--- a/data/nodes/energy/energy_production_wood.ad
+++ b/data/nodes/energy/energy_production_wood.ad
@@ -1,3 +1,5 @@
 - use = undefined
 - energy_balance_group = growth and production
 - co2_free = 0.0
+
+~ demand = PRIMARY_PRODUCTION(energy_production_wood)


### PR DESCRIPTION
Nodes now include queries to query the demands from the primary_production.csv.

UNFORTUNATELY, me and Frans did not succeed in calling this branch differently :(
