### PR TITLE
Updated gqueries for industry CHP chart

### DIFF
--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/centrally_produced_electricity_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/centrally_produced_electricity_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,2 +1,9 @@
-- query = DIVIDE(Q(electricity_demand_in_industry_supplied_by_central_production),BILLIONS)
+- query =
+    MAX(
+      (
+        Q(total_produced_electricity_in_source_of_heat_and_electricity_in_industry) -
+        Q(chp_electricity_in_source_of_heat_and_electricity_in_industry)
+      ),
+      0
+    )
 - unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/centrally_produced_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/centrally_produced_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,0 +1,9 @@
+- query =
+    MAX(
+      (
+        V(industry_final_demand_steam_hot_water, demand) / BILLIONS -
+        Q(chp_heat_in_source_of_heat_and_electricity_in_industry)
+      ),
+      0
+    )
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_electricity_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_electricity_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,0 +1,9 @@
+- query =
+    V(
+      industry_chp_engine_gas_power_fuelmix,
+      industry_chp_turbine_gas_power_fuelmix,
+      industry_chp_ultra_supercritical_coal,
+      industry_chp_combined_cycle_gas_power_fuelmix,
+      output_of_electricity
+    ).sum / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_fossil_electricity_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_fossil_electricity_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,2 +1,0 @@
-- query = Q(fossil_electricity_from_chps_in_industry)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_fossil_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_fossil_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,2 +1,0 @@
-- query = Q(fossil_heat_from_chps_in_industry)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,0 +1,9 @@
+- query =
+    V(
+      industry_chp_engine_gas_power_fuelmix,
+      industry_chp_turbine_gas_power_fuelmix,
+      industry_chp_ultra_supercritical_coal,
+      industry_chp_combined_cycle_gas_power_fuelmix,
+      output_of_heat_carriers
+    ).sum / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_renewable_electricity_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_renewable_electricity_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,2 +1,0 @@
-- query = Q(renewable_electricity_from_chps_in_industry)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_renewable_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/chp_renewable_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,2 +1,0 @@
-- query = Q(renewable_heat_from_chps_in_industry)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/locally_produced_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/locally_produced_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,0 +1,6 @@
+- query =
+    (
+      Q(total_produced_heat_in_source_of_heat_and_electricity_in_industry) -
+      V(industry_final_demand_steam_hot_water, demand) / BILLIONS
+    )
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/other_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/other_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,2 +1,0 @@
-- query = DIVIDE(Q(heat_demand_in_industry_not_supplied_by_chps),BILLIONS)
-- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/total_produced_electricity_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/total_produced_electricity_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,0 +1,3 @@
+- query =
+    V(industry_final_demand_electricity, demand) / BILLIONS
+- unit = pj

--- a/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/total_produced_heat_in_source_of_heat_and_electricity_in_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_28_source_of_heat_and_electricity_used_in_industry/total_produced_heat_in_source_of_heat_and_electricity_in_industry.gql
@@ -1,0 +1,9 @@
+- query =
+    SUM(
+      V(industry_useful_demand_useable_heat, demand),
+      V(CHILDREN(V(industry_aluminium_production)), input_of_useable_heat),
+      V(CHILDREN(V(industry_other_metals_production)), input_of_useable_heat),
+      V(CHILDREN(V(industry_steel_production)), input_of_useable_heat),
+      V(industry_useful_demand_for_chemical_useable_heat, demand)
+    ) / BILLIONS
+- unit = pj


### PR DESCRIPTION
The updated industry CHP chart distinguishes between centrally produced heat, CHP heat and other heat. In this way, users can easily see what amount of CHPs

Old chart:
![energy_transition_model_-_your_free__independent__comprehensive__fact-based_scenario_builder_](https://f.cloud.github.com/assets/4319656/1899663/fe533988-7c3f-11e3-8ace-3294f3420821.jpg)

New chart:
![energy_transition_model_-_your_free__independent__comprehensive__fact-based_scenario_builder_-2](https://f.cloud.github.com/assets/4319656/1899686/89435cf8-7c40-11e3-9736-c31bc1376804.jpg)
