### PR TITLE
Etflex score

### DIFF
--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_score_base.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_score_base.gql
@@ -1,4 +1,4 @@
 # The base score is 950
 
-- query = 950
+- query = 920
 - unit = #

--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_score_investment.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_score_investment.gql
@@ -1,5 +1,5 @@
 # Penalty for investment costs
 # NOTE: this can change the present score if solar thermal panels are touched.
 
-- query = - 0.0065 * Q(etflex_households_investment_per_household)
+- query = - 0.0058 * Q(etflex_households_investment_per_household)
 - unit = #


### PR DESCRIPTION
Tweak of etflex score to prefer heatpump over combin boiler. NOTE: Micro-CHP is not favored.

Fixes https://github.com/quintel/etflex/issues/405
