### PR TITLE
Specify nodes to be omitted from LOLE calculation

### DIFF
--- a/gqueries/modules/security_of_supply/loss_of_load_expectation.gql
+++ b/gqueries/modules/security_of_supply/loss_of_load_expectation.gql
@@ -1,4 +1,11 @@
 # Returns the number of hours per year where the production capacity cannot meet the demand
 
-- query = V(GRAPH(), loss_of_load_expectation(Q(lole_demand), Q(reliable_electricity_production_capacity)))
+- query =
+  V(GRAPH(), loss_of_load_expectation(
+    Q(lole_demand), Q(reliable_electricity_production_capacity), [
+      energy_power_wind_turbine_coastal,
+      energy_power_wind_turbine_inland,
+      energy_power_wind_turbine_offshore
+    ]
+  ))
 - unit = hours


### PR DESCRIPTION
The matching nodes will have their demand profiles removed from the total demand profile prior to calculating the loss-of-load expectation in Merit.

See also:
- https://github.com/quintel/merit/pull/125
- https://github.com/quintel/etengine/pull/726
