### PR TITLE
Fixed preset demands for buildings heating and cooling

### DIFF
--- a/datasets/ame/graph/buildings.yml
+++ b/datasets/ame/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 23999193.9991661
+  :demand_expected_value: 17279419.6793996
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 23999193.9991661
+  :preset_demand: 17279419.6793996
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 134530896.250386
+  :preset_demand: 96862245.3002779
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 134530896.250386
+  :demand_expected_value: 96862245.3002779
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.936521947037269}

--- a/datasets/ams/graph/buildings.yml
+++ b/datasets/ams/graph/buildings.yml
@@ -719,7 +719,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 4898803923.4076
+  :demand_expected_value: 3527138824.85348
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0198469805160688}
@@ -746,7 +746,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 4898803923.4076
+  :preset_demand: 3527138824.85348
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -765,7 +765,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 12572486649.1519
+  :preset_demand: 9052190387.3894
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -773,7 +773,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 12572486649.1519
+  :demand_expected_value: 9052190387.3894
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.893458706213775}

--- a/datasets/be-vlg/graph/buildings.yml
+++ b/datasets/be-vlg/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 48794144000.0
+  :demand_expected_value: 35131783680.0
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 48794144000.0
+  :preset_demand: 35131783680.0
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 76638849444.4444
+  :preset_demand: 55179971600.0
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 76638849444.4444
+  :demand_expected_value: 55179971600.0
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.825624063931196}

--- a/datasets/be/graph/buildings.yml
+++ b/datasets/be/graph/buildings.yml
@@ -719,7 +719,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 292440092.379532
+  :demand_expected_value: 210556866.513263
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -746,7 +746,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 292440092.379532
+  :preset_demand: 210556866.513263
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -765,7 +765,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 115017930050.809
+  :preset_demand: 82812909636.5826
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -773,7 +773,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 115017930050.809
+  :demand_expected_value: 82812909636.5826
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.678228121544005}

--- a/datasets/br/graph/buildings.yml
+++ b/datasets/br/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 2099433593.84663
+  :demand_expected_value: 1511592187.56957
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 2099433593.84663
+  :preset_demand: 1511592187.56957
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 20887252774.429
+  :preset_demand: 15038821997.5889
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 20887252774.429
+  :demand_expected_value: 15038821997.5889
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.245693237915504}

--- a/datasets/de/graph/buildings.yml
+++ b/datasets/de/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 58356676003.7348
+  :demand_expected_value: 42016806722.6891
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 58356676003.7348
+  :preset_demand: 42016806722.6891
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 734638537194.798
+  :preset_demand: 528939746780.255
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 734638537194.798
+  :demand_expected_value: 528939746780.255
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.382481215371728}

--- a/datasets/grs/graph/buildings.yml
+++ b/datasets/grs/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 848360404.701023
+  :demand_expected_value: 610819491.384736
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 848360404.701023
+  :preset_demand: 610819491.384736
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 3757416479.75668
+  :preset_demand: 2705339865.42481
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 3757416479.75668
+  :demand_expected_value: 2705339865.42481
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.859121487242307}

--- a/datasets/nl/graph/buildings.yml
+++ b/datasets/nl/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 62047108568.4415
+  :demand_expected_value: 44673918169.2779
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 62047108568.4415
+  :preset_demand: 44673918169.2779
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 210739066497.953
+  :preset_demand: 151732127878.526
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 210739066497.953
+  :demand_expected_value: 151732127878.526
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.826680111963096}

--- a/datasets/uk/graph/buildings.yml
+++ b/datasets/uk/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 181661349526.594
+  :demand_expected_value: 130796171659.148
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 181661349526.594
+  :preset_demand: 130796171659.148
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 386499165628.176
+  :preset_demand: 278279399252.287
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 386499165628.176
+  :demand_expected_value: 278279399252.287
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.656561741840863}

--- a/datasets/ut/graph/buildings.yml
+++ b/datasets/ut/graph/buildings.yml
@@ -720,7 +720,7 @@ buildings_space_heater_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-build
 
 :buildings_useful_demand_after_insulation_cooling:
   :co2_free: 0.0
-  :demand_expected_value: 63181000000.0
+  :demand_expected_value: 45490320000.0
 buildings_useful_demand_after_insulation_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_after_insulation_cooling: {conversion: 1.0}
 buildings_useful_demand_after_insulation_cooling-(cooling) -- s --> (cooling)-buildings_cooling_collective_cooling_network_electricity: {share: 0.0}
@@ -747,7 +747,7 @@ buildings_useful_demand_after_motion_detection_light-(light) -- s --> (light)-bu
 
 :buildings_useful_demand_cooling:
   :co2_free: 0.0
-  :preset_demand: 63181000000.0
+  :preset_demand: 45490320000.0
 buildings_useful_demand_cooling-(cooling): {conversion: 1.0}
 (cooling)-buildings_useful_demand_cooling: {conversion: 1.0}
 buildings_useful_demand_cooling-(cooling) -- s --> (cooling)-buildings_cooling_savings_insulation_cooling: {share: 0.0}
@@ -766,7 +766,7 @@ buildings_useful_demand_for_appliances-(not_defined) -- s --> (not_defined)-buil
 
 :buildings_useful_demand_for_space_heating:
   :co2_free: 0.0
-  :preset_demand: 200572231934.453
+  :preset_demand: 144412006992.806
 buildings_useful_demand_for_space_heating-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating: {conversion: 1.0}
 buildings_useful_demand_for_space_heating-(useable_heat) -- s --> (useable_heat)-buildings_heating_savings_from_insulation_useable_heat: {share: 0.0}
@@ -774,7 +774,7 @@ buildings_useful_demand_for_space_heating-(useable_heat) -- f --> (useable_heat)
 
 :buildings_useful_demand_for_space_heating_after_insulation:
   :co2_free: 0.0
-  :demand_expected_value: 200572231934.453
+  :demand_expected_value: 144412006992.806
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat): {conversion: 1.0}
 (useable_heat)-buildings_useful_demand_for_space_heating_after_insulation: {conversion: 1.0}
 buildings_useful_demand_for_space_heating_after_insulation-(useable_heat) -- f --> (useable_heat)-buildings_space_heater_network_gas: {share: 0.871959927251584}


### PR DESCRIPTION
Unhappy-smileys-B-gone!

The smileys where unhappy because the preset demand stayed the same but the re-circulation and heat recovery (that took away some of that demand) have been removed. Now the preset demand has been adjusted to the correct value.
