### PR TITLE
Changed heat query for chart 62

### DIFF
--- a/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/other_heat_in_source_of_heat_and_electricity_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/other_heat_in_source_of_heat_and_electricity_in_agriculture.gql
@@ -2,7 +2,7 @@
     DIVIDE(
         MAX(
             SUM(
-                V(agriculture_useful_demand_useable_heat,demand),
+                V(agriculture_locally_available_steam_hot_water,demand),
                 NEG(
                     V(agriculture_chp_engine_network_gas,output_of_heat_carriers)
                 ),


### PR DESCRIPTION
Fixes the issue that heat at different levels are shown in the same chart. Now this chart only deals with the heat from the CHPs and the central network.
