### PR TITLE
Fix to ensure that insulation costs scale with the number of residences.

### DIFF
--- a/data/inputs/households/households_misc/households_insulation_level_new_houses.ad
+++ b/data/inputs/households/households_misc/households_insulation_level_new_houses.ad
@@ -8,7 +8,7 @@
 - update_period = future
 - query =
     cost_per_new_house = AREA(new_houses_insulation_cost_constant) * (USER_INPUT() - AREA(insulation_level_new_houses_min));
-    total_cost = cost_per_new_house * Q(number_of_new_residences);
+    total_cost = cost_per_new_house * QUERY_FUTURE(-> { AREA(number_of_new_residences) });
     saving_fraction = 1.0 - AREA(new_houses_insulation_constant_1) / (USER_INPUT() + AREA(new_houses_insulation_constant_2));
 
     EACH(

--- a/data/inputs/households/households_misc/households_insulation_level_old_houses.ad
+++ b/data/inputs/households/households_misc/households_insulation_level_old_houses.ad
@@ -8,12 +8,11 @@
 - update_period = future
 - query =
     cost_per_old_house = AREA(old_houses_insulation_cost_constant) * (USER_INPUT() - AREA(insulation_level_old_houses_min));
-    total_cost = cost_per_old_house * Q(number_of_old_residences);
+    total_cost = cost_per_old_house * QUERY_FUTURE(-> { AREA(number_of_old_residences) });
     saving_fraction = 1.0 - AREA(old_houses_insulation_constant_1) / (USER_INPUT() + AREA(old_houses_insulation_constant_2));
 
     EACH(
       UPDATE(V(households_old_houses_heating_savings_from_insulation), initial_investment, total_cost),
       UPDATE(LINK(households_old_houses_useful_demand_for_heating,households_old_houses_heating_savings_from_insulation), share, saving_fraction),
       UPDATE(LINK(households_old_houses_useful_demand_for_cooling,households_old_houses_cooling_savings_from_insulation), share, saving_fraction)
-    )
-
+    ) 

--- a/data/inputs/households/households_misc/households_number_of_new_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_new_houses.ad
@@ -3,10 +3,15 @@
 
 - id = 640
 - query = 
+  cost_per_new_house = AREA(new_houses_insulation_cost_constant) * (INPUT_VALUE(households_insulation_level_new_houses) - AREA(insulation_level_new_houses_min));
+  total_cost = cost_per_new_house * USER_INPUT() * 1_000_000;
+  saving_fraction = 1.0 - AREA(new_houses_insulation_constant_1) / (INPUT_VALUE(households_insulation_level_new_houses) + AREA(new_houses_insulation_constant_2));
+
   EACH(
     UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_heating), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_new_residences) })),
     UPDATE_WITH_FACTOR(L(households_new_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_new_residences) })),
     UPDATE(AREA(), number_of_new_residences, USER_INPUT() * 1_000_000),
+    UPDATE(V(households_new_houses_heating_savings_from_insulation), initial_investment, total_cost),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_old_houses) * 1_000_000 + 1),
     UPDATE(AREA(), roof_surface_available_pv, QUERY_PRESENT(-> { AREA(roof_surface_available_pv) }) * (USER_INPUT() + INPUT_VALUE(households_number_of_old_houses)) / 
     (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),

--- a/data/inputs/households/households_misc/households_number_of_old_houses.ad
+++ b/data/inputs/households/households_misc/households_number_of_old_houses.ad
@@ -3,10 +3,15 @@
 
 - id = 639
 - query = 
+  cost_per_old_house = AREA(old_houses_insulation_cost_constant) * (INPUT_VALUE(households_insulation_level_old_houses) - AREA(insulation_level_old_houses_min));
+  total_cost = cost_per_old_house * USER_INPUT() * 1_000_000;
+  saving_fraction = 1.0 - AREA(old_houses_insulation_constant_1) / (INPUT_VALUE(households_insulation_level_old_houses) + AREA(old_houses_insulation_constant_2));
+
   EACH(
     UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_heating), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_old_residences) })),
     UPDATE_WITH_FACTOR(L(households_old_houses_useful_demand_for_cooling), preset_demand, USER_INPUT() * 1_000_000 / QUERY_PRESENT(-> { AREA(number_of_old_residences) })),
     UPDATE(AREA(), number_of_old_residences, USER_INPUT() * 1_000_000),
+    UPDATE(V(households_old_houses_heating_savings_from_insulation), initial_investment, total_cost),
     UPDATE(AREA(), number_households, USER_INPUT() * 1_000_000 + INPUT_VALUE(households_number_of_new_houses) * 1_000_000 + 1),
     UPDATE(AREA(), roof_surface_available_pv, QUERY_PRESENT(-> { AREA(roof_surface_available_pv) }) * (USER_INPUT() + INPUT_VALUE(households_number_of_new_houses)) /
     (QUERY_PRESENT(-> { AREA(number_households) }) / 1_000_000)),


### PR DESCRIPTION
fixes etmodel/#1580

The update statements for `households_number_of_old_houses` now explicitly updates the insulations costs. Idem for new houses.
