### PR TITLE
static own use

### DIFF
--- a/edges/energy/energy_power_hv_network_electricity-energy_power_sector_own_use_electricity@electricity.ad
+++ b/edges/energy/energy_power_hv_network_electricity-energy_power_sector_own_use_electricity@electricity.ad
@@ -1,2 +1,1 @@
-- type = share
-- reversed = true
+- type = constant

--- a/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
+++ b/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = energy sector own use
 - output.loss = elastic
-- groups = [final_demand_group]
+- groups = [final_demand_group, preset_demand]
 - free_co2_factor = 0.0
 
 ~ demand = -EB("own_use_in _electricity,_chp_and_heat_plants", electricity)


### PR DESCRIPTION
Made own of the energy sector use static by setting its edge to constant and adding it to the preset demand group.

Fixes https://github.com/quintel/merit/issues/121.
