### PR TITLE
Updated refinery efficiency to 0.926 (EU average)

### DIFF
--- a/nodes/energy/energy_production_diesel.converter.ad
+++ b/nodes/energy/energy_production_diesel.converter.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = refinery
-- output.diesel = 0.927613462519123
+- output.diesel = 0.926
 - output.loss = elastic
 - groups = []
 - co2_free = 0.0

--- a/nodes/energy/energy_production_gasoline.converter.ad
+++ b/nodes/energy/energy_production_gasoline.converter.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = refinery
-- output.gasoline = 0.927613462519123
+- output.gasoline = 0.926
 - output.loss = elastic
 - groups = []
 - co2_free = 0.0

--- a/nodes/energy/energy_production_heavy_fuel_oil.converter.ad
+++ b/nodes/energy/energy_production_heavy_fuel_oil.converter.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = refinery
-- output.heavy_fuel_oil = 0.927613462519123
+- output.heavy_fuel_oil = 0.926
 - output.loss = elastic
 - groups = []
 - co2_free = 0.0

--- a/nodes/energy/energy_production_kerosene.converter.ad
+++ b/nodes/energy/energy_production_kerosene.converter.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = refinery
-- output.kerosene = 0.927613462519123
+- output.kerosene = 0.926
 - output.loss = elastic
 - groups = []
 - co2_free = 0.0

--- a/nodes/energy/energy_production_lpg.converter.ad
+++ b/nodes/energy/energy_production_lpg.converter.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = refinery
 - output.loss = elastic
-- output.lpg = 0.927613462519123
+- output.lpg = 0.926
 - groups = []
 - co2_free = 0.0


### PR DESCRIPTION
As result of the discussion about the refinery efficiency in https://github.com/quintel/etsource/issues/615, the efficiency of the energy_production_diesel, energy_production_gasoline, energy_production_heavy_fuel_oil, energy_production_kerosene and energy_production_lpg are updated to the EU average value of 0.926. See the [_refinery efficiency source analysis_](https://www.dropbox.com/s/3qmdco9qvihsa7j/20140114%20Refinery%20efficiency%20source%20analysis%20%28without%20EB%29.xlsx).

This commit does not fix the issue with respect to the disregarded refinery losses for the oil use in the non-transport sectors. A [separate ticket](https://github.com/quintel/etsource/issues/725) is created to cover this issue.
