### PR TITLE
Fixed peak demand query to be consistent with LOLE query.

### DIFF
--- a/gqueries/modules/security_of_supply/peak_electricity_demand.gql
+++ b/gqueries/modules/security_of_supply/peak_electricity_demand.gql
@@ -1,5 +1,5 @@
 # Returns the peak electricity demand by using the demand_curve method. This method returns an array of the hourly demand.
 # The peak electricity demand is taken to be the maximum of this array.
 
-- query = MAX(V(GRAPH(), demand_curve))
+- query = MAX(V(GRAPH(), demand_curve(Q(lole_demand))))
 - unit = mw


### PR DESCRIPTION
Update the peak demand gquery such that the demand_curve is scaled by the same value as the one used in the LOLE qquery.
