### PR TITLE
Add transport co2 gql

### DIFF
--- a/gqueries/general/co2/primary_co2_emission_of_transport.gql
+++ b/gqueries/general/co2/primary_co2_emission_of_transport.gql
@@ -1,5 +1,5 @@
 # How much Mt CO2 is emitted yearly by the transport sector
 # Used in transportation education module
 
-- query = V( INTERSECTION(G(final_demand_cbs), SECTOR(transport)), primary_co2_emission).sum / 1000000000
+- query = V( INTERSECTION(G(final_demand_cbs), SECTOR(transport)), primary_co2_emission).sum / 1_000_000_000
 - unit = mt


### PR DESCRIPTION
In the external education module that works with the API I needed a gql that calculates the primary co2 emissions of transportation.
