### PR TITLE
Solar panel fix

### DIFF
--- a/data/inputs/households/households_misc/households_number_of_new_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_new_houses.ad
@@ -6,18 +6,21 @@
   EACH(
     UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_heating), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_new_residences) })),
     UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_new_residences) })),
+    UPDATE(AREA(), number_of_new_residences, USER_INPUT() * 1_000_000),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_old_houses) * 1_000_000 + 1),
     UPDATE_WITH_FACTOR(AREA(), roof_surface_available_pv, (USER_INPUT() + INPUT_VALUE(households_number_of_old_houses)) / 
-    QUERY_PRESENT(-> { Q(households_number_of_residences) })),
+    (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),
     UPDATE(
     V(OUTPUT_SLOTS(LOOKUP(households_solar_pv_solar_radiation),electricity), "links.detect{|l| !l.flexible? }"),
       share,
       (
+        (INPUT_VALUE(households_solar_pv_solar_radiation_market_penetration) / 100.0) * 
         (QUERY_FUTURE(-> { AREA(roof_surface_available_pv) }) / V(households_solar_pv_solar_radiation, land_use_per_unit)) *
         V(households_solar_pv_solar_radiation, typical_electricity_production_per_unit)
       )
     )
   )
+
 - priority = 0
 - max_value_gql = present:Q(number_of_new_residences) * 0.000001 * 10
 - min_value = 0.0

--- a/data/inputs/households/households_misc/households_number_of_old_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_old_houses.ad
@@ -6,13 +6,15 @@
   EACH(
     UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_heating), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_old_residences) })),
     UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_old_residences) })),
+    UPDATE(AREA(), number_of_old_residences, USER_INPUT() * 1_000_000),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_new_houses) * 1_000_000 + 1),
     UPDATE_WITH_FACTOR(AREA(), roof_surface_available_pv, (USER_INPUT() + INPUT_VALUE(households_number_of_new_houses)) / 
-    QUERY_PRESENT(-> { Q(households_number_of_residences) })),
+    (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),
     UPDATE(
     V(OUTPUT_SLOTS(LOOKUP(households_solar_pv_solar_radiation),electricity), "links.detect{|l| !l.flexible? }"),
       share,
       (
+        (INPUT_VALUE(households_solar_pv_solar_radiation_market_penetration) / 100.0) * 
         (QUERY_FUTURE(-> { AREA(roof_surface_available_pv) }) / V(households_solar_pv_solar_radiation, land_use_per_unit)) *
         V(households_solar_pv_solar_radiation, typical_electricity_production_per_unit)
       )


### PR DESCRIPTION
Fixed update statements for number of residences which also updated area for solar PV and solar PV panels.
We now use the AREA attribute number_households instead of the gquery "households_number_of_residences". 

Closes #420
