### PR TITLE
Removed the explicit carrier costs for mixed carriers. 

### DIFF
--- a/carriers/compressed_network_gas.ad
+++ b/carriers/compressed_network_gas.ad
@@ -1,4 +1,3 @@
 - sustainable = 0.0
 - infinite = false
-- cost_per_mj = 0.0
 - graphviz_color = lightgrey

--- a/carriers/lng.ad
+++ b/carriers/lng.ad
@@ -1,6 +1,5 @@
 - sustainable = 0.0
 - infinite = false
-- cost_per_mj = 0.0
 - mj_per_kg = 50.0
 - co2_conversion_per_mj = 0.0569819
 - kg_per_liter = 0.5

--- a/carriers/network_gas.ad
+++ b/carriers/network_gas.ad
@@ -1,4 +1,3 @@
 - sustainable = 0.0
 - infinite = false
-- cost_per_mj = 0.0
 - co2_conversion_per_mj = 0.0

--- a/carriers/waste_mix.ad
+++ b/carriers/waste_mix.ad
@@ -1,4 +1,3 @@
 - sustainable = 0.38
 - infinite = false
-- cost_per_mj = 0.0
 - graphviz_color = darkgrey


### PR DESCRIPTION
This is needed to make https://github.com/quintel/etengine/pull/708 work.
