### PR TITLE
add-on heat pump final demand

### DIFF
--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/ambient_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/ambient_used_for_heating_in_households.gql
@@ -4,5 +4,6 @@
 - query =
     SUM(
       V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_ambient_heat),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_ambient_cold)      
+      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_ambient_cold),
+      V(households_space_heater_heatpump_add_on_electricity,input_of_ambient_heat)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/electricity_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/electricity_used_for_heating_in_households.gql
@@ -3,5 +3,6 @@
 - unit = pj
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_electricity)      
+      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_electricity),
+      V(households_space_heater_heatpump_add_on_electricity,input_of_electricity)      
     ) / BILLIONS


### PR DESCRIPTION
Added electricity use of add-on heat pump to space heating final demand chart.

Before:
![energietransitiemodel_-_je_eigen_onafhankelijke__volledige_en_op_feiten_gebaseerde_energiescenario_](https://cloud.githubusercontent.com/assets/1303760/5660063/f963611c-971b-11e4-97d8-9e026c6ee26c.png)

After:
![energy_transition_model_-_your_free__independent__comprehensive__fact-based_scenario_builder_](https://cloud.githubusercontent.com/assets/1303760/5660066/09e20872-971c-11e4-879e-df859f19832a.png)
