### PR TITLE
 fix_broken_tranpsor_shares

### DIFF
--- a/data/edges/transport/transport_car_using_compressed_natural_gas-transport_road_compressor_network_gas@compressed_network_gas.ad
+++ b/data/edges/transport/transport_car_using_compressed_natural_gas-transport_road_compressor_network_gas@compressed_network_gas.ad
@@ -1,2 +1,4 @@
 - type = share
 - reversed = false
+
+~ parent_share = SHARE(transport_road_compressor_network_gas_parent_share, transport_car_using_compressed_natural_gas)

--- a/data/edges/transport/transport_truck_using_compressed_natural_gas-transport_road_compressor_network_gas@compressed_network_gas.ad
+++ b/data/edges/transport/transport_truck_using_compressed_natural_gas-transport_road_compressor_network_gas@compressed_network_gas.ad
@@ -1,2 +1,4 @@
 - type = share
 - reversed = false
+
+~ parent_share = SHARE(transport_road_compressor_network_gas_parent_share, transport_truck_using_compressed_natural_gas)


### PR DESCRIPTION
fixes broken transport edges. Closes https://github.com/quintel/refinery/issues/13
