### PR TITLE
Some queries in the transport sector nodes did not consider all relevant IEA carriers.

### DIFF
--- a/data/nodes/transport/transport_final_demand_biodiesel.final_demand.ad
+++ b/data/nodes/transport/transport_final_demand_biodiesel.final_demand.ad
@@ -3,4 +3,7 @@
 - groups = [final_demand_cbs]
 - co2_free = 0.0
 
-~ demand = EB("transport", biodiesels)
+~ demand = 
+    EB("transport", biodiesels) + 
+    EB("transport", other_liquid_biofuels) + 
+    EB("transport", "non-specified primary biofuels and waste")

--- a/data/nodes/transport/transport_final_demand_coal.final_demand.ad
+++ b/data/nodes/transport/transport_final_demand_coal.final_demand.ad
@@ -3,4 +3,21 @@
 - groups = [final_demand_cbs]
 - co2_free = 0.0
 
-~ demand = EB("transport", "hard_coal_(if_no_detail)")
+~ demand =
+    EB("transport", "hard_coal_(if_no_detail)") +
+    EB("transport", "brown_coal_(if_no_detail)") +
+    EB("transport", anthracite) +
+    EB("transport", coking_coal) +
+    EB("transport", other_bituminous_coal) +
+    EB("transport", subbituminous_coal) +
+    EB("transport", lignite) +
+    EB("transport", patent_fuel) +
+    EB("transport", coke_oven_coke) +
+    EB("transport", gas_coke) +
+    EB("transport", coal_tar) +
+    EB("transport", "bkb/peat_briquettes") +
+    EB("transport", peat) +
+    EB("transport", gas_works_gas) +
+    EB("transport", coke_oven_gas) +
+    EB("transport", blast_furnace_gas) +
+    EB("transport", other_recovered_gases)

--- a/data/nodes/transport/transport_final_demand_network_gas.final_demand.ad
+++ b/data/nodes/transport/transport_final_demand_network_gas.final_demand.ad
@@ -3,4 +3,6 @@
 - groups = [final_demand_cbs]
 - co2_free = 0.0
 
-~ demand = EB("transport", natural_gas)
+~ demand = 
+    EB("transport", natural_gas) + 
+    EB("transport", biogases)


### PR DESCRIPTION
These queries now cover the IEA carriers in the same way that they are aggregated in the Transport Analysis.
