### PR TITLE
intuitive slider caps

### DIFF
--- a/gqueries/input_elements/max_value/maximum_number_of_agriculture_chp_engine_biogas.gql
+++ b/gqueries/input_elements/max_value/maximum_number_of_agriculture_chp_engine_biogas.gql
@@ -3,6 +3,6 @@
 - query =
     MAX(
     PRODUCT(V(agriculture_chp_engine_biogas,number_of_units),2),
-    PRODUCT(DIVIDE(V(agriculture_useful_demand_electricity,demand),V(agriculture_chp_engine_biogas, "electricity_output_capacity * 8760 * 3600")),2)
+    PRODUCT(DIVIDE(V(agriculture_useful_demand_electricity,demand),V(agriculture_chp_engine_biogas, maximum_yearly_electricity_production_per_unit)),2)
     )
 - unit = #

--- a/gqueries/input_elements/max_value/maximum_number_of_agriculture_chp_supercritical_wood_pellets.gql
+++ b/gqueries/input_elements/max_value/maximum_number_of_agriculture_chp_supercritical_wood_pellets.gql
@@ -3,6 +3,6 @@
 - query =
     MAX(
     PRODUCT(V(agriculture_chp_supercritical_wood_pellets,number_of_units),2),
-    PRODUCT(DIVIDE(V(agriculture_useful_demand_electricity,demand),V(agriculture_chp_supercritical_wood_pellets, "electricity_output_capacity * 8760 * 3600")),2)
+    PRODUCT(DIVIDE(V(agriculture_useful_demand_electricity,demand),V(agriculture_chp_supercritical_wood_pellets, maximum_yearly_electricity_production_per_unit)),2)
     )
 - unit = #

--- a/gqueries/input_elements/max_value/maximum_number_of_chps_in_agriculture.gql
+++ b/gqueries/input_elements/max_value/maximum_number_of_chps_in_agriculture.gql
@@ -3,7 +3,7 @@
 - query =
     MAX(
     PRODUCT(V(agriculture_chp_engine_network_gas,number_of_units),2),
-    PRODUCT(DIVIDE(V(agriculture_useful_demand_electricity,demand),V(agriculture_chp_engine_network_gas, "electricity_output_capacity * 8760 * 3600")),2)
+    PRODUCT(DIVIDE(V(agriculture_useful_demand_electricity,demand),V(agriculture_chp_engine_network_gas, maximum_yearly_electricity_production_per_unit)),2)
     )
 - unit = #
 - deprecated_key = max_value_chp_agri

--- a/inputs/demand/industry/number_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/demand/industry/number_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -9,7 +9,7 @@
     )
 - priority = 0
 - max_value = 30500.0
-- max_value_gql = future:DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_combined_cycle_gas_power_fuelmix,"electricity_output_capacity * 8760 * 3600"))
+- max_value_gql = future:DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_combined_cycle_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit))
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix,number_of_units)
 - step_value = 0.1

--- a/inputs/demand/industry/number_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/demand/industry/number_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -9,7 +9,7 @@
     )
 - priority = 0
 - max_value = 20.0
-- max_value_gql = future:DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_engine_gas_power_fuelmix,"electricity_output_capacity * 8760 * 3600"))
+- max_value_gql = future:DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_engine_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit))
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix,number_of_units)
 - step_value = 0.1

--- a/inputs/demand/industry/number_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/demand/industry/number_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -9,7 +9,7 @@
     )
 - priority = 0
 - max_value = 20.0
-- max_value_gql = future:DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_turbine_gas_power_fuelmix,"electricity_output_capacity * 8760 * 3600"))
+- max_value_gql = future:DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_turbine_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit))
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_chp_combined_cycle_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_combined_cycle_network_gas.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 100000000.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_combined_cycle_network_gas,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_combined_cycle_network_gas,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = future:V(energy_chp_combined_cycle_network_gas,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_chp_supercritical_waste_mix.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_supercritical_waste_mix.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:DIVIDE( DIVIDE( Q(total_electricity_produced), V(energy_chp_supercritical_waste_mix,"electricity_output_capacity * 8760 * 3600") ), 20 )
+- max_value_gql = present:DIVIDE( DIVIDE( Q(total_electricity_produced), V(energy_chp_supercritical_waste_mix,maximum_yearly_electricity_production_per_unit) ), 20 )
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_supercritical_waste_mix,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 1000.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_cofiring_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 1000.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_cofiring_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_cofiring_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_cofiring_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_lignite.ad
+++ b/inputs/supply/number_of/number_of_energy_chp_ultra_supercritical_lignite.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_lignite,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_lignite,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_lignite,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_ccs_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_ccs_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_ccs_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_ccs_network_gas.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_ccs_network_gas,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_ccs_network_gas,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_ccs_network_gas,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_combined_cycle_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_combined_cycle_network_gas.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_network_gas,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_network_gas,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_combined_cycle_network_gas,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_engine_diesel.ad
+++ b/inputs/supply/number_of/number_of_energy_power_engine_diesel.ad
@@ -4,7 +4,7 @@
       UPDATE(L(energy_power_engine_diesel), preset_demand_by_electricity_production, V(energy_power_engine_diesel, production_based_on_number_of_units))
     )
 - priority = 0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_engine_diesel,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_engine_diesel,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_engine_diesel,number_of_units)
 - step_value = 1.0

--- a/inputs/supply/number_of/number_of_energy_power_engine_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_engine_network_gas.ad
@@ -4,7 +4,7 @@
       UPDATE(L(energy_power_engine_network_gas), preset_demand_by_electricity_production, V(energy_power_engine_network_gas, production_based_on_number_of_units))
     )
 - priority = 0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_engine_network_gas,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_engine_network_gas,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_engine_network_gas,number_of_units)
 - step_value = 1.0

--- a/inputs/supply/number_of/number_of_energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/inputs/supply/number_of/number_of_energy_power_nuclear_gen2_uranium_oxide.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_nuclear_gen3_uranium_oxide,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_nuclear_gen3_uranium_oxide,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_nuclear_gen2_uranium_oxide,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/inputs/supply/number_of/number_of_energy_power_nuclear_gen3_uranium_oxide.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_nuclear_gen3_uranium_oxide,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_nuclear_gen3_uranium_oxide,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_nuclear_gen3_uranium_oxide,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_supercritical_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_supercritical_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_supercritical_coal ,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_supercritical_coal ,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_supercritical_coal ,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_supercritical_waste_mix.ad
+++ b/inputs/supply/number_of/number_of_energy_power_supercritical_waste_mix.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:DIVIDE( DIVIDE( Q(total_electricity_produced), V(energy_power_supercritical_waste_mix,"electricity_output_capacity * 8760 * 3600")), 20 )
+- max_value_gql = present:DIVIDE( DIVIDE( Q(total_electricity_produced), V(energy_power_supercritical_waste_mix,maximum_yearly_electricity_production_per_unit)), 20 )
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_supercritical_waste_mix,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_ccs_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_ccs_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_ccs_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_ccs_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_ccs_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_cofiring_coal.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_cofiring_coal,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_cofiring_coal,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_cofiring_coal,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_crude_oil.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_crude_oil.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_crude_oil,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_crude_oil,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_crude_oil,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_lignite.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_lignite.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_lignite,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_lignite,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_lignite,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_network_gas.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_network_gas.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_network_gas,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_network_gas,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_network_gas,number_of_units)
 - step_value = 0.1

--- a/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
+++ b/inputs/supply/number_of/number_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
@@ -5,7 +5,7 @@
     )
 - priority = 0
 - max_value = 300.0
-- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,"electricity_output_capacity * 8760 * 3600")),2)
+- max_value_gql = present:PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,maximum_yearly_electricity_production_per_unit)),2)
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,number_of_units)
 - step_value = 0.1


### PR DESCRIPTION
Adjusted the upper limits of all dispatchable and must-run plants to be based on their capacity rather then their production. 
This fixes the behavior that plants with very few FLHs (e.g., Wartsilla plant) have ridiculously high slider maxima. 

Fixes https://github.com/quintel/etsource/issues/863
