### PR TITLE
Remove "factor" attribute from inputs

### DIFF
--- a/gqueries/general/shares/share_of_coal_boiler_in_hot_water_produced_in_households.gql
+++ b/gqueries/general/shares/share_of_coal_boiler_in_hot_water_produced_in_households.gql
@@ -1,0 +1,4 @@
+# Returns how much of the hot water demand of households is provided by coal-powered heaters
+
+- query = V(households_water_heater_coal,share_of_households_useful_demand_hot_water)
+- unit = factor

--- a/gqueries/general/shares/share_of_combined_network_gas_in_hot_water_produced_in_households.gql
+++ b/gqueries/general/shares/share_of_combined_network_gas_in_hot_water_produced_in_households.gql
@@ -1,0 +1,4 @@
+# Returns how much of the hot water demand of households is provided by combined network gas-powered water heaters
+
+- query = V(households_water_heater_combined_network_gas,share_of_households_useful_demand_hot_water)
+- unit = factor

--- a/inputs/costs/agriculture_chp_supercritical_wood_pellets.ad
+++ b/inputs/costs/agriculture_chp_supercritical_wood_pellets.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/costs_biomass.ad
+++ b/inputs/costs/costs_biomass.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 5.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/costs_co2.ad
+++ b/inputs/costs/costs_co2.ad
@@ -7,7 +7,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/costs_co2_free_allocation.ad
+++ b/inputs/costs/costs_co2_free_allocation.ad
@@ -3,8 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:AREA(co2_percentage_free)
+- start_value_gql = present:AREA(co2_percentage_free) * 100
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/costs/costs_coal.ad
+++ b/inputs/costs/costs_coal.ad
@@ -7,7 +7,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 5.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/costs_gas.ad
+++ b/inputs/costs/costs_gas.ad
@@ -7,7 +7,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 5.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/costs_oil.ad
+++ b/inputs/costs/costs_oil.ad
@@ -7,7 +7,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 5.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/costs_uranium.ad
+++ b/inputs/costs/costs_uranium.ad
@@ -7,7 +7,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 5.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_combustion_coal_plant.ad
+++ b/inputs/costs/investment_costs_combustion_coal_plant.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_combustion_gas_plant.ad
+++ b/inputs/costs/investment_costs_combustion_gas_plant.ad
@@ -24,7 +24,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_combustion_oil_plant.ad
+++ b/inputs/costs/investment_costs_combustion_oil_plant.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_combustion_waste_incinerator.ad
+++ b/inputs/costs/investment_costs_combustion_waste_incinerator.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_earth_geothermal_electricity.ad
+++ b/inputs/costs/investment_costs_earth_geothermal_electricity.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_electric_heat_pumps.ad
+++ b/inputs/costs/investment_costs_electric_heat_pumps.ad
@@ -17,7 +17,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_fuel_cell.ad
+++ b/inputs/costs/investment_costs_fuel_cell.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_gas_heat_pumps.ad
+++ b/inputs/costs/investment_costs_gas_heat_pumps.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_micro_chp.ad
+++ b/inputs/costs/investment_costs_micro_chp.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_nuclear_nuclear_plant.ad
+++ b/inputs/costs/investment_costs_nuclear_nuclear_plant.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_solar_concentrated_solar_power.ad
+++ b/inputs/costs/investment_costs_solar_concentrated_solar_power.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_solar_solar_panels.ad
+++ b/inputs/costs/investment_costs_solar_solar_panels.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_water_mountains.ad
+++ b/inputs/costs/investment_costs_water_mountains.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_water_river.ad
+++ b/inputs/costs/investment_costs_water_river.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_wind_offshore.ad
+++ b/inputs/costs/investment_costs_wind_offshore.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/investment_costs_wind_onshore.ad
+++ b/inputs/costs/investment_costs_wind_onshore.ad
@@ -5,7 +5,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_combustion_biomass_plant.ad
+++ b/inputs/costs/om_costs_combustion_biomass_plant.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_combustion_coal_plant.ad
+++ b/inputs/costs/om_costs_combustion_coal_plant.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_combustion_gas_plant.ad
+++ b/inputs/costs/om_costs_combustion_gas_plant.ad
@@ -43,7 +43,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_combustion_oil_plant.ad
+++ b/inputs/costs/om_costs_combustion_oil_plant.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_combustion_waste_incinerator.ad
+++ b/inputs/costs/om_costs_combustion_waste_incinerator.ad
@@ -11,7 +11,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_earth_geothermal_electricity.ad
+++ b/inputs/costs/om_costs_earth_geothermal_electricity.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_nuclear_nuclear_plant.ad
+++ b/inputs/costs/om_costs_nuclear_nuclear_plant.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_water_mountains.ad
+++ b/inputs/costs/om_costs_water_mountains.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_water_river.ad
+++ b/inputs/costs/om_costs_water_river.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_wind_offshore.ad
+++ b/inputs/costs/om_costs_wind_offshore.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/costs/om_costs_wind_onshore.ad
+++ b/inputs/costs/om_costs_wind_onshore.ad
@@ -9,7 +9,6 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/agriculture/agriculture_burner_crude_oil_share.ad
+++ b/inputs/demand/agriculture/agriculture_burner_crude_oil_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 9.0
-- start_value_gql = present:V(agriculture_burner_crude_oil,share_of_agriculture_useful_demand_useable_heat)
+- start_value_gql = present:V(agriculture_burner_crude_oil,share_of_agriculture_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/agriculture/agriculture_burner_network_gas_share.ad
+++ b/inputs/demand/agriculture/agriculture_burner_network_gas_share.ad
@@ -4,8 +4,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 67.0
-- start_value_gql = present:V(agriculture_burner_network_gas,share_of_agriculture_useful_demand_useable_heat)
+- start_value_gql = present:V(agriculture_burner_network_gas,share_of_agriculture_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/agriculture/agriculture_burner_wood_pellets_share.ad
+++ b/inputs/demand/agriculture/agriculture_burner_wood_pellets_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(agriculture_burner_wood_pellets,share_of_agriculture_useful_demand_useable_heat)
+- start_value_gql = present:V(agriculture_burner_wood_pellets,share_of_agriculture_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/agriculture/agriculture_final_demand_steam_hot_water_share.ad
+++ b/inputs/demand/agriculture/agriculture_final_demand_steam_hot_water_share.ad
@@ -16,8 +16,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(agriculture_final_demand_steam_hot_water,share_of_agriculture_useful_demand_useable_heat)
+- start_value_gql = future:V(agriculture_final_demand_steam_hot_water,share_of_agriculture_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/agriculture/agriculture_geothermal_share.ad
+++ b/inputs/demand/agriculture/agriculture_geothermal_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(agriculture_geothermal,share_of_agriculture_useful_demand_useable_heat)
+- start_value_gql = present:V(agriculture_geothermal,share_of_agriculture_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/agriculture/agriculture_heatpump_water_water_ts_electricity_share.ad
+++ b/inputs/demand/agriculture/agriculture_heatpump_water_water_ts_electricity_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(agriculture_heatpump_water_water_ts_electricity,share_of_agriculture_useful_demand_useable_heat)
+- start_value_gql = present:V(agriculture_heatpump_water_water_ts_electricity,share_of_agriculture_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/agriculture/agriculture_useful_demand_electricity.ad
+++ b/inputs/demand/agriculture/agriculture_useful_demand_electricity.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/agriculture/agriculture_useful_demand_useable_heat.ad
+++ b/inputs/demand/agriculture/agriculture_useful_demand_useable_heat.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/agriculture/number_of_agriculture_chp_engine_biogas.ad
+++ b/inputs/demand/agriculture/number_of_agriculture_chp_engine_biogas.ad
@@ -14,6 +14,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(agriculture_chp_engine_biogas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/demand/agriculture/number_of_agriculture_chp_engine_network_gas.ad
+++ b/inputs/demand/agriculture/number_of_agriculture_chp_engine_network_gas.ad
@@ -14,6 +14,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(agriculture_chp_engine_network_gas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/demand/agriculture/number_of_agriculture_chp_supercritical_wood_pellets.ad
+++ b/inputs/demand/agriculture/number_of_agriculture_chp_supercritical_wood_pellets.ad
@@ -14,6 +14,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(agriculture_chp_supercritical_wood_pellets,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/demand/buildings/buildings_cooling/buildings_cooling_airconditioning_share.ad
+++ b/inputs/demand/buildings/buildings_cooling/buildings_cooling_airconditioning_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_cooling_airconditioning_electricity,share_of_buildings_useful_demand_after_insulation_cooling)
+- start_value_gql = present:V(buildings_cooling_airconditioning_electricity,share_of_buildings_useful_demand_after_insulation_cooling) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_cooling/buildings_cooling_collective_cooling_network_electricity_share.ad
+++ b/inputs/demand/buildings/buildings_cooling/buildings_cooling_collective_cooling_network_electricity_share.ad
@@ -11,9 +11,8 @@
 - max_value = 15.0
 - max_value_gql = present:PRODUCT(DIVIDE(AREA(cold_network_potential),V(buildings_useful_demand_after_insulation_cooling,demand)),100)
 - min_value = 0.0
-- start_value_gql = present:V(buildings_cooling_collective_cooling_network_electricity,share_of_buildings_useful_demand_after_insulation_cooling)
+- start_value_gql = present:V(buildings_cooling_collective_cooling_network_electricity,share_of_buildings_useful_demand_after_insulation_cooling) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - dependent_on = has_cold_network

--- a/inputs/demand/buildings/buildings_cooling/buildings_cooling_collective_heatpump_water_water_ts_electricity_share.ad
+++ b/inputs/demand/buildings/buildings_cooling/buildings_cooling_collective_heatpump_water_water_ts_electricity_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_cooling_collective_heatpump_water_water_ts_electricity,share_of_buildings_useful_demand_after_insulation_cooling)
+- start_value_gql = present:V(buildings_cooling_collective_heatpump_water_water_ts_electricity,share_of_buildings_useful_demand_after_insulation_cooling) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_cooling/buildings_cooling_heatpump_air_water_network_gas_share.ad
+++ b/inputs/demand/buildings/buildings_cooling/buildings_cooling_heatpump_air_water_network_gas_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_cooling_heatpump_air_water_network_gas,share_of_buildings_useful_demand_after_insulation_cooling)
+- start_value_gql = present:V(buildings_cooling_heatpump_air_water_network_gas,share_of_buildings_useful_demand_after_insulation_cooling) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_district_heating/buildings_chp_engine_biogas_share.ad
+++ b/inputs/demand/buildings/buildings_district_heating/buildings_chp_engine_biogas_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_chp_engine_biogas,share_of_buildings_final_demand_steam_hot_water)
+- start_value_gql = present:V(buildings_chp_engine_biogas,share_of_buildings_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_district_heating/buildings_collective_chp_network_gas_share.ad
+++ b/inputs/demand/buildings/buildings_district_heating/buildings_collective_chp_network_gas_share.ad
@@ -15,8 +15,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_collective_chp_network_gas,steam_hot_water_output_link_share)
+- start_value_gql = present:V(buildings_collective_chp_network_gas,steam_hot_water_output_link_share) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_district_heating/buildings_collective_chp_wood_pellets_share.ad
+++ b/inputs/demand/buildings/buildings_district_heating/buildings_collective_chp_wood_pellets_share.ad
@@ -15,8 +15,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_collective_chp_wood_pellets,steam_hot_water_output_link_share)
+- start_value_gql = present:V(buildings_collective_chp_wood_pellets,steam_hot_water_output_link_share) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_district_heating/buildings_collective_geothermal_share.ad
+++ b/inputs/demand/buildings/buildings_district_heating/buildings_collective_geothermal_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_collective_geothermal,share_of_buildings_final_demand_steam_hot_water)
+- start_value_gql = present:V(buildings_collective_geothermal,share_of_buildings_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_district_heating/buildings_heat_network_connection_steam_hot_water_share.ad
+++ b/inputs/demand/buildings/buildings_district_heating/buildings_heat_network_connection_steam_hot_water_share.ad
@@ -15,8 +15,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_heat_network_connection_steam_hot_water,steam_hot_water_output_link_share)
+- start_value_gql = present:V(buildings_heat_network_connection_steam_hot_water,steam_hot_water_output_link_share) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_coal_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_coal_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_coal,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_coal,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_collective_heatpump_water_water_ts_electricity_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_collective_heatpump_water_water_ts_electricity_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_collective_heatpump_water_water_ts_electricity,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_collective_heatpump_water_water_ts_electricity,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_crude_oil_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_crude_oil_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_crude_oil,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_crude_oil,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_district_heating_steam_hot_water_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_district_heating_steam_hot_water_share.ad
@@ -16,8 +16,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_district_heating_steam_hot_water,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_district_heating_steam_hot_water,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_electricity_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_electricity_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_electricity,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_electricity,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_heatpump_air_water_network_gas_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_heatpump_air_water_network_gas_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_heatpump_air_water_network_gas,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_heatpump_air_water_network_gas,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_network_gas_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_network_gas_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_network_gas,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_network_gas,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_solar_thermal_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_solar_thermal_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 13.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_solar_thermal,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_solar_thermal,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_wood_pellets_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_wood_pellets_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_space_heater_wood_pellets,share_of_buildings_useful_demand_for_space_heating_after_insulation)
+- start_value_gql = present:V(buildings_space_heater_wood_pellets,share_of_buildings_useful_demand_for_space_heating_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_misc/buildings_insulation_level.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_insulation_level.ad
@@ -4,7 +4,6 @@
 - max_value_gql = present:AREA(insulation_level_buildings_max)
 - min_value_gql = present:AREA(insulation_level_buildings_min)
 - start_value_gql = present:AREA(insulation_level_buildings_min)
-- factor = 1.0
 - update_period = future
 - dependent_on = has_buildings
 - query =

--- a/inputs/demand/buildings/buildings_misc/buildings_lighting_savings_from_daylight_control_light.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_lighting_savings_from_daylight_control_light.ad
@@ -3,8 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_lighting_savings_from_daylight_control_light,share_of_buildings_useful_demand_after_motion_detection_light)
+- start_value_gql = present:V(buildings_lighting_savings_from_daylight_control_light,share_of_buildings_useful_demand_after_motion_detection_light) * 387
 - step_value = 0.1
-- factor = 387.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_misc/buildings_lighting_savings_from_motion_detection_light.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_lighting_savings_from_motion_detection_light.ad
@@ -3,8 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_lighting_savings_from_motion_detection_light,share_of_buildings_useful_demand_light)
+- start_value_gql = present:V(buildings_lighting_savings_from_motion_detection_light,share_of_buildings_useful_demand_light) * 680
 - step_value = 0.1
-- factor = 680.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_misc/buildings_solar_pv_solar_radiation_market_penetration.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_solar_pv_solar_radiation_market_penetration.ad
@@ -13,8 +13,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:DIVIDE(V(buildings_solar_pv_solar_radiation,output_of_electricity),Q(potential_electricity_production_of_solar_roof_pv))
+- start_value_gql = present:DIVIDE(V(buildings_solar_pv_solar_radiation,output_of_electricity),Q(potential_electricity_production_of_solar_roof_pv)) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/buildings/buildings_misc/buildings_useful_demand_cooling.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_useful_demand_cooling.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/buildings/buildings_misc/buildings_useful_demand_cooling_electricity.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_useful_demand_cooling_electricity.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/buildings/buildings_misc/buildings_useful_demand_for_appliances.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_useful_demand_for_appliances.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/buildings/buildings_misc/buildings_useful_demand_for_space_heating.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_useful_demand_for_space_heating.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/buildings/buildings_misc/number_of_buildings.ad
+++ b/inputs/demand/buildings/buildings_misc/number_of_buildings.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_climate/households_climate_influence.ad
+++ b/inputs/demand/households/households_climate/households_climate_influence.ad
@@ -15,7 +15,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 1.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_cooking/households_cooker_halogen_electricity_share.ad
+++ b/inputs/demand/households/households_cooking/households_cooker_halogen_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_cooker_halogen_electricity,share_of_households_useful_demand_cooking_useable_heat)
+- start_value_gql = present:V(households_cooker_halogen_electricity,share_of_households_useful_demand_cooking_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooking/households_cooker_induction_electricity_share.ad
+++ b/inputs/demand/households/households_cooking/households_cooker_induction_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_cooker_induction_electricity,share_of_households_useful_demand_cooking_useable_heat)
+- start_value_gql = present:V(households_cooker_induction_electricity,share_of_households_useful_demand_cooking_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooking/households_cooker_network_gas_share.ad
+++ b/inputs/demand/households/households_cooking/households_cooker_network_gas_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_cooker_network_gas,share_of_households_useful_demand_cooking_useable_heat)
+- start_value_gql = present:V(households_cooker_network_gas,share_of_households_useful_demand_cooking_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooking/households_cooker_resistive_electricity_share.ad
+++ b/inputs/demand/households/households_cooking/households_cooker_resistive_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_cooker_resistive_electricity,share_of_households_useful_demand_cooking_useable_heat)
+- start_value_gql = present:V(households_cooker_resistive_electricity,share_of_households_useful_demand_cooking_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooking/households_cooker_wood_pellets_share.ad
+++ b/inputs/demand/households/households_cooking/households_cooker_wood_pellets_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_cooker_wood_pellets,share_of_households_useful_demand_cooking_useable_heat)
+- start_value_gql = present:V(households_cooker_wood_pellets,share_of_households_useful_demand_cooking_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooling/households_cooling_airconditioning_electricity_share.ad
+++ b/inputs/demand/households/households_cooling/households_cooling_airconditioning_electricity_share.ad
@@ -3,8 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = future:V(households_cooling_airconditioning_electricity,share_of_households_useful_demand_for_cooling_after_insulation)
+- start_value_gql = future:V(households_cooling_airconditioning_electricity,share_of_households_useful_demand_for_cooling_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooling/households_cooling_heatpump_air_water_electricity_share.ad
+++ b/inputs/demand/households/households_cooling/households_cooling_heatpump_air_water_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = future:V(households_cooling_heatpump_air_water_electricity,share_of_households_useful_demand_for_cooling_after_insulation)
+- start_value_gql = future:V(households_cooling_heatpump_air_water_electricity,share_of_households_useful_demand_for_cooling_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooling/households_cooling_heatpump_ground_water_electricity_share.ad
+++ b/inputs/demand/households/households_cooling/households_cooling_heatpump_ground_water_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = future:V(households_cooling_heatpump_ground_water_electricity,share_of_households_useful_demand_for_cooling_after_insulation)
+- start_value_gql = future:V(households_cooling_heatpump_ground_water_electricity,share_of_households_useful_demand_for_cooling_after_insulation) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_cooling/households_useful_demand_for_cooling.ad
+++ b/inputs/demand/households/households_cooling/households_useful_demand_for_cooling.ad
@@ -5,7 +5,6 @@
 - min_value = -10.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_demand/households_useful_demand_cooking_per_person.ad
+++ b/inputs/demand/households/households_demand/households_useful_demand_cooking_per_person.ad
@@ -8,7 +8,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_demand/households_useful_demand_electric_appliances.ad
+++ b/inputs/demand/households/households_demand/households_useful_demand_electric_appliances.ad
@@ -17,7 +17,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_demand/households_useful_demand_heat_per_person.ad
+++ b/inputs/demand/households/households_demand/households_useful_demand_heat_per_person.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_demand/households_useful_demand_lighting.ad
+++ b/inputs/demand/households/households_demand/households_useful_demand_lighting.ad
@@ -8,7 +8,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_district_heating/households_collective_chp_biogas_share.ad
+++ b/inputs/demand/households/households_district_heating/households_collective_chp_biogas_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_collective_chp_biogas,share_of_households_final_demand_steam_hot_water)
+- start_value_gql = present:V(households_collective_chp_biogas,share_of_households_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_district_heating/households_collective_chp_network_gas_share.ad
+++ b/inputs/demand/households/households_district_heating/households_collective_chp_network_gas_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_collective_chp_network_gas,share_of_households_final_demand_steam_hot_water)
+- start_value_gql = present:V(households_collective_chp_network_gas,share_of_households_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_district_heating/households_collective_chp_wood_pellets_share.ad
+++ b/inputs/demand/households/households_district_heating/households_collective_chp_wood_pellets_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_collective_chp_wood_pellets,share_of_households_final_demand_steam_hot_water)
+- start_value_gql = present:V(households_collective_chp_wood_pellets,share_of_households_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_district_heating/households_collective_geothermal_share.ad
+++ b/inputs/demand/households/households_district_heating/households_collective_geothermal_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_collective_geothermal,share_of_households_final_demand_steam_hot_water)
+- start_value_gql = present:V(households_collective_geothermal,share_of_households_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_district_heating/households_heat_network_connection_steam_hot_water_share.ad
+++ b/inputs/demand/households/households_district_heating/households_heat_network_connection_steam_hot_water_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_heat_network_connection_steam_hot_water,share_of_households_final_demand_steam_hot_water)
+- start_value_gql = present:V(households_heat_network_connection_steam_hot_water,share_of_households_final_demand_steam_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_efficiency/households_appliances_clothes_dryer_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_clothes_dryer_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -4.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_computer_media_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_computer_media_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -20.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_dishwasher_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_dishwasher_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -52.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_fridge_freezer_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_fridge_freezer_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -57.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_other_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_other_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -20.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_television_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_television_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -20.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_vacuum_cleaner_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_vacuum_cleaner_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -20.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_washing_machine_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_washing_machine_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = -67.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_heating/households_space_heater_coal_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_coal_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_coal,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_coal,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_combined_network_gas_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_combined_network_gas_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_combined_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_combined_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_crude_oil_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_crude_oil_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_crude_oil,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_crude_oil,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_district_heating_steam_hot_water_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_district_heating_steam_hot_water_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_electricity_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_electricity,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_electricity,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_heatpump_add_on_electricity_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_heatpump_add_on_electricity_share.ad
@@ -12,8 +12,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_useful_demand_for_space_heating_after_insulation_for_houses_with_add_on,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater)
+- start_value_gql = present:V(households_useful_demand_for_space_heating_after_insulation_for_houses_with_add_on,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_heatpump_air_water_electricity_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_heatpump_air_water_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_heatpump_ground_water_electricity_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_heatpump_ground_water_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_micro_chp_network_gas_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_micro_chp_network_gas_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - max_value_gql = present:PRODUCT(100,SUM(0.9,NEG(DIVIDE(GRAPH(number_of_years),100))))
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_micro_chp_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_micro_chp_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_network_gas_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_network_gas_share.ad
@@ -8,8 +8,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_heating/households_space_heater_wood_pellets_share.ad
+++ b/inputs/demand/households/households_heating/households_space_heater_wood_pellets_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_wood_pellets,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)
+- start_value_gql = present:V(households_space_heater_wood_pellets,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_useful_demand_hot_water_share.ad
+++ b/inputs/demand/households/households_hot_water/households_useful_demand_hot_water_share.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/households/households_hot_water/households_water_heater_coal_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_coal_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_coal_boiler_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_coal_boiler_in_hot_water_produced_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_combined_network_gas_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_combined_network_gas_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_condensing_gas_heater_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_combined_network_gas_in_hot_water_produced_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_crude_oil_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_crude_oil_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_oil_boiler_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_oil_boiler_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_heat_network_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_heat_network_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_fuel_cell_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_fuel_cell_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- start_value_gql = present:V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_heatpump_ground_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_heatpump_ground_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_micro_chp_network_gas_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_micro_chp_network_gas_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:Q(share_of_micro_chp_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_micro_chp_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_network_gas_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_network_gas_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:Q(share_of_gas_boiler_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_gas_boiler_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_resistive_electricity_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_resistive_electricity_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:Q(share_of_electric_boiler_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_electric_boiler_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_solar_thermal_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_solar_thermal_share.ad
@@ -12,8 +12,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(households_useful_demand_for_hot_water_for_houses_with_solar_heater,share_of_households_useful_demand_hot_water)
+- start_value_gql = present:V(households_useful_demand_for_hot_water_for_houses_with_solar_heater,share_of_households_useful_demand_hot_water) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_hot_water/households_water_heater_wood_pellets_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_wood_pellets_share.ad
@@ -9,8 +9,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 50.0
-- start_value_gql = present:Q(share_of_wood_stove_in_hot_water_production_in_households)
+- start_value_gql = present:Q(share_of_wood_stove_in_hot_water_production_in_households) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_light/households_lighting_efficient_fluorescent_electricity_share.ad
+++ b/inputs/demand/households/households_light/households_lighting_efficient_fluorescent_electricity_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 5.0
-- start_value_gql = present:V(households_lighting_efficient_fluorescent_electricity,share_of_households_useful_demand_light)
+- start_value_gql = present:V(households_lighting_efficient_fluorescent_electricity,share_of_households_useful_demand_light) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_light/households_lighting_incandescent_electricity_share.ad
+++ b/inputs/demand/households/households_light/households_lighting_incandescent_electricity_share.ad
@@ -4,8 +4,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 95.0
-- start_value_gql = present:V(households_lighting_incandescent_electricity,share_of_households_useful_demand_light)
+- start_value_gql = present:V(households_lighting_incandescent_electricity,share_of_households_useful_demand_light) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_light/households_lighting_led_electricity_share.ad
+++ b/inputs/demand/households/households_light/households_lighting_led_electricity_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(households_lighting_led_electricity,share_of_households_useful_demand_light)
+- start_value_gql = present:V(households_lighting_led_electricity,share_of_households_useful_demand_light) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_misc/households_behavior_close_windows_turn_off_heating.ad
+++ b/inputs/demand/households/households_misc/households_behavior_close_windows_turn_off_heating.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 1500.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_misc/households_behavior_low_temperature_washing.ad
+++ b/inputs/demand/households/households_misc/households_behavior_low_temperature_washing.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 250.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_misc/households_behavior_standby_killer_turn_off_appliances.ad
+++ b/inputs/demand/households/households_misc/households_behavior_standby_killer_turn_off_appliances.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 454.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_misc/households_behavior_turn_off_the_light.ad
+++ b/inputs/demand/households/households_misc/households_behavior_turn_off_the_light.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 1000.0
 - unit = %
 - update_period = future
 - update_type = %

--- a/inputs/demand/households/households_misc/households_insulation_level_new_houses.ad
+++ b/inputs/demand/households/households_misc/households_insulation_level_new_houses.ad
@@ -4,7 +4,6 @@
 - max_value_gql = present:AREA(insulation_level_new_houses_max)
 - min_value_gql = present:AREA(insulation_level_new_houses_min)
 - start_value_gql = present:AREA(insulation_level_new_houses_min)
-- factor = 1.0
 - update_period = future
 - query =
     cost_per_new_house = AREA(new_houses_insulation_cost_constant) * (USER_INPUT() - AREA(insulation_level_new_houses_min));

--- a/inputs/demand/households/households_misc/households_insulation_level_old_houses.ad
+++ b/inputs/demand/households/households_misc/households_insulation_level_old_houses.ad
@@ -4,7 +4,6 @@
 - max_value_gql = present:AREA(insulation_level_old_houses_max)
 - min_value_gql = present:AREA(insulation_level_old_houses_min)
 - start_value_gql = present:AREA(insulation_level_old_houses_min)
-- factor = 1.0
 - update_period = future
 - query =
     cost_per_old_house = AREA(old_houses_insulation_cost_constant) * (USER_INPUT() - AREA(insulation_level_old_houses_min));

--- a/inputs/demand/households/households_misc/households_number_of_inhabitants.ad
+++ b/inputs/demand/households/households_misc/households_number_of_inhabitants.ad
@@ -19,9 +19,8 @@
 - priority = 0
 - max_value_gql = present:AREA(number_of_inhabitants) * 0.000001 * 2
 - min_value_gql = present:AREA(number_of_inhabitants) * 0.000001 * 0.5
-- start_value_gql = present:AREA(number_of_inhabitants)
+- start_value_gql = present:AREA(number_of_inhabitants) * 1.0e-06
 - step_value = 0.1
-- factor = 1.0e-06
 - unit = #
 - update_period = future
 - update_type = mixed

--- a/inputs/demand/households/households_misc/households_number_of_new_houses.ad
+++ b/inputs/demand/households/households_misc/households_number_of_new_houses.ad
@@ -28,8 +28,7 @@
 - priority = 0
 - max_value_gql = present:Q(number_of_new_residences) * 0.000001 * 10
 - min_value = 0.0
-- start_value_gql = present:Q(number_of_new_residences)
+- start_value_gql = present:Q(number_of_new_residences) * 0.000001
 - step_value = 0.1
-- factor = 1.0e-06
 - unit = #
 - update_period = future

--- a/inputs/demand/households/households_misc/households_number_of_old_houses.ad
+++ b/inputs/demand/households/households_misc/households_number_of_old_houses.ad
@@ -28,9 +28,8 @@
 - priority = 0
 - max_value_gql = present:Q(number_of_old_residences) * 0.000001
 - min_value = 0.0
-- start_value_gql = present:Q(number_of_old_residences)
+- start_value_gql = present:Q(number_of_old_residences) * 0.000001
 - step_value = 0.1
-- factor = 1.0e-06
 - unit = #
 - update_period = future
 

--- a/inputs/demand/households/households_misc/households_solar_pv_solar_radiation_market_penetration.ad
+++ b/inputs/demand/households/households_misc/households_solar_pv_solar_radiation_market_penetration.ad
@@ -13,8 +13,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:DIVIDE(V(households_solar_pv_solar_radiation,output_of_electricity),Q(potential_electricity_production_of_solar_roof_pv))
+- start_value_gql = present:DIVIDE(V(households_solar_pv_solar_radiation,output_of_electricity),Q(potential_electricity_production_of_solar_roof_pv)) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/energy_steel_hisarna_transformation_coal_woodpellets_share.ad
+++ b/inputs/demand/industry/energy_steel_hisarna_transformation_coal_woodpellets_share.ad
@@ -7,8 +7,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(energy_steel_hisarna_transformation_coal,torrified_biomass_pellets_input_conversion)
+- start_value_gql = present:V(energy_steel_hisarna_transformation_coal,torrified_biomass_pellets_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_aluminium_carbothermalreduction_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_carbothermalreduction_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_aluminium_carbothermalreduction_electricity, share_of_industry_aluminium_production)
+- start_value_gql = present:V(industry_aluminium_carbothermalreduction_electricity, share_of_industry_aluminium_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_aluminium_electrolysis_bat_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_electrolysis_bat_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_aluminium_electrolysis_bat_electricity, share_of_industry_aluminium_production)
+- start_value_gql = present:V(industry_aluminium_electrolysis_bat_electricity, share_of_industry_aluminium_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_aluminium_electrolysis_current_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_electrolysis_current_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_aluminium_electrolysis_current_electricity, share_of_industry_aluminium_production)
+- start_value_gql = present:V(industry_aluminium_electrolysis_current_electricity, share_of_industry_aluminium_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_aluminium_production.ad
+++ b/inputs/demand/industry/industry_aluminium_production.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_aluminium_smeltoven_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_smeltoven_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_aluminium_smeltoven_electricity, share_of_industry_aluminium_production)
+- start_value_gql = present:V(industry_aluminium_smeltoven_electricity, share_of_industry_aluminium_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_burner_coal_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 5.5
-- start_value_gql = present:V(industry_burner_coal,share_of_industry_useful_demand_useable_heat)
+- start_value_gql = present:V(industry_burner_coal,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_burner_crude_oil_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 24.5
-- start_value_gql = present:V(industry_burner_crude_oil,share_of_industry_useful_demand_useable_heat)
+- start_value_gql = present:V(industry_burner_crude_oil,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_burner_network_gas_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 42.5
-- start_value_gql = present:V(industry_burner_network_gas,share_of_industry_useful_demand_useable_heat)
+- start_value_gql = present:V(industry_burner_network_gas,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_burner_wood_pellets_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = present:V(industry_burner_wood_pellets,share_of_industry_useful_demand_useable_heat)
+- start_value_gql = present:V(industry_burner_wood_pellets,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_chemicals_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_burner_coal_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 5.5
-- start_value_gql = present:V(industry_chemicals_burner_coal,share_of_industry_useful_demand_for_chemical_useable_heat)
+- start_value_gql = present:V(industry_chemicals_burner_coal,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_chemicals_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_burner_crude_oil_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 24.5
-- start_value_gql = present:V(industry_chemicals_burner_crude_oil,share_of_industry_useful_demand_for_chemical_useable_heat)
+- start_value_gql = present:V(industry_chemicals_burner_crude_oil,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_chemicals_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_burner_network_gas_share.ad
@@ -1,4 +1,4 @@
-- id =
+- id = 
 - query =
     EACH(
       UPDATE(LINK(industry_chemicals_burner_network_gas,industry_useful_demand_for_chemical_useable_heat), share, DIVIDE(USER_INPUT(),100)),
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 42.5
-- start_value_gql = present:V(industry_chemicals_burner_network_gas,share_of_industry_useful_demand_for_chemical_useable_heat)
+- start_value_gql = present:V(industry_chemicals_burner_network_gas,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_chemicals_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_burner_wood_pellets_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = present:V(industry_chemicals_burner_wood_pellets,share_of_industry_useful_demand_for_chemical_useable_heat)
+- start_value_gql = present:V(industry_chemicals_burner_wood_pellets,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_final_demand_for_chemical_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_steam_hot_water_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat)
+- start_value_gql = future:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_final_demand_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_steam_hot_water_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat)
+- start_value_gql = future:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_other_metals_process_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_other_metals_process_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_other_metals_process_heat_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_other_metals_process_heat_useable_heat_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_other_metals_production.ad
+++ b/inputs/demand/industry/industry_other_metals_production.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_steel_blastfurnace_bat_consumption_useable_heat_share.ad
+++ b/inputs/demand/industry/industry_steel_blastfurnace_bat_consumption_useable_heat_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_steel_blastfurnace_bat_consumption_useable_heat, share_of_industry_steel_production)
+- start_value_gql = present:V(industry_steel_blastfurnace_bat_consumption_useable_heat, share_of_industry_steel_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_steel_blastfurnace_current_consumption_useable_heat_share.ad
+++ b/inputs/demand/industry/industry_steel_blastfurnace_current_consumption_useable_heat_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_steel_blastfurnace_current_consumption_useable_heat, share_of_industry_steel_production)
+- start_value_gql = present:V(industry_steel_blastfurnace_current_consumption_useable_heat, share_of_industry_steel_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_steel_electricfurnace_electricity_share.ad
+++ b/inputs/demand/industry/industry_steel_electricfurnace_electricity_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_steel_electricfurnace_electricity, share_of_industry_steel_production)
+- start_value_gql = present:V(industry_steel_electricfurnace_electricity, share_of_industry_steel_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_steel_hisarna_consumption_useable_heat_share.ad
+++ b/inputs/demand/industry/industry_steel_hisarna_consumption_useable_heat_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(industry_steel_hisarna_consumption_useable_heat, share_of_industry_steel_production)
+- start_value_gql = present:V(industry_steel_hisarna_consumption_useable_heat, share_of_industry_steel_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_steel_production.ad
+++ b/inputs/demand/industry/industry_steel_production.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_crude_oil_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_crude_oil_non_energetic.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_electricity.ad
+++ b/inputs/demand/industry/industry_useful_demand_electricity.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_crude_oil_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_crude_oil_non_energetic.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_electricity.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_electricity.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_electricity_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_network_gas_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_network_gas_non_energetic.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_non_energetic.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_useable_heat.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_useable_heat.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_useable_heat_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_network_gas_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_network_gas_non_energetic.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_useable_heat.ad
+++ b/inputs/demand/industry/industry_useful_demand_useable_heat.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/industry_useful_demand_useable_heat_efficiencty.ad
+++ b/inputs/demand/industry/industry_useful_demand_useable_heat_efficiencty.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/industry/number_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/demand/industry/number_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -14,6 +14,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/demand/industry/number_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/demand/industry/number_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -14,6 +14,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/demand/industry/number_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/demand/industry/number_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -14,6 +14,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/demand/lighting_buildings/buildings_lighting_efficient_fluorescent_electricity_share.ad
+++ b/inputs/demand/lighting_buildings/buildings_lighting_efficient_fluorescent_electricity_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_lighting_efficient_fluorescent_electricity,share_of_buildings_useful_demand_after_motion_detection_daylight_control_light)
+- start_value_gql = present:V(buildings_lighting_efficient_fluorescent_electricity,share_of_buildings_useful_demand_after_motion_detection_daylight_control_light) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/lighting_buildings/buildings_lighting_led_electricity_share.ad
+++ b/inputs/demand/lighting_buildings/buildings_lighting_led_electricity_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_lighting_led_electricity,share_of_buildings_useful_demand_after_motion_detection_daylight_control_light)
+- start_value_gql = present:V(buildings_lighting_led_electricity,share_of_buildings_useful_demand_after_motion_detection_daylight_control_light) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/lighting_buildings/buildings_lighting_standard_fluorescent_electricity_share.ad
+++ b/inputs/demand/lighting_buildings/buildings_lighting_standard_fluorescent_electricity_share.ad
@@ -10,8 +10,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(buildings_lighting_standard_fluorescent_electricity,share_of_buildings_useful_demand_after_motion_detection_daylight_control_light)
+- start_value_gql = present:V(buildings_lighting_standard_fluorescent_electricity,share_of_buildings_useful_demand_after_motion_detection_daylight_control_light) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/other/other_useful_demand_electricity.ad
+++ b/inputs/demand/other/other_useful_demand_electricity.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/other/other_useful_demand_non_energetic.ad
+++ b/inputs/demand/other/other_useful_demand_non_energetic.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/other/other_useful_demand_useable_heat.ad
+++ b/inputs/demand/other/other_useful_demand_useable_heat.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_car/transport_car_using_compressed_natural_gas_share.ad
+++ b/inputs/demand/transport/transport_car/transport_car_using_compressed_natural_gas_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:V(transport_car_using_compressed_natural_gas,share_of_transport_useful_demand_car_kms)
+- start_value_gql = present:V(transport_car_using_compressed_natural_gas,share_of_transport_useful_demand_car_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_car/transport_car_using_diesel_mix_share.ad
+++ b/inputs/demand/transport/transport_car/transport_car_using_diesel_mix_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 46.0
-- start_value_gql = present:V(transport_car_using_diesel_mix,share_of_transport_useful_demand_car_kms)
+- start_value_gql = present:V(transport_car_using_diesel_mix,share_of_transport_useful_demand_car_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_car/transport_car_using_electricity_share.ad
+++ b/inputs/demand/transport/transport_car/transport_car_using_electricity_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(transport_car_using_electricity,share_of_transport_useful_demand_car_kms)
+- start_value_gql = present:V(transport_car_using_electricity,share_of_transport_useful_demand_car_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_car/transport_car_using_gasoline_mix_share.ad
+++ b/inputs/demand/transport/transport_car/transport_car_using_gasoline_mix_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 46.0
-- start_value_gql = present:V(transport_car_using_gasoline_mix,share_of_transport_useful_demand_car_kms)
+- start_value_gql = present:V(transport_car_using_gasoline_mix,share_of_transport_useful_demand_car_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_car/transport_car_using_lpg_share.ad
+++ b/inputs/demand/transport/transport_car/transport_car_using_lpg_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 7.0
-- start_value_gql = present:V(transport_car_using_lpg,share_of_transport_useful_demand_car_kms)
+- start_value_gql = present:V(transport_car_using_lpg,share_of_transport_useful_demand_car_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_car/transport_useful_demand_car_kms.ad
+++ b/inputs/demand/transport/transport_car/transport_useful_demand_car_kms.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_diesel/transport_road_mixer_diesel_biodiesel_share.ad
+++ b/inputs/demand/transport/transport_diesel/transport_road_mixer_diesel_biodiesel_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_road_mixer_diesel,biodiesel_input_conversion)
+- start_value_gql = present:V(transport_road_mixer_diesel,biodiesel_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_diesel/transport_road_mixer_diesel_diesel_share.ad
+++ b/inputs/demand/transport/transport_diesel/transport_road_mixer_diesel_diesel_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_road_mixer_diesel,diesel_input_conversion)
+- start_value_gql = present:V(transport_road_mixer_diesel,diesel_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_efficiency/transport_car_using_diesel_mix_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_car_using_diesel_mix_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_efficiency/transport_car_using_electricity_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_car_using_electricity_efficiency.ad
@@ -11,7 +11,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_efficiency/transport_truck_using_compressed_natural_gas_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_truck_using_compressed_natural_gas_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_efficiency/transport_useful_demand_planes_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_useful_demand_planes_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_efficiency/transport_useful_demand_ships_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_useful_demand_ships_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_efficiency/transport_useful_demand_trains_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_useful_demand_trains_efficiency.ad
@@ -5,7 +5,6 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_gasoline/transport_road_mixer_gasoline_ethanol_share.ad
+++ b/inputs/demand/transport/transport_gasoline/transport_road_mixer_gasoline_ethanol_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_road_mixer_gasoline,bio_ethanol_input_conversion)
+- start_value_gql = present:V(transport_road_mixer_gasoline,bio_ethanol_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_gasoline/transport_road_mixer_gasoline_gasoline_share.ad
+++ b/inputs/demand/transport/transport_gasoline/transport_road_mixer_gasoline_gasoline_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_road_mixer_gasoline,gasoline_input_conversion)
+- start_value_gql = present:V(transport_road_mixer_gasoline,gasoline_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_marine/transport_ship_using_biodiesel_share.ad
+++ b/inputs/demand/transport/transport_marine/transport_ship_using_biodiesel_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_ship_using_biodiesel,share_of_transport_useful_demand_ships)
+- start_value_gql = present:V(transport_ship_using_biodiesel,share_of_transport_useful_demand_ships) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_marine/transport_ship_using_diesel_share.ad
+++ b/inputs/demand/transport/transport_marine/transport_ship_using_diesel_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_ship_using_diesel,share_of_transport_useful_demand_ships)
+- start_value_gql = present:V(transport_ship_using_diesel,share_of_transport_useful_demand_ships) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_marine/transport_ship_using_heavy_fuel_oil_share.ad
+++ b/inputs/demand/transport/transport_marine/transport_ship_using_heavy_fuel_oil_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_ship_using_heavy_fuel_oil,share_of_transport_useful_demand_ships)
+- start_value_gql = present:V(transport_ship_using_heavy_fuel_oil,share_of_transport_useful_demand_ships) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_marine/transport_useful_demand_ships.ad
+++ b/inputs/demand/transport/transport_marine/transport_useful_demand_ships.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_plane/transport_plane_using_bio_ethanol_share.ad
+++ b/inputs/demand/transport/transport_plane/transport_plane_using_bio_ethanol_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_plane_using_bio_ethanol,share_of_transport_useful_demand_planes)
+- start_value_gql = present:V(transport_plane_using_bio_ethanol,share_of_transport_useful_demand_planes) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_plane/transport_plane_using_gasoline_share.ad
+++ b/inputs/demand/transport/transport_plane/transport_plane_using_gasoline_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_plane_using_gasoline,share_of_transport_useful_demand_planes)
+- start_value_gql = present:V(transport_plane_using_gasoline,share_of_transport_useful_demand_planes) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_plane/transport_plane_using_kerosene_share.ad
+++ b/inputs/demand/transport/transport_plane/transport_plane_using_kerosene_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_plane_using_kerosene,share_of_transport_useful_demand_planes)
+- start_value_gql = present:V(transport_plane_using_kerosene,share_of_transport_useful_demand_planes) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_plane/transport_useful_demand_planes.ad
+++ b/inputs/demand/transport/transport_plane/transport_useful_demand_planes.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_train/transport_rail_mixer_diesel_biodiesel_share.ad
+++ b/inputs/demand/transport/transport_train/transport_rail_mixer_diesel_biodiesel_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_rail_mixer_diesel,biodiesel_input_conversion)
+- start_value_gql = present:V(transport_rail_mixer_diesel,biodiesel_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_train/transport_rail_mixer_diesel_diesel_share.ad
+++ b/inputs/demand/transport/transport_train/transport_rail_mixer_diesel_diesel_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(transport_rail_mixer_diesel,diesel_input_conversion)
+- start_value_gql = present:V(transport_rail_mixer_diesel,diesel_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_train/transport_train_using_coal_share.ad
+++ b/inputs/demand/transport/transport_train/transport_train_using_coal_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:V(transport_train_using_coal,share_of_transport_useful_demand_trains)
+- start_value_gql = present:V(transport_train_using_coal,share_of_transport_useful_demand_trains) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_train/transport_train_using_diesel_share.ad
+++ b/inputs/demand/transport/transport_train/transport_train_using_diesel_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 99.0
-- start_value_gql = present:V(transport_train_using_diesel,share_of_transport_useful_demand_trains)
+- start_value_gql = present:V(transport_train_using_diesel,share_of_transport_useful_demand_trains) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_train/transport_train_using_electricity_share.ad
+++ b/inputs/demand/transport/transport_train/transport_train_using_electricity_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(transport_train_using_electricity,share_of_transport_useful_demand_trains)
+- start_value_gql = present:V(transport_train_using_electricity,share_of_transport_useful_demand_trains) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_train/transport_useful_demand_trains.ad
+++ b/inputs/demand/transport/transport_train/transport_useful_demand_trains.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/demand/transport/transport_truck/transport_truck_using_compressed_natural_gas_share.ad
+++ b/inputs/demand/transport/transport_truck/transport_truck_using_compressed_natural_gas_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(transport_truck_using_compressed_natural_gas,share_of_transport_useful_demand_truck_kms)
+- start_value_gql = present:V(transport_truck_using_compressed_natural_gas,share_of_transport_useful_demand_truck_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_truck/transport_truck_using_diesel_mix_share.ad
+++ b/inputs/demand/transport/transport_truck/transport_truck_using_diesel_mix_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 99.0
-- start_value_gql = present:V(transport_truck_using_diesel_mix,share_of_transport_useful_demand_truck_kms)
+- start_value_gql = present:V(transport_truck_using_diesel_mix,share_of_transport_useful_demand_truck_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_truck/transport_truck_using_electricity_share.ad
+++ b/inputs/demand/transport/transport_truck/transport_truck_using_electricity_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(transport_truck_using_electricity,share_of_transport_useful_demand_truck_kms)
+- start_value_gql = present:V(transport_truck_using_electricity,share_of_transport_useful_demand_truck_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_truck/transport_truck_using_gasoline_mix_share.ad
+++ b/inputs/demand/transport/transport_truck/transport_truck_using_gasoline_mix_share.ad
@@ -11,8 +11,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:V(transport_truck_using_gasoline_mix,share_of_transport_useful_demand_truck_kms)
+- start_value_gql = present:V(transport_truck_using_gasoline_mix,share_of_transport_useful_demand_truck_kms) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/demand/transport/transport_truck/transport_useful_demand_truck_kms.ad
+++ b/inputs/demand/transport/transport_truck/transport_useful_demand_truck_kms.ad
@@ -5,7 +5,6 @@
 - min_value = -5.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future
 - update_type = %y

--- a/inputs/misc/energy_import_steam_hot_water_preset_demands.ad
+++ b/inputs/misc/energy_import_steam_hot_water_preset_demands.ad
@@ -7,9 +7,8 @@
 - priority = 0
 - max_value = 6.0
 - min_value = 0.0
-- start_value_gql = present:V(energy_import_steam_hot_water,demand)
+- start_value_gql = present:V(energy_import_steam_hot_water,demand) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = PJ
 - update_period = future
 - dependent_on = has_heat_import

--- a/inputs/misc/initial_updates_max_demands.ad
+++ b/inputs/misc/initial_updates_max_demands.ad
@@ -11,6 +11,5 @@
 - min_value = 2008.0
 - start_value = 2040.0
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = before

--- a/inputs/misc/initial_updates_preset_demands.ad
+++ b/inputs/misc/initial_updates_preset_demands.ad
@@ -35,6 +35,5 @@
 - min_value = 2008.0
 - start_value = 2040.0
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = before

--- a/inputs/modules/biofuel_fce/bio_ethanol_from_beet_sugar_share.ad
+++ b/inputs/modules/biofuel_fce/bio_ethanol_from_beet_sugar_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present: FCE_START_VALUE(bio_ethanol, sugar_beets) / 100
+- start_value_gql = present: FCE_START_VALUE(bio_ethanol, sugar_beets)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/biofuel_fce/bio_ethanol_from_cane_sugar_share.ad
+++ b/inputs/modules/biofuel_fce/bio_ethanol_from_cane_sugar_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present: FCE_START_VALUE(bio_ethanol, sugar_cane) / 100
+- start_value_gql = present: FCE_START_VALUE(bio_ethanol, sugar_cane)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/biofuel_fce/biodiesel_from_palm_oil_share.ad
+++ b/inputs/modules/biofuel_fce/biodiesel_from_palm_oil_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present: FCE_START_VALUE(biodiesel, palm_oil) / 100
+- start_value_gql = present: FCE_START_VALUE(biodiesel, palm_oil)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/biofuel_fce/biodiesel_from_waste_fats_share.ad
+++ b/inputs/modules/biofuel_fce/biodiesel_from_waste_fats_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present: FCE_START_VALUE(biodiesel, waste_fats) / 100
+- start_value_gql = present: FCE_START_VALUE(biodiesel, waste_fats)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_australia_share.ad
+++ b/inputs/modules/coal_fce/coal_from_australia_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present: FCE_START_VALUE(coal, australia) / 100
+- start_value_gql = present: FCE_START_VALUE(coal, australia)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_east_asia_share.ad
+++ b/inputs/modules/coal_fce/coal_from_east_asia_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),east_asia) / 100
+- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),east_asia)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_eastern_europe_share.ad
+++ b/inputs/modules/coal_fce/coal_from_eastern_europe_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),eastern_europe) / 100
+- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),eastern_europe)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_north_america_share.ad
+++ b/inputs/modules/coal_fce/coal_from_north_america_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),north_america) / 100
+- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),north_america)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_russia_share.ad
+++ b/inputs/modules/coal_fce/coal_from_russia_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present: FCE_START_VALUE(coal, russia) / 100
+- start_value_gql = present: FCE_START_VALUE(coal, russia)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_south_africa_share.ad
+++ b/inputs/modules/coal_fce/coal_from_south_africa_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),south_africa) / 100
+- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),south_africa)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_south_america_share.ad
+++ b/inputs/modules/coal_fce/coal_from_south_america_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),south_america) / 100
+- start_value_gql = present:FCE_START_VALUE(CARRIER(coal),south_america)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/coal_fce/coal_from_western_europe_share.ad
+++ b/inputs/modules/coal_fce/coal_from_western_europe_share.ad
@@ -6,6 +6,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/employment/employment_economic_multiplier.ad
+++ b/inputs/modules/employment/employment_economic_multiplier.ad
@@ -5,5 +5,4 @@
 - min_value = 1.0
 - start_value_gql = present:AREA(economic_multiplier)
 - step_value = 0.1
-- factor = 1.0
 - update_period = both

--- a/inputs/modules/employment/employment_fraction_production.ad
+++ b/inputs/modules/employment/employment_fraction_production.ad
@@ -3,8 +3,7 @@
 - priority = 0
 - max_value = 90.0
 - min_value = 0.0
-- start_value_gql = present:AREA(employment_fraction_production)
+- start_value_gql = present:AREA(employment_fraction_production) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = both

--- a/inputs/modules/employment/employment_local_fraction.ad
+++ b/inputs/modules/employment/employment_local_fraction.ad
@@ -3,8 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:AREA(employment_local_fraction)
+- start_value_gql = present:AREA(employment_local_fraction) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = both

--- a/inputs/modules/gas_fce/gas_from_algeria_share.ad
+++ b/inputs/modules/gas_fce/gas_from_algeria_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(natural_gas, algeria) / 100
+- start_value_gql = present:FCE_START_VALUE(natural_gas, algeria)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/gas_fce/gas_from_middle_east_share.ad
+++ b/inputs/modules/gas_fce/gas_from_middle_east_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(natural_gas, middle_east) / 100
+- start_value_gql = present:FCE_START_VALUE(natural_gas, middle_east)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/gas_fce/gas_from_nederlands_share.ad
+++ b/inputs/modules/gas_fce/gas_from_nederlands_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(natural_gas, netherlands) / 100
+- start_value_gql = present:FCE_START_VALUE(natural_gas, netherlands)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/gas_fce/gas_from_norway_share.ad
+++ b/inputs/modules/gas_fce/gas_from_norway_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(natural_gas, norway) / 100
+- start_value_gql = present:FCE_START_VALUE(natural_gas, norway)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/gas_fce/gas_from_russia_share.ad
+++ b/inputs/modules/gas_fce/gas_from_russia_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(natural_gas, russia) / 100
+- start_value_gql = present:FCE_START_VALUE(natural_gas, russia)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/nuclear_fce/uranium_from_australia_share.ad
+++ b/inputs/modules/nuclear_fce/uranium_from_australia_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(uranium_oxide, australia) / 100
+- start_value_gql = present:FCE_START_VALUE(uranium_oxide, australia)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/nuclear_fce/uranium_from_canada_share.ad
+++ b/inputs/modules/nuclear_fce/uranium_from_canada_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(uranium_oxide, canada) / 100
+- start_value_gql = present:FCE_START_VALUE(uranium_oxide, canada)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/modules/nuclear_fce/uranium_from_kazachstan_share.ad
+++ b/inputs/modules/nuclear_fce/uranium_from_kazachstan_share.ad
@@ -4,8 +4,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(uranium_oxide, kazachstan) / 100
+- start_value_gql = present:FCE_START_VALUE(uranium_oxide, kazachstan)
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/coal_plant_fuel/co_firing_biocoal_share.ad
+++ b/inputs/supply/coal_plant_fuel/co_firing_biocoal_share.ad
@@ -17,8 +17,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(energy_power_ultra_supercritical_coal,torrified_biomass_pellets_input_conversion)
+- start_value_gql = present:V(energy_power_ultra_supercritical_coal,torrified_biomass_pellets_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/coal_plant_fuel/co_firing_coal_share.ad
+++ b/inputs/supply/coal_plant_fuel/co_firing_coal_share.ad
@@ -17,8 +17,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(energy_power_ultra_supercritical_coal,coal_input_conversion)
+- start_value_gql = present:V(energy_power_ultra_supercritical_coal,coal_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/energy_sector_gas/energy_mixer_for_gas_power_fuel_bio_oil_share.ad
+++ b/inputs/supply/energy_sector_gas/energy_mixer_for_gas_power_fuel_bio_oil_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(energy_mixer_for_gas_power_fuel, bio_oil_input_conversion)
+- start_value_gql = present:V(energy_mixer_for_gas_power_fuel, bio_oil_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/energy_sector_gas/energy_mixer_for_gas_power_fuel_crude_oil_share.ad
+++ b/inputs/supply/energy_sector_gas/energy_mixer_for_gas_power_fuel_crude_oil_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(energy_mixer_for_gas_power_fuel, crude_oil_input_conversion)
+- start_value_gql = present:V(energy_mixer_for_gas_power_fuel, crude_oil_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/energy_sector_gas/energy_mixer_for_gas_power_fuel_natural_gas_share.ad
+++ b/inputs/supply/energy_sector_gas/energy_mixer_for_gas_power_fuel_natural_gas_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(energy_mixer_for_gas_power_fuel, network_gas_input_conversion)
+- start_value_gql = present:V(energy_mixer_for_gas_power_fuel, network_gas_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/fuels_gas/green_gas_total_share.ad
+++ b/inputs/supply/fuels_gas/green_gas_total_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 0.0
-- start_value_gql = present:V(energy_national_gas_network_natural_gas,greengas_input_conversion)
+- start_value_gql = present:V(energy_national_gas_network_natural_gas,greengas_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/fuels_gas/natural_gas_total_share.ad
+++ b/inputs/supply/fuels_gas/natural_gas_total_share.ad
@@ -5,8 +5,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 100.0
-- start_value_gql = present:V(energy_national_gas_network_natural_gas,natural_gas_input_conversion)
+- start_value_gql = present:V(energy_national_gas_network_natural_gas,natural_gas_input_conversion) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_chp_combined_cycle_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_combined_cycle_network_gas.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = future:V(energy_chp_combined_cycle_network_gas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_chp_supercritical_waste_mix.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_supercritical_waste_mix.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_supercritical_waste_mix,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_cofiring_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_cofiring_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_lignite.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_lignite.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_lignite,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_lignite

--- a/inputs/supply/number_of/number_of_energy_heater_for_heat_network_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_heater_for_heat_network_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_heater_for_heat_network_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_heater_for_heat_network_network_gas.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_network_gas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_heater_for_heat_network_waste_mix.ad
+++ b/inputs/supply/number_of/number_of_energy_heater_for_heat_network_waste_mix.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_waste_mix,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_heater_for_heat_network_wood_pellets.ad
+++ b/inputs/supply/number_of/number_of_energy_heater_for_heat_network_wood_pellets.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_heater_for_heat_network_wood_pellets,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_ccs_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_network_gas.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_ccs_network_gas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_network_gas.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_network_gas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_engine_diesel.ad
+++ b/inputs/supply/number_of/number_of_energy_power_engine_diesel.ad
@@ -9,6 +9,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_engine_diesel,number_of_units)
 - step_value = 1.0
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_geothermal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_geothermal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_geothermal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_hydro_mountain.ad
+++ b/inputs/supply/number_of/number_of_energy_power_hydro_mountain.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_hydro_mountain,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_mountains

--- a/inputs/supply/number_of/number_of_energy_power_hydro_river.ad
+++ b/inputs/supply/number_of/number_of_energy_power_hydro_river.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_hydro_river,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/inputs/supply/number_of/number_of_energy_power_nuclear_gen2_uranium_oxide.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_nuclear_gen2_uranium_oxide,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_old_technologies

--- a/inputs/supply/number_of/number_of_energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/inputs/supply/number_of/number_of_energy_power_nuclear_gen3_uranium_oxide.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_nuclear_gen3_uranium_oxide,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_solar_csp_solar_radiation.ad
+++ b/inputs/supply/number_of/number_of_energy_power_solar_csp_solar_radiation.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_solar_csp_solar_radiation,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_solar_csp

--- a/inputs/supply/number_of/number_of_energy_power_solar_pv_solar_radiation.ad
+++ b/inputs/supply/number_of/number_of_energy_power_solar_pv_solar_radiation.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_solar_pv_solar_radiation,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_supercritical_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_supercritical_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_supercritical_coal ,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_supercritical_waste_mix.ad
+++ b/inputs/supply/number_of/number_of_energy_power_supercritical_waste_mix.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_supercritical_waste_mix,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_turbine_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_turbine_network_gas.ad
@@ -9,6 +9,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_turbine_network_gas,number_of_units)
 - step_value = 1.0
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_ccs_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_ccs_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_ccs_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_cofiring_coal.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_cofiring_coal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_crude_oil.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_crude_oil.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_crude_oil,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_lignite.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_lignite.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_lignite,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_lignite

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_network_gas.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_network_gas,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_lignite

--- a/inputs/supply/number_of/number_of_energy_power_wind_turbine_coastal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_wind_turbine_coastal.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_coastal,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_coastline

--- a/inputs/supply/number_of/number_of_energy_power_wind_turbine_inland.ad
+++ b/inputs/supply/number_of/number_of_energy_power_wind_turbine_inland.ad
@@ -10,6 +10,5 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_inland,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future

--- a/inputs/supply/number_of/number_of_energy_power_wind_turbine_offshore.ad
+++ b/inputs/supply/number_of/number_of_energy_power_wind_turbine_offshore.ad
@@ -10,7 +10,6 @@
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_offshore,number_of_units)
 - step_value = 0.1
-- factor = 1.0
 - unit = #
 - update_period = future
 - dependent_on = has_coastline

--- a/inputs/targets/policy_area_biomass.ad
+++ b/inputs/targets/policy_area_biomass.ad
@@ -7,6 +7,5 @@
 - start_value = 0.0
 - start_value_gql = present:GRAPH(area_footprint)
 - step_value = 0.1
-- factor = 1.0
 - unit = km2
 - update_period = future

--- a/inputs/targets/policy_area_green_gas.ad
+++ b/inputs/targets/policy_area_green_gas.ad
@@ -5,6 +5,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 1.0
 - unit = km2
 - update_period = future

--- a/inputs/targets/policy_area_land_for_csp.ad
+++ b/inputs/targets/policy_area_land_for_csp.ad
@@ -7,7 +7,6 @@
 - start_value = 0.0
 - start_value_gql = present:V(energy_power_solar_csp_solar_radiation,total_land_use)
 - step_value = 1.0
-- factor = 1.0
 - unit = km2
 - update_period = future
 - dependent_on = has_solar_csp

--- a/inputs/targets/policy_area_land_for_solar_panels.ad
+++ b/inputs/targets/policy_area_land_for_solar_panels.ad
@@ -7,6 +7,5 @@
 - start_value = 0.0
 - start_value_gql = present:V(energy_power_solar_pv_solar_radiation,total_land_use)
 - step_value = 1.0
-- factor = 1.0
 - unit = km2
 - update_period = future

--- a/inputs/targets/policy_area_offshore.ad
+++ b/inputs/targets/policy_area_offshore.ad
@@ -7,7 +7,6 @@
 - start_value = 10.0
 - start_value_gql = present:V(energy_power_wind_turbine_offshore,total_land_use)
 - step_value = 1.0
-- factor = 1.0
 - unit = km2
 - update_period = future
 - dependent_on = has_coastline

--- a/inputs/targets/policy_area_onshore_coast.ad
+++ b/inputs/targets/policy_area_onshore_coast.ad
@@ -7,7 +7,6 @@
 - start_value = 7.0
 - start_value_gql = present:V(energy_power_wind_turbine_coastal,total_land_use)
 - step_value = 1.0
-- factor = 1.0
 - unit = km
 - update_period = future
 - dependent_on = has_coastline

--- a/inputs/targets/policy_area_onshore_land.ad
+++ b/inputs/targets/policy_area_onshore_land.ad
@@ -7,6 +7,5 @@
 - start_value = 30.0
 - start_value_gql = present:V(energy_power_wind_turbine_inland,total_land_use)
 - step_value = 1.0
-- factor = 1.0
 - unit = km2
 - update_period = future

--- a/inputs/targets/policy_area_roofs_for_solar_panels.ad
+++ b/inputs/targets/policy_area_roofs_for_solar_panels.ad
@@ -7,6 +7,5 @@
 - start_value = 0.0
 - start_value_gql = present:V(households_solar_pv_solar_radiation,total_land_use)
 - step_value = 0.1
-- factor = 1.0
 - unit = km2
 - update_period = future

--- a/inputs/targets/policy_cost_electricity_cost.ad
+++ b/inputs/targets/policy_cost_electricity_cost.ad
@@ -5,6 +5,5 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = both

--- a/inputs/targets/policy_cost_energy_use.ad
+++ b/inputs/targets/policy_cost_energy_use.ad
@@ -5,6 +5,5 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/targets/policy_cost_total_energy_cost.ad
+++ b/inputs/targets/policy_cost_total_energy_cost.ad
@@ -5,6 +5,5 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 1.0
-- factor = 100.0
 - unit = %
 - update_period = both

--- a/inputs/targets/policy_dependence_max_dependence.ad
+++ b/inputs/targets/policy_dependence_max_dependence.ad
@@ -5,6 +5,5 @@
 - min_value = 0.0
 - start_value = 50.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/targets/policy_dependence_max_electricity_dependence.ad
+++ b/inputs/targets/policy_dependence_max_electricity_dependence.ad
@@ -5,6 +5,5 @@
 - min_value = 0.0
 - start_value = 50.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/targets/policy_grid_baseload_maximum.ad
+++ b/inputs/targets/policy_grid_baseload_maximum.ad
@@ -5,6 +5,5 @@
 - min_value = 0.0
 - start_value = 60.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/targets/policy_grid_intermittent_maximum.ad
+++ b/inputs/targets/policy_grid_intermittent_maximum.ad
@@ -5,6 +5,5 @@
 - min_value = 0.0
 - start_value = 30.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = future

--- a/inputs/targets/policy_sustainability_co2_emissions.ad
+++ b/inputs/targets/policy_sustainability_co2_emissions.ad
@@ -5,6 +5,5 @@
 - min_value = -100.0
 - start_value = 0.0
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = both

--- a/inputs/targets/policy_sustainability_renewable_percentage.ad
+++ b/inputs/targets/policy_sustainability_renewable_percentage.ad
@@ -4,8 +4,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 4.0
-- start_value_gql = present:Q(renewability)
+- start_value_gql = present:Q(renewability) * 100
 - step_value = 0.1
-- factor = 100.0
 - unit = %
 - update_period = both


### PR DESCRIPTION
The value, where set, has been removed from input documents. The only place where the "factor" had any effect, `start_value_gql`, has been modified to use the factor value in the GQL.

I had to add two new queries:
- share_of_coal_boiler_in_hot_water_produced_in_households
- share_of_combined_network_gas_in_hot_water_produced_in_households

... both of these were referenced in the `start_value_gql` of an input, but weren't actually defined, which meant that the start value for the input was discarded. I'm fairly sure the two queries are correct, but please double-check them. :smile:

When this pull request is merged, please also merge quintel/etengine#665.
