### PR TITLE
pushing CSV files that are now generated from rdr. 

### DIFF
--- a/data/datasets/nl/shares/energy_distribution_waste_mix_child_share.csv
+++ b/data/datasets/nl/shares/energy_distribution_waste_mix_child_share.csv
@@ -1,1 +1,3 @@
-key,shareenergy_distribution_non_biogenic_waste,0.459931169energy_distribution_biogenic_waste,0.540068831
+key,share
+energy_distribution_non_biogenic_waste,0.459931169
+energy_distribution_biogenic_waste,0.540068831


### PR DESCRIPTION
The Research Analysis have been moved from Dropbox to rdr repository. 
All CSV files for etsource (used by the new graph) are now generated on rdr. 

At the same time, the analysis_manager got updated, which exports the CSV files from the Excel analyses. 

As expected, the same CSV files are produced. With one exception: 
there is one difference in the new line command in one file, see below. 

git diff:
![screen shot 2013-08-22 at 09 47 57](https://f.cloud.github.com/assets/2749265/1007126/393a364e-0aff-11e3-8fa7-743cd773e045.png)

I investigated this with @jorisberkhout yesterday, and we could not find the difference in the two files (using less and more...). So, I suggest we replace the old CSV with the new one and merge this branch. 
