### PR TITLE
Fixed typo

### DIFF
--- a/data/inputs/households/households_misc/households_number_of_new_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_new_houses.ad
@@ -8,7 +8,7 @@
     UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_new_residences) })),
     UPDATE(AREA(), number_of_new_residences, USER_INPUT() * 1_000_000),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_old_houses) * 1_000_000 + 1),
-    UPDATE(AREA(), roof_surface_available_pv, QUERY_PRESENT(-> { AREA(roof_surface_available_pv) }) * (USER_INPUT() + INPUT_VALUE(households_number_of_new_houses)) / 
+    UPDATE(AREA(), roof_surface_available_pv, QUERY_PRESENT(-> { AREA(roof_surface_available_pv) }) * (USER_INPUT() + INPUT_VALUE(households_number_of_old_houses)) / 
     (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),
     UPDATE(
     V(OUTPUT_SLOTS(LOOKUP(households_solar_pv_solar_radiation),electricity), "links.detect{|l| !l.flexible? }"),


### PR DESCRIPTION
See https://github.com/quintel/etsource/commit/9796b7a590ba038ca437a9939ef4fe8f33b0693f#commitcomment-3859718

Stragely enough, the fixing of the typo does not seem to influence the behavior of the ETM. This could be due to the   following: if the update statement for old houses is executed **after** the update statement for new houses.
