### PR TITLE
Support nested attributes in import:node task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -133,7 +133,7 @@ namespace :import do
             node.public_send("#{ attr_name }=", {})
           end
 
-          node.public_send(attr_name)[key.split('__', 2)[1]] = value
+          node.public_send(attr_name)[key.split('__', 2)[1].to_sym] = value
         end
       elsif ENV[attribute.name.to_s]
         node.public_send(:"#{ attribute.name }=", ENV[attribute.name.to_s])


### PR DESCRIPTION
@mariatsagkaraki Notified me that the `import:node` task was incapable of accepting nested attributes, which usually take the form of two words split by a `.`, e.g. "import.gas", "output.electricity".

Dots are not allowed to be used in the names of environment variables (a limitation which comes from the terminal/shell, not from our software), therefore something else needs to be substituted in their place. I propose this patch, which allows you to use a double-underscore in place of the dot:

Instead of

```
rake import:node NODE=node_key output.electricity=0.2
```

... run ...

```
rake import:node NODE=node_key output__electricity=0.2
```

@jorisberkhout Is this an acceptable solution? Can the VBA script be adapted to replace dots with double-underscores in attribute names before running `rake`?
