### PR TITLE
Added input efficiencies for energy_torrefeaction_wood converter because...

### DIFF
--- a/data/nodes/energy/energy_torrefaction_wood.converter.ad
+++ b/data/nodes/energy/energy_torrefaction_wood.converter.ad
@@ -1,5 +1,7 @@
 - use = undefined
 - energy_balance_group = biomass conversion
+~ input.network_gas = 0.053
+~ input.wood = 0.947
 - output.loss = elastic
 - output.torrified_biomass_pellets = 0.91
 - co2_free = 0.0


### PR DESCRIPTION
... this is a pseudomixer.

Added `input.network_gas` and `input.wood` efficiency as quick fix.
