### PR TITLE
Add Gqueries for retrieving time curves

### DIFF
--- a/gqueries/general/time_curves/production_curve_bio_residues_for_firing.gql
+++ b/gqueries/general/time_curves/production_curve_bio_residues_for_firing.gql
@@ -1,0 +1,2 @@
+- unit = pj
+- query = TIME_CURVE(energy_distribution_bio_residues_for_firing, max_demand)

--- a/gqueries/general/time_curves/production_curve_coal.gql
+++ b/gqueries/general/time_curves/production_curve_coal.gql
@@ -1,0 +1,2 @@
+- unit = pj
+- query = TIME_CURVE(energy_extraction_coal, preset_demand)

--- a/gqueries/general/time_curves/production_curve_crude_oil.gql
+++ b/gqueries/general/time_curves/production_curve_crude_oil.gql
@@ -1,0 +1,2 @@
+- unit = pj
+- query = TIME_CURVE(energy_extraction_crude_oil, preset_demand)

--- a/gqueries/general/time_curves/production_curve_lignite.gql
+++ b/gqueries/general/time_curves/production_curve_lignite.gql
@@ -1,0 +1,2 @@
+- unit = pj
+- query = TIME_CURVE(energy_extraction_lignite, preset_demand)

--- a/gqueries/general/time_curves/production_curve_natural_gas.gql
+++ b/gqueries/general/time_curves/production_curve_natural_gas.gql
@@ -1,0 +1,2 @@
+- unit = pj
+- query = TIME_CURVE(energy_extraction_natural_gas, preset_demand)

--- a/gqueries/general/time_curves/production_curve_uranium.gql
+++ b/gqueries/general/time_curves/production_curve_uranium.gql
@@ -1,0 +1,2 @@
+- unit = pj
+- query = TIME_CURVE(energy_extraction_uranium_oxide, preset_demand)


### PR DESCRIPTION
Queries have been added so that ETModel can access time curves for the scenario's dataset. The required `TIME_CURVE` function was added in quintel/etengine@08601e05.

Ref quintel/etengine#697
