### PR TITLE
Add input.wood_pellets efficiency to converters

### DIFF
--- a/data/nodes/energy/energy_chp_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
+++ b/data/nodes/energy/energy_chp_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
@@ -1,7 +1,8 @@
 - use = energetic
 - energy_balance_group = central power generation
 ~ input.coal = 0.5
-~ input.torrified_biomass_pellets = 0.5
+~ input.wood_pellets = 0.5
+~ input.torrified_biomass_pellets = 0.0
 - output.electricity =
 - output.loss = elastic
 - output.steam_hot_water = 0.15

--- a/data/nodes/energy/energy_power_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
+++ b/data/nodes/energy/energy_power_ultra_supercritical_cofiring_coal_rdr.central_producer.ad
@@ -1,7 +1,8 @@
 - use = energetic
 - energy_balance_group = central power generation
 ~ input.coal = 0.5
-~ input.torrified_biomass_pellets = 0.5
+~ input.wood_pellets = 0.5
+~ input.torrified_biomass_pellets = 0.0
 - output.electricity =
 - output.loss = elastic
 - availability = 0.88


### PR DESCRIPTION
The `input.wood_pellets` efficiency was not correctly specified in two converters.
