### PR TITLE
Add flex-max statement to energy_distribution_bio_residues and set energ...

### DIFF
--- a/data/nodes/energy/energy_distribution_bio_residues_for_firing.converter.ad
+++ b/data/nodes/energy/energy_distribution_bio_residues_for_firing.converter.ad
@@ -5,4 +5,4 @@
 # This converter is a combination of a timecurve and flex-max situation. It should be something like:
 # ~ max_demand = TIME_CURVE(timecurve_bioresidues_for_firing)
 
-~ demand = 34.0872093
+~ max_demand = 34.0872093

--- a/data/nodes/energy/energy_production_bio_residues_for_firing.ad
+++ b/data/nodes/energy/energy_production_bio_residues_for_firing.ad
@@ -1,5 +1,3 @@
 - use = undefined
 - energy_balance_group = growth and production
 - co2_free = 0.0
-
-~ demand = PRIMARY_PRODUCTION(energy_production_bio_residues_for_firing)

--- a/data/nodes/energy/energy_production_wood.ad
+++ b/data/nodes/energy/energy_production_wood.ad
@@ -2,4 +2,5 @@
 - energy_balance_group = growth and production
 - co2_free = 0.0
 
-~ demand = PRIMARY_PRODUCTION(energy_production_wood)
+# ~ demand = PRIMARY_PRODUCTION(energy_production_wood)
+~ demand = 0.0


### PR DESCRIPTION
...y_production_wood to zero

The flex-max statement was set in the production converter and need to be set in the distribution converter to work properly. In addition the primary production of wood is set to zero, because all torrified_biomass_pellets and wood_pellets are imported. Locally produced torrified_biomass_pellets and wood_pellets are made from wood and is zero in the current model.
