### PR TITLE
etflex_score_fix

### DIFF
--- a/data/gqueries/modules/etflex/etflex_level_2/etflex_households_score_base.gql
+++ b/data/gqueries/modules/etflex/etflex_level_2/etflex_households_score_base.gql
@@ -1,4 +1,4 @@
 # The base score is 950
 
-- query = 950
+- query = 920
 - unit = #

--- a/data/gqueries/modules/etflex/etflex_level_2/etflex_households_score_investment.gql
+++ b/data/gqueries/modules/etflex/etflex_level_2/etflex_households_score_investment.gql
@@ -1,5 +1,5 @@
 # Penalty for investment costs
 # NOTE: this can change the present score if solar thermal panels are touched.
 
-- query = - 0.0065 * Q(etflex_households_investment_per_household)
+- query = - 0.0058 * Q(etflex_households_investment_per_household)
 - unit = #


### PR DESCRIPTION
Tweaked the score to prefer the heatpump over the combi boiler and stay below 999
Micro CHP is not favored though... :unamused: 

Fixes https://github.com/quintel/etflex/issues/399
