### PR TITLE
Removing the hard-coded natural gas import from etsource

### DIFF
--- a/data/nodes/energy/energy_import_natural_gas.ad
+++ b/data/nodes/energy/energy_import_natural_gas.ad
@@ -2,5 +2,3 @@
 - energy_balance_group = import
 - groups = [energy_import, energy_import_export, primary_energy_demand]
 - co2_free = 0.0
-
-~ demand = 0.0


### PR DESCRIPTION
Removing the hard-coded natural gas import from etsource since it is no longer necessary for NL and incorrect for DE
https://github.com/quintel/refinery/issues/51#issuecomment-23776040
