### PR TITLE
Add 2011 values from timecurve to extraction converters

### DIFF
--- a/data/nodes/energy/energy_extraction_coal.ad
+++ b/data/nodes/energy/energy_extraction_coal.ad
@@ -5,4 +5,5 @@
 - co2_free = 0.0
 - preset_demand = 0.0
 
+# ~ demand = TIME_CURVE(timecurve_coal)
 ~ demand = 0.0

--- a/data/nodes/energy/energy_extraction_crude_oil.ad
+++ b/data/nodes/energy/energy_extraction_crude_oil.ad
@@ -5,4 +5,5 @@
 - co2_free = 0.0
 - preset_demand = 78982467461.5649
 
+# ~ demand = TIME_CURVE(timecurve_crude_oil)
 ~ demand = 68.68040649

--- a/data/nodes/energy/energy_extraction_lignite.ad
+++ b/data/nodes/energy/energy_extraction_lignite.ad
@@ -2,4 +2,5 @@
 - energy_balance_group = extraction
 - co2_free = 0.0
 
+# ~ demand = TIME_CURVE(timecurve_lignite)
 ~ demand = 0.0

--- a/data/nodes/energy/energy_extraction_natural_gas.ad
+++ b/data/nodes/energy/energy_extraction_natural_gas.ad
@@ -3,4 +3,5 @@
 - co2_free = 0.0
 - preset_demand = 2292000000000.0
 
+# ~ demand = TIME_CURVE(timecurve_natural_gas)
 ~ demand = 2154.48

--- a/data/nodes/energy/energy_extraction_uranium_oxide.ad
+++ b/data/nodes/energy/energy_extraction_uranium_oxide.ad
@@ -2,4 +2,5 @@
 - energy_balance_group = extraction
 - co2_free = 0.0
 
+# ~ demand = TIME_CURVE(timecurve_uranium_oxide)
 ~ demand = 0.0


### PR DESCRIPTION
As quick fix before the `TIME_CURVE` function will work, I added the extraction values for 2011 manually.
