### PR TITLE
gql_cleanup

### DIFF
--- a/nodes/industry/industry_locally_available_steam_hot_water.ad
+++ b/nodes/industry/industry_locally_available_steam_hot_water.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = locally available
-- groups = []
+- groups = [heat_production]
 - co2_free = 0.0


### PR DESCRIPTION
Added industry_locally_available_steam_hot_water to heat production group. This allows us to track the monetized heat in industry
