### PR TITLE
average_effective_output_of_nominal_capacity_over_lifetime

### DIFF
--- a/datasets/ame/graph/agriculture.yml
+++ b/datasets/ame/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 4000000.0

--- a/datasets/ame/graph/buildings.yml
+++ b/datasets/ame/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 2627027.02702703
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 3256278.10689267
   :forecasting_error: 0.05

--- a/datasets/ame/graph/energy.yml
+++ b/datasets/ame/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/ame/graph/households.yml
+++ b/datasets/ame/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 4651825.86698953
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 3114817.35218156
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 859479.437461647
   :forecasting_error: 0.0

--- a/datasets/ame/graph/industry.yml
+++ b/datasets/ame/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 3858674.07701469
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ame/graph/other.yml
+++ b/datasets/ame/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ams/graph/agriculture.yml
+++ b/datasets/ams/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 0.0

--- a/datasets/ams/graph/buildings.yml
+++ b/datasets/ams/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 693000000.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -504,7 +504,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/ams/graph/energy.yml
+++ b/datasets/ams/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -961,7 +961,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -990,7 +990,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1016,7 +1016,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1045,7 +1045,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1071,7 +1071,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1323,7 +1323,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1349,7 +1349,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1408,7 +1408,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1434,7 +1434,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1463,7 +1463,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1544,7 +1544,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1564,7 +1564,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1593,7 +1593,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1625,7 +1625,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1654,7 +1654,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1685,7 +1685,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1711,7 +1711,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1740,7 +1740,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1767,7 +1767,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/ams/graph/households.yml
+++ b/datasets/ams/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -638,7 +638,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05
@@ -854,7 +854,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1128,7 +1128,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1212,7 +1212,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ams/graph/industry.yml
+++ b/datasets/ams/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ams/graph/other.yml
+++ b/datasets/ams/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/be-vlg/graph/agriculture.yml
+++ b/datasets/be-vlg/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 6271578947.36842
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 5263200000.0

--- a/datasets/be-vlg/graph/buildings.yml
+++ b/datasets/be-vlg/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 185142857.142857
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 380571428.571429
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 328950000.0
   :forecasting_error: 0.05

--- a/datasets/be-vlg/graph/energy.yml
+++ b/datasets/be-vlg/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5978.59327217125
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5440.51837163692
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7658.45070422535
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3201.48364739008
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5598.87246725371
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 854.534861138085
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 58185000000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/be-vlg/graph/households.yml
+++ b/datasets/be-vlg/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 436050000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/be-vlg/graph/industry.yml
+++ b/datasets/be-vlg/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 11568000000.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 2587500000.0
   :forecasting_error: 0.0

--- a/datasets/be-vlg/graph/other.yml
+++ b/datasets/be-vlg/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/be/graph/agriculture.yml
+++ b/datasets/be/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 11485463677.6102
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 3866000000.0

--- a/datasets/be/graph/buildings.yml
+++ b/datasets/be/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 152715936356.757
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -504,7 +504,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/be/graph/energy.yml
+++ b/datasets/be/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4186.9212962963
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7823.17596566524
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5193.8202247191
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 10059.880239521
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1235.54473524041
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 63000000000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/be/graph/households.yml
+++ b/datasets/be/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 922500000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/be/graph/industry.yml
+++ b/datasets/be/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 127506784866.243
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/be/graph/other.yml
+++ b/datasets/be/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 1748922358.1708
   :forecasting_error: 0.0

--- a/datasets/br/graph/agriculture.yml
+++ b/datasets/br/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 0.0

--- a/datasets/br/graph/buildings.yml
+++ b/datasets/br/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 781714285.714286
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 829125000.0
   :forecasting_error: 0.05

--- a/datasets/br/graph/energy.yml
+++ b/datasets/br/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7843.13725490196
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 11279.8917130396
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 143.905048138149
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7742.39287846425
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 19800000000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/br/graph/households.yml
+++ b/datasets/br/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 408375000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/br/graph/industry.yml
+++ b/datasets/br/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 4864000000.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/br/graph/other.yml
+++ b/datasets/br/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/de/graph/agriculture.yml
+++ b/datasets/de/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 0.0

--- a/datasets/de/graph/buildings.yml
+++ b/datasets/de/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 81000000000.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 41915138580.305
   :forecasting_error: 0.05

--- a/datasets/de/graph/energy.yml
+++ b/datasets/de/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6570.0
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6867.6948177261
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6867.6948177261
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6867.6948177261
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6570.0
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3852.96413031881
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7269.17440156326
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 828.469214837131
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1301.61671728347
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 996604947153.678
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7633.83266120358
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7633.83266120358
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1486.26817447496
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7372.15318048976
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 4279990680.00003
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/de/graph/households.yml
+++ b/datasets/de/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 55561927885.5206
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/de/graph/industry.yml
+++ b/datasets/de/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 320000000000.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/de/graph/other.yml
+++ b/datasets/de/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/grs/graph/agriculture.yml
+++ b/datasets/grs/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 3400000.0

--- a/datasets/grs/graph/buildings.yml
+++ b/datasets/grs/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 489405405.405405
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/grs/graph/energy.yml
+++ b/datasets/grs/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6587.21295924775
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6587.21295924775
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6587.21295924775
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5098.81422924901
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5522.23888055972
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7843.13725490196
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7065.43209876543
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 1682918240.45839
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6811.88364589448
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6811.88364589448
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 533806692.759039
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/grs/graph/households.yml
+++ b/datasets/grs/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 10320750.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/grs/graph/industry.yml
+++ b/datasets/grs/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 3079793568.87654
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/grs/graph/other.yml
+++ b/datasets/grs/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-drenthe/graph/agriculture.yml
+++ b/datasets/nl-drenthe/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 655999841.429314

--- a/datasets/nl-drenthe/graph/buildings.yml
+++ b/datasets/nl-drenthe/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-drenthe/graph/energy.yml
+++ b/datasets/nl-drenthe/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6870.37037037037
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 22515499.7501925
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-drenthe/graph/households.yml
+++ b/datasets/nl-drenthe/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 2400000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-drenthe/graph/industry.yml
+++ b/datasets/nl-drenthe/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-drenthe/graph/other.yml
+++ b/datasets/nl-drenthe/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-flevoland/graph/agriculture.yml
+++ b/datasets/nl-flevoland/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 252169917.301731

--- a/datasets/nl-flevoland/graph/buildings.yml
+++ b/datasets/nl-flevoland/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-flevoland/graph/energy.yml
+++ b/datasets/nl-flevoland/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 322063847.719566
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-flevoland/graph/households.yml
+++ b/datasets/nl-flevoland/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 17924748.5778497
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-flevoland/graph/industry.yml
+++ b/datasets/nl-flevoland/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-flevoland/graph/other.yml
+++ b/datasets/nl-flevoland/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-friesland/graph/agriculture.yml
+++ b/datasets/nl-friesland/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 345710779.326252

--- a/datasets/nl-friesland/graph/buildings.yml
+++ b/datasets/nl-friesland/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-friesland/graph/energy.yml
+++ b/datasets/nl-friesland/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 750557861.082189
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-friesland/graph/households.yml
+++ b/datasets/nl-friesland/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 32708327.5224856
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-friesland/graph/industry.yml
+++ b/datasets/nl-friesland/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-friesland/graph/other.yml
+++ b/datasets/nl-friesland/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-gelderland/graph/agriculture.yml
+++ b/datasets/nl-gelderland/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 1848665572.42489

--- a/datasets/nl-gelderland/graph/buildings.yml
+++ b/datasets/nl-gelderland/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-gelderland/graph/energy.yml
+++ b/datasets/nl-gelderland/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 28174217906.5096
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4835.61618202912
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4835.61618202912
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 3213665928.59834
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-gelderland/graph/households.yml
+++ b/datasets/nl-gelderland/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 99150080.3208748
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-gelderland/graph/industry.yml
+++ b/datasets/nl-gelderland/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-gelderland/graph/other.yml
+++ b/datasets/nl-gelderland/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-groningen/graph/agriculture.yml
+++ b/datasets/nl-groningen/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 398351444.361856

--- a/datasets/nl-groningen/graph/buildings.yml
+++ b/datasets/nl-groningen/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-groningen/graph/energy.yml
+++ b/datasets/nl-groningen/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 5994694356.77746
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-groningen/graph/households.yml
+++ b/datasets/nl-groningen/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 32164316.1844975
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-groningen/graph/industry.yml
+++ b/datasets/nl-groningen/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-groningen/graph/other.yml
+++ b/datasets/nl-groningen/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-limburg/graph/agriculture.yml
+++ b/datasets/nl-limburg/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 1014099077.40635

--- a/datasets/nl-limburg/graph/buildings.yml
+++ b/datasets/nl-limburg/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-limburg/graph/energy.yml
+++ b/datasets/nl-limburg/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11067193676
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 36162439684.9317
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-limburg/graph/households.yml
+++ b/datasets/nl-limburg/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 58741418.7011078
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-limburg/graph/industry.yml
+++ b/datasets/nl-limburg/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-limburg/graph/other.yml
+++ b/datasets/nl-limburg/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord-brabant/graph/agriculture.yml
+++ b/datasets/nl-noord-brabant/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 2594704620.01847

--- a/datasets/nl-noord-brabant/graph/buildings.yml
+++ b/datasets/nl-noord-brabant/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-noord-brabant/graph/energy.yml
+++ b/datasets/nl-noord-brabant/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487078
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 46917.2932330827
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 45186131847.2703
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4334.00846498731
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4334.00846498731
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 6019511755.09329
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-noord-brabant/graph/households.yml
+++ b/datasets/nl-noord-brabant/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 122405266.381689
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord-brabant/graph/industry.yml
+++ b/datasets/nl-noord-brabant/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord-brabant/graph/other.yml
+++ b/datasets/nl-noord-brabant/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord-holland/graph/agriculture.yml
+++ b/datasets/nl-noord-holland/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 3011852723.45885

--- a/datasets/nl-noord-holland/graph/buildings.yml
+++ b/datasets/nl-noord-holland/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-noord-holland/graph/energy.yml
+++ b/datasets/nl-noord-holland/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487078
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5326.88766114181
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 34031457391.3044
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6394.8
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6394.8
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 31610917865.8618
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-noord-holland/graph/households.yml
+++ b/datasets/nl-noord-holland/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 145478288.923728
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord-holland/graph/industry.yml
+++ b/datasets/nl-noord-holland/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord-holland/graph/other.yml
+++ b/datasets/nl-noord-holland/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord/graph/agriculture.yml
+++ b/datasets/nl-noord/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 5531500757.71927
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 1400062065.11742

--- a/datasets/nl-noord/graph/buildings.yml
+++ b/datasets/nl-noord/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-noord/graph/energy.yml
+++ b/datasets/nl-noord/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7142.85714285714
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6846.15384615385
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 16821000000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-noord/graph/households.yml
+++ b/datasets/nl-noord/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 67272643.706983
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord/graph/industry.yml
+++ b/datasets/nl-noord/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 24779446532.0693
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-noord/graph/other.yml
+++ b/datasets/nl-noord/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-overijssel/graph/agriculture.yml
+++ b/datasets/nl-overijssel/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 797471394.699912

--- a/datasets/nl-overijssel/graph/buildings.yml
+++ b/datasets/nl-overijssel/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-overijssel/graph/energy.yml
+++ b/datasets/nl-overijssel/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6366.66666666667
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 141405200.610851
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-overijssel/graph/households.yml
+++ b/datasets/nl-overijssel/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 55262603.1419726
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-overijssel/graph/industry.yml
+++ b/datasets/nl-overijssel/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-overijssel/graph/other.yml
+++ b/datasets/nl-overijssel/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-utrecht/graph/agriculture.yml
+++ b/datasets/nl-utrecht/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 786712839.24384

--- a/datasets/nl-utrecht/graph/buildings.yml
+++ b/datasets/nl-utrecht/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-utrecht/graph/energy.yml
+++ b/datasets/nl-utrecht/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 993984243.734914
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-utrecht/graph/households.yml
+++ b/datasets/nl-utrecht/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 62811114.6306054
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-utrecht/graph/industry.yml
+++ b/datasets/nl-utrecht/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-utrecht/graph/other.yml
+++ b/datasets/nl-utrecht/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-zeeland/graph/agriculture.yml
+++ b/datasets/nl-zeeland/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 256090578.352767

--- a/datasets/nl-zeeland/graph/buildings.yml
+++ b/datasets/nl-zeeland/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-zeeland/graph/energy.yml
+++ b/datasets/nl-zeeland/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8174.16666666667
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 21770123478.2609
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6394.8
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6394.8
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 4602534934.5919
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-zeeland/graph/households.yml
+++ b/datasets/nl-zeeland/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 19546747.6604491
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-zeeland/graph/industry.yml
+++ b/datasets/nl-zeeland/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-zeeland/graph/other.yml
+++ b/datasets/nl-zeeland/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-zuid-holland/graph/agriculture.yml
+++ b/datasets/nl-zuid-holland/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 5211504545.30911

--- a/datasets/nl-zuid-holland/graph/buildings.yml
+++ b/datasets/nl-zuid-holland/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/nl-zuid-holland/graph/energy.yml
+++ b/datasets/nl-zuid-holland/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5242.69085487077
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4377.28937728938
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5989.18083462133
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 60019913487.3269
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7174.86062647356
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7174.86062647356
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 18165708821.2478
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl-zuid-holland/graph/households.yml
+++ b/datasets/nl-zuid-holland/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 184469900.176769
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-zuid-holland/graph/industry.yml
+++ b/datasets/nl-zuid-holland/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl-zuid-holland/graph/other.yml
+++ b/datasets/nl-zuid-holland/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl/graph/agriculture.yml
+++ b/datasets/nl/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 102139534883.721
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 26600000000.0

--- a/datasets/nl/graph/buildings.yml
+++ b/datasets/nl/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 13395348837.2093
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 749250000.0
   :forecasting_error: 0.05

--- a/datasets/nl/graph/energy.yml
+++ b/datasets/nl/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5142.78799612778
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6414.61617007252
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6414.61617007252
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6414.61617007252
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5098.81422924901
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5522.23888055972
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7843.13725490196
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4400.0
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7065.43209876543
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 905.660377358491
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 148712992217.707
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6919.22008544709
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6919.22008544709
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 47772000000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/nl/graph/households.yml
+++ b/datasets/nl/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 1500750000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl/graph/industry.yml
+++ b/datasets/nl/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 141488372093.023
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/nl/graph/other.yml
+++ b/datasets/nl/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/pl/graph/agriculture.yml
+++ b/datasets/pl/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 5420000000.0

--- a/datasets/pl/graph/buildings.yml
+++ b/datasets/pl/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -504,7 +504,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/pl/graph/energy.yml
+++ b/datasets/pl/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5454.85390648449
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4444.53326405404
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4444.53326405404
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4444.53326405404
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1153.21252059308
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4224.41580496852
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5769.31423611111
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/pl/graph/households.yml
+++ b/datasets/pl/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 9000000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/pl/graph/industry.yml
+++ b/datasets/pl/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/pl/graph/other.yml
+++ b/datasets/pl/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ro/graph/agriculture.yml
+++ b/datasets/ro/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 2000000000.0

--- a/datasets/ro/graph/buildings.yml
+++ b/datasets/ro/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -504,7 +504,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/ro/graph/energy.yml
+++ b/datasets/ro/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1321.51898734177
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1325.96685082873
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1325.96685082873
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1325.96685082873
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7954.64209780298
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3525.10760401722
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 577.235772357724
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5063.03724928367
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 67131000000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/ro/graph/households.yml
+++ b/datasets/ro/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 9000000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ro/graph/industry.yml
+++ b/datasets/ro/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ro/graph/other.yml
+++ b/datasets/ro/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/tr/graph/agriculture.yml
+++ b/datasets/tr/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 20890000000.0

--- a/datasets/tr/graph/buildings.yml
+++ b/datasets/tr/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -504,7 +504,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/tr/graph/energy.yml
+++ b/datasets/tr/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1789.68996062992
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6106.25800635764
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7984.89425981873
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3666.66666666667
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3283.40611353712
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5101.52346130408
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 537787800000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/tr/graph/households.yml
+++ b/datasets/tr/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 607500000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/tr/graph/industry.yml
+++ b/datasets/tr/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/tr/graph/other.yml
+++ b/datasets/tr/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/uk/graph/agriculture.yml
+++ b/datasets/uk/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 14502985787.2707

--- a/datasets/uk/graph/buildings.yml
+++ b/datasets/uk/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 246755025.0
   :forecasting_error: 0.05

--- a/datasets/uk/graph/energy.yml
+++ b/datasets/uk/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4312.04508099872
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4828.97733226016
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4828.97733226016
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4828.97733226016
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4562.08824287961
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5719.25202507952
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5719.25202507952
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6156.6518411033
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4446.72551222805
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 521907531751.114
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4077.33635468462
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4077.33635468462
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1286.36601489922
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/uk/graph/households.yml
+++ b/datasets/uk/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 500987475.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/uk/graph/industry.yml
+++ b/datasets/uk/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/uk/graph/other.yml
+++ b/datasets/uk/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ut/graph/agriculture.yml
+++ b/datasets/ut/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 115704109589.041
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 26600000000.0

--- a/datasets/ut/graph/buildings.yml
+++ b/datasets/ut/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 18638805970.1493
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/ut/graph/energy.yml
+++ b/datasets/ut/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5006.87397346895
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7033.04913999755
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7033.04913999755
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7033.04913999755
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11067193676
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4686.83530777058
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5256.0
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8330.06535947712
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6266.66666666667
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4077.50144592249
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 96078786664.9309
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7848.37560559765
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7848.37560559765
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 54932274696.3448
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/ut/graph/households.yml
+++ b/datasets/ut/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 1037500000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 2714600472.64521
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 7802698872.38893
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 1773340652.81567
   :forecasting_error: 0.0

--- a/datasets/ut/graph/industry.yml
+++ b/datasets/ut/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 232784313725.49
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/ut/graph/other.yml
+++ b/datasets/ut/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/za/graph/agriculture.yml
+++ b/datasets/za/graph/agriculture.yml
@@ -60,7 +60,7 @@ agriculture_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-agricultu
 
 :agriculture_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -93,7 +93,7 @@ agriculture_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-a
 
 :agriculture_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -120,7 +120,7 @@ agriculture_chp_engine_network_gas-(network_gas) -- s --> (network_gas)-energy_n
 
 :agriculture_chp_supercritical_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7500.0
@@ -153,7 +153,7 @@ agriculture_final_demand_crude_oil-(crude_oil) -- s --> (crude_oil)-energy_distr
 
 :agriculture_final_demand_electricity:
   :availability: 0.0
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.0
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :costs_per_mj: 0.0
   :demand_expected_value: 21029392800.0

--- a/datasets/za/graph/buildings.yml
+++ b/datasets/za/graph/buildings.yml
@@ -35,7 +35,7 @@ buildings_appliances_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-buildin
 
 :buildings_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -70,7 +70,7 @@ buildings_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-bui
 
 :buildings_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -97,7 +97,7 @@ buildings_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energy
 
 :buildings_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -505,7 +505,7 @@ buildings_local_production_electricity-(electricity) -- d --> (electricity)-buil
 
 :buildings_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.05

--- a/datasets/za/graph/energy.yml
+++ b/datasets/za/graph/energy.yml
@@ -1,6 +1,6 @@
 :energy_chp_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -27,7 +27,7 @@ energy_chp_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :energy_chp_supercritical_waste_mix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -54,7 +54,7 @@ energy_chp_supercritical_waste_mix-(waste_mix) -- s --> (waste_mix)-energy_distr
 
 :energy_chp_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -86,7 +86,7 @@ energy_chp_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-energ
 
 :energy_chp_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -116,7 +116,7 @@ energy_chp_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (to
 
 :energy_chp_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -148,7 +148,7 @@ energy_chp_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood_p
 
 :energy_chp_ultra_supercritical_lignite:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4204.8
@@ -962,7 +962,7 @@ energy_national_gas_network_natural_gas-(greengas) -- s --> (greengas)-energy_di
 
 :energy_power_combined_cycle_ccs_coal:
   :availability: 0.87
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.981071814381664
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -991,7 +991,7 @@ energy_power_combined_cycle_ccs_coal-(torrified_biomass_pellets) -- s --> (torri
 
 :energy_power_combined_cycle_ccs_network_gas:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.979125780553078
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 4818.0
@@ -1017,7 +1017,7 @@ energy_power_combined_cycle_ccs_network_gas-(network_gas) -- s --> (network_gas)
 
 :energy_power_combined_cycle_coal:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6324.11
@@ -1046,7 +1046,7 @@ energy_power_combined_cycle_coal-(torrified_biomass_pellets) -- s --> (torrified
 
 :energy_power_combined_cycle_network_gas:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 4687.0
@@ -1072,7 +1072,7 @@ energy_power_combined_cycle_network_gas-(network_gas) -- s --> (network_gas)-ene
 
 :energy_power_engine_diesel:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1324,7 +1324,7 @@ energy_power_mv_transport_network_electricity-(electricity) -- f --> (electricit
 
 :energy_power_nuclear_gen2_uranium_oxide:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5194.81865284974
@@ -1350,7 +1350,7 @@ energy_power_nuclear_gen2_uranium_oxide-(uranium_oxide) -- s --> (uranium_oxide)
 
 :energy_power_nuclear_gen3_uranium_oxide:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 7884.0
@@ -1409,7 +1409,7 @@ energy_power_solar_csp_solar_radiation-(solar_radiation) -- s --> (solar_radiati
 
 :energy_power_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.05
   :full_load_hours: 1050.0
@@ -1435,7 +1435,7 @@ energy_power_solar_pv_solar_radiation-(solar_radiation) -- s --> (solar_radiatio
 
 :energy_power_supercritical_coal:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 5409.41974885565
@@ -1464,7 +1464,7 @@ energy_power_supercritical_coal-(torrified_biomass_pellets) -- s --> (torrified_
 
 :energy_power_supercritical_waste_mix:
   :availability: 0.9
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.97
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6190.0
@@ -1545,7 +1545,7 @@ energy_power_transformer_mv_hv_electricity-(electricity) -- i --> (electricity)-
 
 :energy_power_turbine_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 1000.0
@@ -1565,7 +1565,7 @@ energy_power_turbine_network_gas-(network_gas) -- s --> (network_gas)-energy_nat
 
 :energy_power_ultra_supercritical_ccs_coal:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98116169544741
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788
@@ -1594,7 +1594,7 @@ energy_power_ultra_supercritical_ccs_coal-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_coal:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1626,7 +1626,7 @@ energy_power_ultra_supercritical_coal-(wood_pellets) -- s --> (wood_pellets)-ene
 
 :energy_power_ultra_supercritical_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1655,7 +1655,7 @@ energy_power_ultra_supercritical_coal_rdr-(torrified_biomass_pellets) -- s --> (
 
 :energy_power_ultra_supercritical_cofiring_coal_rdr:
   :availability: 0.88
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6950.0
@@ -1686,7 +1686,7 @@ energy_power_ultra_supercritical_cofiring_coal_rdr-(wood_pellets) -- s --> (wood
 
 :energy_power_ultra_supercritical_crude_oil:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 3504.0
@@ -1712,7 +1712,7 @@ energy_power_ultra_supercritical_crude_oil-(crude_oil) -- s --> (crude_oil)-ener
 
 :energy_power_ultra_supercritical_lignite:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.9875
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6329.1
@@ -1741,7 +1741,7 @@ energy_power_ultra_supercritical_lignite-(torrified_biomass_pellets) -- s --> (t
 
 :energy_power_ultra_supercritical_network_gas:
   :availability: 0.89
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 603819000.0
   :forecasting_error: 0.0
@@ -1768,7 +1768,7 @@ energy_power_ultra_supercritical_network_gas-(network_gas) -- s --> (network_gas
 
 :energy_power_ultra_supercritical_oxyfuel_ccs_lignite:
   :availability: 0.85
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.96969696969697
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.85
   :forecasting_error: 0.0
   :full_load_hours: 5971.71063829788

--- a/datasets/za/graph/households.yml
+++ b/datasets/za/graph/households.yml
@@ -72,7 +72,7 @@ households_appliances_washing_machine_electricity-(electricity) -- s --> (electr
 
 :households_collective_chp_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -105,7 +105,7 @@ households_collective_chp_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat
 
 :households_collective_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -132,7 +132,7 @@ households_collective_chp_network_gas-(network_gas) -- s --> (network_gas)-energ
 
 :households_collective_chp_wood_pellets:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -639,7 +639,7 @@ households_old_houses_useful_demand_for_heating-(useable_heat) -- s --> (useable
 
 :households_solar_pv_solar_radiation:
   :availability: 0.98
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.83
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 11970000000.0
   :forecasting_error: 0.05
@@ -855,7 +855,7 @@ households_space_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_space_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1129,7 +1129,7 @@ households_water_heater_district_heating_steam_hot_water-(steam_hot_water) -- s 
 
 :households_water_heater_fuel_cell_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -1213,7 +1213,7 @@ households_water_heater_heatpump_ground_water_electricity-(electricity) -- s -->
 
 :households_water_heater_micro_chp_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/za/graph/industry.yml
+++ b/datasets/za/graph/industry.yml
@@ -146,7 +146,7 @@ industry_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-industry_fin
 
 :industry_chp_combined_cycle_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0
@@ -173,7 +173,7 @@ industry_chp_combined_cycle_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_
 
 :industry_chp_engine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 6000.0
@@ -199,7 +199,7 @@ industry_chp_engine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_fu
 
 :industry_chp_turbine_gas_power_fuelmix:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -225,7 +225,7 @@ industry_chp_turbine_gas_power_fuelmix-(gas_power_fuelmix) -- s --> (gas_power_f
 
 :industry_chp_ultra_supercritical_coal:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.99
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0

--- a/datasets/za/graph/other.yml
+++ b/datasets/za/graph/other.yml
@@ -80,7 +80,7 @@ other_burner_wood_pellets-(wood_pellets) -- s --> (wood_pellets)-other_final_dem
 
 :other_chp_engine_biogas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :forecasting_error: 0.0
   :full_load_hours: 8000.0
@@ -113,7 +113,7 @@ other_chp_engine_biogas_dumped_heat-(dumped_heat) -- d --> (dumped_heat)-other_c
 
 :other_chp_engine_network_gas:
   :availability: 0.97
-  :average_effective_output_of_nominal_capacity_over_lifetime: 0.98
+  :average_effective_output_of_nominal_capacity_over_lifetime: 1.0
   :co2_free: 0.0
   :demand_expected_value: 0.0
   :forecasting_error: 0.0


### PR DESCRIPTION
Set the value of all instances of average_effective_output_of_nominal_capacity_over_lifetime to 1.0. 

Fixes https://github.com/quintel/etsource/issues/582
