### PR TITLE
Removed hard-coded (Dutch) values from capacity credit gquery.

### DIFF
--- a/gqueries/modules/security_of_supply/capacity_credit_wind.gql
+++ b/gqueries/modules/security_of_supply/capacity_credit_wind.gql
@@ -1,23 +1,26 @@
 # Returns the capacity credit of wind as a function of the installed wind capacity
-# (p1 * installed_wind_capacity + p2) / (installed_wind_capacity + q1) / installed_wind_capacity
-# The parameters p1, p2 and q1 are country specific and defined in ETDatset
-# This capacity credit function is only valid from an installed wind capacity of 378 MW onwards;
-# For lower installed capacities, we assume the capacity credit to have the same value as at 379 MW
+# (p1 * installed_wind_capacity + p2) / (installed_wind_capacity + q1) / installed_wind_capacity.
+# The parameters p1, p2 and q1 are country specific and defined in the area analysis in ETDatset.
+# This capacity credit function is only valid for installed wind capacities higher than the present value;
+# For lower installed capacities, we assume the capacity credit is equal to its present value.
 
 - query =
-    installed_wind_capacity = SUM(
-                                    INPUT_VALUE(number_of_energy_power_wind_turbine_coastal) * V(energy_power_wind_turbine_coastal, electricity_output_capacity),
-                                    INPUT_VALUE(number_of_energy_power_wind_turbine_inland) * V(energy_power_wind_turbine_inland, electricity_output_capacity),
-                                    INPUT_VALUE(number_of_energy_power_wind_turbine_offshore) * V(energy_power_wind_turbine_offshore, electricity_output_capacity)
-                              ); 
+    future_installed_wind_capacity = SUM(
+        INPUT_VALUE(number_of_energy_power_wind_turbine_coastal) * V(energy_power_wind_turbine_coastal, electricity_output_capacity),
+        INPUT_VALUE(number_of_energy_power_wind_turbine_inland) * V(energy_power_wind_turbine_inland, electricity_output_capacity),
+        INPUT_VALUE(number_of_energy_power_wind_turbine_offshore) * V(energy_power_wind_turbine_offshore, electricity_output_capacity)
+    ); 
 
-    base_value = 0.328;
-    fit_value = ( QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p1) }) * installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p2) }) ) / ( installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_q1) })) / installed_wind_capacity;
+    present_installed_wind_capacity = QUERY_PRESENT(-> { SUM(
+        V(energy_power_wind_turbine_coastal, "number_of_units * electricity_output_capacity"),
+        V(energy_power_wind_turbine_inland, "number_of_units * electricity_output_capacity"),
+        V(energy_power_wind_turbine_offshore, "number_of_units * electricity_output_capacity")  
+    )});
 
-    IF(
-        GREATER(installed_wind_capacity, 379),
-        fit_value,
-        base_value
-    )
+    present_capacity_credit = ( QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p1) }) * present_installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p2) }) ) / ( present_installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_q1) })) / present_installed_wind_capacity;
+
+    future_capacity_credit = ( QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p1) }) * future_installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p2) }) ) / ( future_installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_q1) })) / future_installed_wind_capacity;
+
+    MIN(present_capacity_credit, future_capacity_credit)
 
 - unit = factor


### PR DESCRIPTION
As of https://github.com/quintel/etsource/commit/3bab0d2696a9b37ad4a0904714afb1d22e73a178, we capped the capacity credit of wind turbines to the Dutch value at 378 MW of installed wind capacity (i.e. 0.328) for installed wind capacities lower than 378 MW. These numbers come from the [thesis](http://refman.et-model.com/publications/1847) by Edgar Wilton. This cap is there to avoid that the capacity credit can increase to infinity for small installed wind capacities. Now that we are adding country dependent capacity credit curves, the hard coded values need to be replaced by dynamic numbers and we decided to cap the capacity credit to the present value for each country.
