### PR TITLE
Created import:node task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,12 @@ source 'https://rubygems.org'
 
 gem 'rake'
 
+group :development, :test do
+  gem 'atlas',    ref: 'f80949d', github: 'quintel/atlas'
+end
+
 group :test do
   gem 'rspec'
   gem 'rubel',    ref: 'e36554a', github: 'quintel/rubel'
   gem 'refinery', ref: '58c1138', github: 'quintel/refinery'
-  gem 'atlas',    ref: 'f80949d', github: 'quintel/atlas'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,9 @@ namespace :import do
         energy_balance_group='electricity network'
   DESC
   task :node do
-    require_relative '../atlas/lib/atlas'
+    require 'bundler'
+    Bundler.require(:test)
+
     Atlas.data_dir = File.expand_path(File.dirname(__FILE__))
 
     node = Atlas::Node.find(ENV['NODE'])


### PR DESCRIPTION
Creates the means for external scripts and programs to update node attributes, without having to write directly to the document files.
## 

Provide the task with a NODE variable specifying the key of the node to be updated, and then one or more additional variables specifying the attributes to be changed.

For example:

``` sh
rake import:node NODE=industry_burner_coal technical_lifetime=14.0
```

You may specify multiple attributes to update:

``` sh
rake import:node \
  NODE=energy_power_lv_network_electricity \
  free_co2_factor=0.2 \
  availability=1.0 \
  network_capacity_available_in_mw=74803.6
```

Be sure to surround values in quotes if the value contains any spaces, or non-alphanumeric characters:

``` sh
rake import:node \
  NODE=energy_power_lv_network_electricity \
  energy_balance_group='electricity network'
```
