### PR TITLE
Add input efficiencies as quick fix for pseudomixers

### DIFF
--- a/data/nodes/energy/energy_chp_ultra_supercritical_coal_rdr.central_producer.ad
+++ b/data/nodes/energy/energy_chp_ultra_supercritical_coal_rdr.central_producer.ad
@@ -1,6 +1,8 @@
 - use = energetic
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - output.steam_hot_water = 0.15
 - availability = 0.88

--- a/data/nodes/energy/energy_chp_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
+++ b/data/nodes/energy/energy_chp_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
@@ -1,6 +1,8 @@
 - use = energetic
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 0.5
+~ input.torrified_biomass_pellets = 0.5
+- output.electricity =
 - output.loss = elastic
 - output.steam_hot_water = 0.15
 - availability = 0.88

--- a/data/nodes/energy/energy_power_combined_cycle_ccs_coal.central_producer.ad
+++ b/data/nodes/energy/energy_power_combined_cycle_ccs_coal.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.87
 - co2_free = 0.85

--- a/data/nodes/energy/energy_power_combined_cycle_coal.central_producer.ad
+++ b/data/nodes/energy/energy_power_combined_cycle_coal.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.9
 - co2_free = 0.0

--- a/data/nodes/energy/energy_power_supercritical_coal.central_producer.ad
+++ b/data/nodes/energy/energy_power_supercritical_coal.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.89
 - co2_free = 0.0

--- a/data/nodes/energy/energy_power_ultra_supercritical_ccs_coal.central_producer.ad
+++ b/data/nodes/energy/energy_power_ultra_supercritical_ccs_coal.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.85
 - co2_free = 0.85

--- a/data/nodes/energy/energy_power_ultra_supercritical_coal_rdr.central_producer.ad
+++ b/data/nodes/energy/energy_power_ultra_supercritical_coal_rdr.central_producer.ad
@@ -1,6 +1,8 @@
 - use = energetic
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.88
 - co2_free = 0.0

--- a/data/nodes/energy/energy_power_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
+++ b/data/nodes/energy/energy_power_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
@@ -1,6 +1,8 @@
 - use = energetic
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.coal = 0.5
+~ input.torrified_biomass_pellets = 0.5
+- output.electricity =
 - output.loss = elastic
 - availability = 0.88
 - co2_free = 0.0

--- a/data/nodes/energy/energy_power_ultra_supercritical_lignite.central_producer.ad
+++ b/data/nodes/energy/energy_power_ultra_supercritical_lignite.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.lignite = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.89
 - co2_free = 0.0

--- a/data/nodes/energy/energy_power_ultra_supercritical_oxyfuel_ccs_lignite.central_producer.ad
+++ b/data/nodes/energy/energy_power_ultra_supercritical_oxyfuel_ccs_lignite.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central power generation
-- output.electricity = 
+~ input.lignite = 1.0
+~ input.torrified_biomass_pellets = 0.0
+- output.electricity =
 - output.loss = elastic
 - availability = 0.85
 - co2_free = 0.85

--- a/data/nodes/energy/energy_steel_hisarna_transformation_coal.converter.ad
+++ b/data/nodes/energy/energy_steel_hisarna_transformation_coal.converter.ad
@@ -1,5 +1,7 @@
 - use = energetic
 - energy_balance_group = coal conversion
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
 - output.coupling_carrier = 1.0
 - output.loss = elastic
 - output.steam_hot_water = 0.95

--- a/data/nodes/industry/industry_chp_ultra_supercritical_coal.central_producer.ad
+++ b/data/nodes/industry/industry_chp_ultra_supercritical_coal.central_producer.ad
@@ -1,5 +1,7 @@
 - use = energetic
 - energy_balance_group = central CHPs
+~ input.coal = 1.0
+~ input.torrified_biomass_pellets = 0.0
 - output.electricity = 0.3
 - output.loss = elastic
 - output.steam_hot_water = 0.35


### PR DESCRIPTION
`input.coal`, `input.lignite` and `input.torrified_biomass_pellets` efficiencies are defined for the pseudomixers described in quintel/inputexcel#300. 

For _cofiring_ plants the effiencies are set to:

```
~ input.coal = 0.5
~ input.torriefied_biomass_pellets = 0.5
```

For all other converters the efficiencies are set to:

```
~ input.coal/lignite = 1.0
~ input.torriefied_biomass_pellets = 0.0
```
