### PR TITLE
Fix buildings solar PV input start value

### DIFF
--- a/gqueries/input_elements/max_value/buildings_potential_electricity_production_of_solar_roof_pv.gql
+++ b/gqueries/input_elements/max_value/buildings_potential_electricity_production_of_solar_roof_pv.gql
@@ -1,0 +1,10 @@
+- query =
+    PRODUCT(
+      DIVIDE(
+        AREA(buildings_roof_surface_available_for_pv),
+        V(buildings_solar_pv_solar_radiation,land_use_per_unit)
+      ),
+      V(buildings_solar_pv_solar_radiation,typical_electricity_production_per_unit)
+    )
+- unit = mj
+- deprecated_key = potential_roof_pv_production

--- a/gqueries/input_elements/max_value/households_potential_electricity_production_of_solar_roof_pv.gql
+++ b/gqueries/input_elements/max_value/households_potential_electricity_production_of_solar_roof_pv.gql
@@ -1,8 +1,3 @@
-# !!!!!!!!!!!!!!!
-# This is used in an update statement for solar_pv, which cannot use this GQL. Therefor this GQL is again on
-# "graph_api.rb". This should  be adjusted when updating this query.
-# !!!!!!!!!!!!!!!
-
 - query =
     PRODUCT(
       DIVIDE(

--- a/inputs/demand/buildings/buildings_misc/buildings_solar_pv_solar_radiation_market_penetration.ad
+++ b/inputs/demand/buildings/buildings_misc/buildings_solar_pv_solar_radiation_market_penetration.ad
@@ -12,7 +12,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:DIVIDE(V(buildings_solar_pv_solar_radiation,output_of_electricity),Q(potential_electricity_production_of_solar_roof_pv)) * 100
+- start_value_gql = present:DIVIDE(V(buildings_solar_pv_solar_radiation,output_of_electricity),Q(buildings_potential_electricity_production_of_solar_roof_pv)) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future

--- a/inputs/demand/households/households_misc/households_solar_pv_solar_radiation_market_penetration.ad
+++ b/inputs/demand/households/households_misc/households_solar_pv_solar_radiation_market_penetration.ad
@@ -12,7 +12,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 1.0
-- start_value_gql = present:DIVIDE(V(households_solar_pv_solar_radiation,output_of_electricity),Q(potential_electricity_production_of_solar_roof_pv)) * 100
+- start_value_gql = present:DIVIDE(V(households_solar_pv_solar_radiation,output_of_electricity),Q(households_potential_electricity_production_of_solar_roof_pv)) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future


### PR DESCRIPTION
The start value for buildings solar PV potential was being determined by dividing electricity output of buildings PV by the available capacity in _households_.

The "PV potential" query has been replaced with separate households and buildings queries.

Closes quintel/etengine#711.
