### PR TITLE
change availability of Hydro Mountain. 

### DIFF
--- a/data/nodes/energy/energy_power_hydro_mountain.central_producer.ad
+++ b/data/nodes/energy/energy_power_hydro_mountain.central_producer.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - groups = [preset_demand, central_production, cost_electricity_production, electricity_production, primary_energy_demand, sustainable_production]
 - merit_order.type = dispatchable
-- availability = 0.98
+- availability = 0.33
 - co2_free = 0.0
 - forecasting_error = 0.0
 - households_supplied_per_unit = 0.0


### PR DESCRIPTION
As discussed in https://github.com/quintel/etdataset/issues/342, we reduce the availability of hydro mountain to limit its production in merit order.
