### PR TITLE
Made own use in the energy power sector dynamic

### DIFF
--- a/edges/energy/energy_power_hv_network_electricity-energy_power_sector_own_use_electricity@electricity.ad
+++ b/edges/energy/energy_power_hv_network_electricity-energy_power_sector_own_use_electricity@electricity.ad
@@ -1,2 +1,2 @@
 - type = share
-- reversed = false
+- reversed = true

--- a/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
+++ b/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = energy sector own use
 - output.loss = elastic
-- groups = [preset_demand]
+- groups = [final_demand_group]
 - free_co2_factor = 0.0
 
 ~ demand = -EB("own_use_in _electricity,_chp_and_heat_plants", electricity)


### PR DESCRIPTION
Made own use in the energy power sector dynamic (fixed percentage of converter throughput) by changing the edge into a reversed share and by removing the preset_demand group. Furthermore, the converter is added to the final_demand_group, in line with the cokes oven own use and the refinery own use (see https://github.com/quintel/etsource/issues/725#issuecomment-36336377).
