### PR TITLE
Removed demand query for uranium distribution

### DIFF
--- a/data/nodes/energy/energy_distribution_uranium_oxide.ad
+++ b/data/nodes/energy/energy_distribution_uranium_oxide.ad
@@ -4,5 +4,3 @@
 - output.uranium_oxide = 1.0
 - groups = []
 - co2_free = 0.0
-
-~ demand = EB(total_primary_energy_supply, nuclear)


### PR DESCRIPTION
Removed demand query for uranium distribution. No longer necessary for NL and causing a validation error for DE
