### PR TITLE
lole_fix

### DIFF
--- a/gqueries/modules/security_of_supply/capacity_credit_wind.gql
+++ b/gqueries/modules/security_of_supply/capacity_credit_wind.gql
@@ -21,6 +21,6 @@
 
     future_capacity_credit = ( QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p1) }) * future_installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_p2) }) ) / ( future_installed_wind_capacity + QUERY_FUTURE(-> { AREA(capacity_credit_wind_constant_q1) })) / future_installed_wind_capacity;
 
-    MIN(present_capacity_credit, future_capacity_credit)
+    MIN(present_capacity_credit, MAX(future_capacity_credit, 0.05))
 
 - unit = factor

--- a/gqueries/modules/security_of_supply/lole_demand.gql
+++ b/gqueries/modules/security_of_supply/lole_demand.gql
@@ -9,5 +9,5 @@
 # deliver electricity during the day, whereas in the ETM, the reduction of the
 # network losses due to their electricity is averaged over the year.
 
-- query = V(GRAPH(), final_demand_for_electricity) + V(GRAPH(), energy_sector_final_demand_for_electricity) + QUERY_PRESENT(-> { V(energy_power_hv_network_loss, demand) })
+- query = V(GRAPH(), final_demand_for_electricity) + QUERY_PRESENT(-> { V(energy_power_hv_network_loss, demand) })
 - unit = pj


### PR DESCRIPTION
Fixed lole queries: double counting of own use in energy sector is removed and capacity credit cannot become lower than 5% (0.05)

Fixes https://github.com/quintel/etmodel/issues/1804
