### PR TITLE
Defining adaptive slider caps for central heaters. 

### DIFF
--- a/data/inputs/number_of/number_of_energy_heater_for_heat_network_coal.ad
+++ b/data/inputs/number_of/number_of_energy_heater_for_heat_network_coal.ad
@@ -6,6 +6,7 @@
     )
 - priority = 0
 - max_value = 100.0
+- max_value_gql = present:PRODUCT(DIVIDE(SUM(V(G(final_demand_cbs),input_of_steam_hot_water)),V(energy_heater_for_heat_network_coal,typical_heat_production_per_unit)),0.5)
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_coal,number_of_units)
 - step_value = 0.1

--- a/data/inputs/number_of/number_of_energy_heater_for_heat_network_network_gas.ad
+++ b/data/inputs/number_of/number_of_energy_heater_for_heat_network_network_gas.ad
@@ -6,6 +6,7 @@
     )
 - priority = 0
 - max_value = 300.0
+- max_value_gql = present:PRODUCT(DIVIDE(SUM(V(G(final_demand_cbs),input_of_steam_hot_water)),V(energy_heater_for_heat_network_network_gas,typical_heat_production_per_unit)),1.5)
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_network_gas,number_of_units)
 - step_value = 0.1

--- a/data/inputs/number_of/number_of_energy_heater_for_heat_network_waste_mix.ad
+++ b/data/inputs/number_of/number_of_energy_heater_for_heat_network_waste_mix.ad
@@ -6,6 +6,7 @@
     )
 - priority = 0
 - max_value = 5000.0
+- max_value_gql = present:PRODUCT(DIVIDE(SUM(V(G(final_demand_cbs),input_of_steam_hot_water)),V(energy_heater_for_heat_network_waste_mix,typical_heat_production_per_unit)),1.2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_waste_mix,number_of_units)
 - step_value = 0.1


### PR DESCRIPTION
Instead of hard-coding the max slider caps for central coal, gas and waste heaters, a max_value_gql is introduced. 

Problems with preset scenarios are not expected, because the max slider settings are slightly increased for NL: 

```
Old / new slider caps:
Central coal-fired heater: 100 / 112.6
Central gas-fired heater: 300 / 337.8
Central waste-fired heater: 5000 / 5404.9
```

This change is necessary, because these sliders would jump to the hard-coded maximum in the EU-model. 
