### PR TITLE
Query crude oil loss from EB

### DIFF
--- a/nodes/energy/energy_distribution_crude_oil_loss.ad
+++ b/nodes/energy/energy_distribution_crude_oil_loss.ad
@@ -4,4 +4,4 @@
 - groups = []
 - co2_free = 0.0
 
-~ demand = 0.0
+~ demand = -EB(losses, crude_oil)


### PR DESCRIPTION
In the network_gas converter we query the loss from the energy balance. We can do similar with crude_oil.

(Part of the attempt to close quintel/etdataset#110)
