### PR TITLE
Updated DE and UK AREA data to include number of old an new houses.

### DIFF
--- a/data/datasets/uk/uk.ad
+++ b/data/datasets/uk/uk.ad
@@ -47,6 +47,8 @@
 - market_share_daylight_control = 0.205
 - market_share_motion_detection = 0.265
 - number_households = 7349500.0
+- number_of_old_residences: 22325600.0
+- number_of_new_residences: 3634400.0
 - number_inhabitants = 16530388.0
 - offshore_suitable_for_wind = 16000.0
 - onshore_suitable_for_wind = 11379.0

--- a/datasets/de/area.yml
+++ b/datasets/de/area.yml
@@ -37,6 +37,8 @@
     :market_share_daylight_control: 0.205
     :market_share_motion_detection: 0.265
     :number_households: 40076000.0
+    :number_of_old_residences: 34465360.0
+    :number_of_new_residences: 5610640.0
     :number_inhabitants: 82329800.0
     :offshore_suitable_for_wind: 1010.0
     :onshore_suitable_for_wind: 23665.0

--- a/datasets/uk/area.yml
+++ b/datasets/uk/area.yml
@@ -38,6 +38,8 @@
     :market_share_daylight_control: 0.205
     :market_share_motion_detection: 0.265
     :number_households: 25960000.0
+    :number_of_old_residences: 22325600.0
+    :number_of_new_residences: 3634400.0
     :number_inhabitants: 61383000.0
     :offshore_suitable_for_wind: 372000.0
     :onshore_suitable_for_wind: 56761.0


### PR DESCRIPTION
Related to [this commit](https://github.com/quintel/etsource/commit/434ccd37819f33f3d32310ae50650ef0a2a16e14), where we updated only the AREA data for NL. The current commit updates the AREA file for DE and UK as well.
