### PR TITLE
buildings_chp_engine_biogas_dumped_heat

### DIFF
--- a/nodes/buildings/buildings_chp_engine_biogas_dumped_heat.ad
+++ b/nodes/buildings/buildings_chp_engine_biogas_dumped_heat.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = distribution
-- groups = [preset_demand]
+- groups = []
 - free_co2_factor = 0.0


### PR DESCRIPTION
Removed buildings_chp_engine_biogas_dumped_heat from preset_demand group. It seems that the graph initializes just fine without it. Fixes https://github.com/quintel/etengine/issues/700
