### PR TITLE
residences input fix

### DIFF
--- a/data/inputs/households/households_misc/households_number_of_new_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_new_houses.ad
@@ -8,7 +8,7 @@
     UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_new_residences) })),
     UPDATE(AREA(), number_of_new_residences, USER_INPUT() * 1_000_000),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_old_houses) * 1_000_000 + 1),
-    UPDATE_WITH_FACTOR(AREA(), roof_surface_available_pv, (USER_INPUT() + INPUT_VALUE(households_number_of_old_houses)) / 
+    UPDATE(AREA(), roof_surface_available_pv, QUERY_PRESENT(-> { AREA(roof_surface_available_pv) }) * (USER_INPUT() + INPUT_VALUE(households_number_of_new_houses)) / 
     (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),
     UPDATE(
     V(OUTPUT_SLOTS(LOOKUP(households_solar_pv_solar_radiation),electricity), "links.detect{|l| !l.flexible? }"),

--- a/data/inputs/households/households_misc/households_number_of_old_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_old_houses.ad
@@ -8,7 +8,7 @@
     UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_old_residences) })),
     UPDATE(AREA(), number_of_old_residences, USER_INPUT() * 1_000_000),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_new_houses) * 1_000_000 + 1),
-    UPDATE_WITH_FACTOR(AREA(), roof_surface_available_pv, (USER_INPUT() + INPUT_VALUE(households_number_of_new_houses)) / 
+    UPDATE(AREA(), roof_surface_available_pv, QUERY_PRESENT(-> { AREA(roof_surface_available_pv) }) * (USER_INPUT() + INPUT_VALUE(households_number_of_new_houses)) /
     (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),
     UPDATE(
     V(OUTPUT_SLOTS(LOOKUP(households_solar_pv_solar_radiation),electricity), "links.detect{|l| !l.flexible? }"),


### PR DESCRIPTION
Work around for issue #420: removed UPDATE_WITH_FACTOR for roof_surface_available_pv update. Fixes #420 

We document the investigation of the source for this issue in https://github.com/quintel/etsource/issues/427
