### PR TITLE
added a parent share (including new CSV and parent shares in 2 edges.ad)

### DIFF
--- a/data/datasets/nl/shares/residences_useful_demand_for_hot_water_after_solar_heater_and_add_on_parent_share.csv
+++ b/data/datasets/nl/shares/residences_useful_demand_for_hot_water_after_solar_heater_and_add_on_parent_share.csv
@@ -1,0 +1,3 @@
+key,share
+households_useful_demand_for_hot_water_after_solar_heater,1
+households_useful_demand_for_hot_water_for_houses_with_add_on,0

--- a/data/edges/households/households_useful_demand_for_hot_water_after_solar_heater-households_useful_demand_for_hot_water_after_solar_heater_and_add_on@useable_heat.ad
+++ b/data/edges/households/households_useful_demand_for_hot_water_after_solar_heater-households_useful_demand_for_hot_water_after_solar_heater_and_add_on@useable_heat.ad
@@ -1,2 +1,4 @@
 - type = flexible
 - reversed = false
+
+~ parent_share = SHARE(residences_useful_demand_for_hot_water_after_solar_heater_and_add_on_parent_share, households_useful_demand_for_hot_water_after_solar_heater)

--- a/data/edges/households/households_useful_demand_for_hot_water_for_houses_with_add_on-households_useful_demand_for_hot_water_after_solar_heater_and_add_on@useable_heat.ad
+++ b/data/edges/households/households_useful_demand_for_hot_water_for_houses_with_add_on-households_useful_demand_for_hot_water_after_solar_heater_and_add_on@useable_heat.ad
@@ -1,4 +1,8 @@
 - type = share
 - reversed = false
 
+~ parent_share = SHARE(residences_useful_demand_for_hot_water_after_solar_heater_and_add_on_parent_share, households_useful_demand_for_hot_water_for_houses_with_add_on)
+
 ~ child_share = SHARE(residences_useful_demand_for_hot_water_for_houses_with_add_on_child_share, households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+
+


### PR DESCRIPTION
Created a new CSV that is exported by the Residence Analysis. 
It is now hard-coded that `households_useful_demand_for_hot_water_for_houses_with_add_on` has zero energy demand. (the converter is currently not being used). 

![screen shot 2013-08-08 at 14 42 59](https://f.cloud.github.com/assets/2749265/931236/2c4801e6-0028-11e3-827b-5e066df509be.png)
