### PR TITLE
adding output.steam_hot_water attribute to the converter energy_heater_for_heat_network_geothermal.central_producer.ad

### DIFF
--- a/data/nodes/energy/energy_heater_for_heat_network_geothermal.central_producer.ad
+++ b/data/nodes/energy/energy_heater_for_heat_network_geothermal.central_producer.ad
@@ -1,6 +1,8 @@
 - use = undefined
 - energy_balance_group = central heat generation
 - groups = [cost_traditional_heat, heat_production]
+- output.loss = elastic
+- output.steam_hot_water = 1.0
 - availability = 0.0
 - co2_free = 0.0
 - forecasting_error = 0.0


### PR DESCRIPTION
Fixes https://github.com/quintel/etsource/issues/537
