### PR TITLE
removing charcoal from final demand residences. 

### DIFF
--- a/data/nodes/households/households_final_demand_coal.final_demand.ad
+++ b/data/nodes/households/households_final_demand_coal.final_demand.ad
@@ -16,5 +16,4 @@
     EB("residential", gas_coke) +
     EB("residential", coal_tar) +
     EB("residential", "bkb/peat_briquettes") +
-    EB("residential", peat) +
-    EB("residential", charcoal)
+    EB("residential", peat)


### PR DESCRIPTION
Follow up of https://github.com/quintel/etdataset/pull/310. Charcoal is not a relevant carrier in Residences.
