### PR TITLE
Added demand for uranium distribution

### DIFF
--- a/data/nodes/energy/energy_distribution_uranium_oxide.ad
+++ b/data/nodes/energy/energy_distribution_uranium_oxide.ad
@@ -3,3 +3,5 @@
 - output.loss = elastic
 - output.uranium_oxide = 1.0
 - co2_free = 0.0
+
+~ demand = EB(total_primary_energy_supply, nuclear)


### PR DESCRIPTION
By adding the demand for the uranium distribution converter from the energy balance problems with import and export from different converters is avoided.

See https://github.com/quintel/refinery/issues/24#issuecomment-22318886
