### PR TITLE
New queries for chart 57

### DIFF
--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/appliances_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/appliances_demand_in_households.gql
@@ -1,0 +1,3 @@
+- query =
+    V(households_final_demand_for_appliances_electricity,demand) / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/cooking_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/cooking_demand_in_households.gql
@@ -1,0 +1,3 @@
+- query = 
+    V(households_useful_demand_cooking_useable_heat, demand) / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/cooling_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/cooling_demand_in_households.gql
@@ -1,0 +1,6 @@
+- query = 
+    SUM(
+      V(households_old_houses_useful_demand_for_cooling,demand),
+      V(households_new_houses_useful_demand_for_cooling,demand)
+    ) / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/cooling_demand_in_use_of_final_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/cooling_demand_in_use_of_final_demand_in_households.gql
@@ -1,2 +1,0 @@
-- query = DIVIDE(V(households_useful_demand_for_cooling_after_insulation,demand),BILLIONS)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/electricity_demand_excluding_heating_in_use_of_final_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/electricity_demand_excluding_heating_in_use_of_final_demand_in_households.gql
@@ -1,8 +1,0 @@
-- query =
-    DIVIDE(SUM(V(
-    households_final_demand_for_hot_water_electricity,
-    households_final_demand_for_cooking_electricity,
-    households_final_demand_for_lighting_electricity,
-    households_final_demand_for_appliances_electricity,demand
-    )),BILLIONS)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/heat_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/heat_demand_in_households.gql
@@ -1,0 +1,6 @@
+- query = 
+    SUM(
+      V(households_new_houses_useful_demand_for_heating,demand),
+      V(households_old_houses_useful_demand_for_heating,demand)
+    ) / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/heat_demand_including_electric_heating_in_use_of_final_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/heat_demand_including_electric_heating_in_use_of_final_demand_in_households.gql
@@ -1,2 +1,0 @@
-- query = DIVIDE(V(households_useful_demand_for_space_heating_after_insulation,demand),BILLIONS)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/hot_water_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/hot_water_demand_in_households.gql
@@ -1,0 +1,3 @@
+- query = 
+    V(households_useful_demand_hot_water,demand) / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/hot_water_demand_in_use_of_final_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/hot_water_demand_in_use_of_final_demand_in_households.gql
@@ -1,2 +1,0 @@
-- query = DIVIDE(V(households_useful_demand_hot_water,demand),BILLIONS)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/lighting_demand_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_57_use_of_final_demand_in_households/lighting_demand_in_households.gql
@@ -1,0 +1,3 @@
+- query = 
+    V(households_useful_demand_light,demand) / BILLIONS
+- unit = pj


### PR DESCRIPTION
The chart now reflects the sliders of the slide and shows **useful** instead of **final** demand.

Part of https://github.com/quintel/etsource/issues/628

BEFORE: 
![energy_transition_model_-_your_free__independent__comprehensive__fact-based_scenario_builder](https://f.cloud.github.com/assets/1303760/1593757/7397fcf4-52d0-11e3-8061-be7edfc08504.png)

AFTER:

![energy_transition_model_-_your_free__independent__comprehensive__fact-based_scenario_builder](https://f.cloud.github.com/assets/1303760/1593763/89e403cc-52d0-11e3-8ed5-54f6c4f573f4.png)
