### PR TITLE
Remove households supplied per unit

### DIFF
--- a/nodes/agriculture/agriculture_burner_crude_oil.converter.ad
+++ b/nodes/agriculture/agriculture_burner_crude_oil.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/agriculture/agriculture_burner_network_gas.converter.ad
+++ b/nodes/agriculture/agriculture_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/agriculture/agriculture_burner_wood_pellets.converter.ad
+++ b/nodes/agriculture/agriculture_burner_wood_pellets.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/agriculture/agriculture_chp_engine_biogas.central_producer.ad
+++ b/nodes/agriculture/agriculture_chp_engine_biogas.central_producer.ad
@@ -10,7 +10,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/agriculture/agriculture_chp_engine_network_gas.central_producer.ad
+++ b/nodes/agriculture/agriculture_chp_engine_network_gas.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.1
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/agriculture/agriculture_chp_supercritical_wood_pellets.central_producer.ad
+++ b/nodes/agriculture/agriculture_chp_supercritical_wood_pellets.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/agriculture/agriculture_final_demand_electricity.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_electricity.final_demand.ad
@@ -4,7 +4,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/agriculture/agriculture_geothermal.converter.ad
+++ b/nodes/agriculture/agriculture_geothermal.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 3672.39293209657
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 971.765172263585
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_chp_engine_biogas.central_producer.ad
+++ b/nodes/buildings/buildings_chp_engine_biogas.central_producer.ad
@@ -10,7 +10,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/buildings/buildings_collective_chp_network_gas.central_producer.ad
+++ b/nodes/buildings/buildings_collective_chp_network_gas.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/buildings/buildings_collective_chp_wood_pellets.central_producer.ad
+++ b/nodes/buildings/buildings_collective_chp_wood_pellets.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/buildings/buildings_collective_geothermal.converter.ad
+++ b/nodes/buildings/buildings_collective_geothermal.converter.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 3672.39293209657
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_cooling_airconditioning_electricity.converter.ad
+++ b/nodes/buildings/buildings_cooling_airconditioning_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2240.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_cooling_collective_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/buildings/buildings_cooling_collective_heatpump_water_water_ts_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_cooling_heatpump_air_water_network_gas.converter.ad
+++ b/nodes/buildings/buildings_cooling_heatpump_air_water_network_gas.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 4000.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_final_demand_electricity.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_electricity.final_demand.ad
@@ -4,7 +4,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/buildings/buildings_heat_network_connection_steam_hot_water.ad
+++ b/nodes/buildings/buildings_heat_network_connection_steam_hot_water.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_heating_savings_from_insulation_useable_heat.ad
+++ b/nodes/buildings/buildings_heating_savings_from_insulation_useable_heat.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/buildings/buildings_lighting_savings_from_daylight_control_light.ad
+++ b/nodes/buildings/buildings_lighting_savings_from_daylight_control_light.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/buildings/buildings_lighting_savings_from_motion_detection_light.ad
+++ b/nodes/buildings/buildings_lighting_savings_from_motion_detection_light.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/buildings/buildings_solar_pv_solar_radiation.central_producer.ad
+++ b/nodes/buildings/buildings_solar_pv_solar_radiation.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.05
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0001
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/buildings/buildings_space_heater_coal.converter.ad
+++ b/nodes/buildings/buildings_space_heater_coal.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 1042.44
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_collective_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/buildings/buildings_space_heater_collective_heatpump_water_water_ts_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 4380.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_crude_oil.converter.ad
+++ b/nodes/buildings/buildings_space_heater_crude_oil.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 981.12
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/buildings/buildings_space_heater_district_heating_steam_hot_water.converter.ad
@@ -6,7 +6,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2500.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_electricity.converter.ad
+++ b/nodes/buildings/buildings_space_heater_electricity.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 1716.96
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_heatpump_air_water_network_gas.converter.ad
+++ b/nodes/buildings/buildings_space_heater_heatpump_air_water_network_gas.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 4380.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_network_gas.converter.ad
+++ b/nodes/buildings/buildings_space_heater_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2000.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_solar_thermal.converter.ad
+++ b/nodes/buildings/buildings_space_heater_solar_thermal.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 791.666666666667
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/buildings/buildings_space_heater_wood_pellets.converter.ad
+++ b/nodes/buildings/buildings_space_heater_wood_pellets.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 1016.16
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_chp_combined_cycle_network_gas.central_producer.ad
+++ b/nodes/energy/energy_chp_combined_cycle_network_gas.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.11
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.01
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_chp_ultra_supercritical_coal.central_producer.ad
+++ b/nodes/energy/energy_chp_ultra_supercritical_coal.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_chp_ultra_supercritical_cofiring_coal.central_producer.ad
+++ b/nodes/energy/energy_chp_ultra_supercritical_cofiring_coal.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_chp_ultra_supercritical_lignite.central_producer.ad
+++ b/nodes/energy/energy_chp_ultra_supercritical_lignite.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_export_electricity.ad
+++ b/nodes/energy/energy_export_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 5427.6084
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 4200.0

--- a/nodes/energy/energy_heat_network_backup_heater_network_gas.converter.ad
+++ b/nodes/energy/energy_heat_network_backup_heater_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_coal.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_coal.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_crude_oil.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_crude_oil.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_geothermal.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_geothermal.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_lignite.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_lignite.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_network_gas.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_network_gas.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_waste_mix.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_wood_pellets.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_wood_pellets.central_producer.ad
@@ -6,7 +6,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_import_electricity.ad
+++ b/nodes/energy/energy_import_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 5427.6084
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 4200.0

--- a/nodes/energy/energy_interconnector_imported_electricity.converter.ad
+++ b/nodes/energy/energy_interconnector_imported_electricity.converter.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/energy/energy_power_combined_cycle_ccs_coal.central_producer.ad
+++ b/nodes/energy/energy_power_combined_cycle_ccs_coal.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.83
 - free_co2_factor = 0.85
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.4
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0364

--- a/nodes/energy/energy_power_combined_cycle_ccs_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_combined_cycle_ccs_network_gas.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.87
 - free_co2_factor = 0.85
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.2
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0482

--- a/nodes/energy/energy_power_combined_cycle_coal.central_producer.ad
+++ b/nodes/energy/energy_power_combined_cycle_coal.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.85
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.036

--- a/nodes/energy/energy_power_combined_cycle_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_combined_cycle_network_gas.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.11
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0464

--- a/nodes/energy/energy_power_engine_diesel.central_producer.ad
+++ b/nodes/energy/energy_power_engine_diesel.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0001
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.01

--- a/nodes/energy/energy_power_engine_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_engine_network_gas.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.1
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/energy/energy_power_geothermal.central_producer.ad
+++ b/nodes/energy/energy_power_geothermal.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 1.5
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_hv_network_electricity.ad
+++ b/nodes/energy/energy_power_hv_network_electricity.ad
@@ -6,7 +6,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0

--- a/nodes/energy/energy_power_hydro_mountain.central_producer.ad
+++ b/nodes/energy/energy_power_hydro_mountain.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.33
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 100.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_hydro_river.central_producer.ad
+++ b/nodes/energy/energy_power_hydro_river.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_lv_network_electricity.ad
+++ b/nodes/energy/energy_power_lv_network_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0

--- a/nodes/energy/energy_power_mv_distribution_network_electricity.ad
+++ b/nodes/energy/energy_power_mv_distribution_network_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0

--- a/nodes/energy/energy_power_mv_transport_network_electricity.ad
+++ b/nodes/energy/energy_power_mv_transport_network_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0

--- a/nodes/energy/energy_power_nuclear_gen2_uranium_oxide.central_producer.ad
+++ b/nodes/energy/energy_power_nuclear_gen2_uranium_oxide.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.87
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 5.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_nuclear_gen3_uranium_oxide.central_producer.ad
+++ b/nodes/energy/energy_power_nuclear_gen3_uranium_oxide.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.92
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 5.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_solar_csp_solar_radiation.central_producer.ad
+++ b/nodes/energy/energy_power_solar_csp_solar_radiation.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.99
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 2.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_solar_pv_solar_radiation.central_producer.ad
+++ b/nodes/energy/energy_power_solar_pv_solar_radiation.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.05
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.1
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_supercritical_coal.central_producer.ad
+++ b/nodes/energy/energy_power_supercritical_coal.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.89
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.018

--- a/nodes/energy/energy_power_supercritical_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_power_supercritical_waste_mix.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.5
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_transformer_lv_mv_electricity.ad
+++ b/nodes/energy/energy_power_transformer_lv_mv_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0

--- a/nodes/energy/energy_power_transformer_mv_hv_electricity.ad
+++ b/nodes/energy/energy_power_transformer_mv_hv_electricity.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0

--- a/nodes/energy/energy_power_turbine_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_turbine_network_gas.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.1
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.034

--- a/nodes/energy/energy_power_ultra_supercritical_ccs_coal.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_ccs_coal.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.87
 - free_co2_factor = 0.85
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.4
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0425

--- a/nodes/energy/energy_power_ultra_supercritical_coal.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_coal.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.046

--- a/nodes/energy/energy_power_ultra_supercritical_cofiring_coal.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_cofiring_coal.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.88
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.046

--- a/nodes/energy/energy_power_ultra_supercritical_crude_oil.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_crude_oil.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.89
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0225

--- a/nodes/energy/energy_power_ultra_supercritical_lignite.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_lignite.central_producer.ad
@@ -7,7 +7,6 @@
 - merit_order.type = dispatchable
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_ultra_supercritical_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_network_gas.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.04

--- a/nodes/energy/energy_power_ultra_supercritical_oxyfuel_ccs_lignite.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_oxyfuel_ccs_lignite.central_producer.ad
@@ -7,7 +7,6 @@
 - availability = 0.87
 - free_co2_factor = 0.85
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.4
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_wind_turbine_coastal.central_producer.ad
+++ b/nodes/energy/energy_power_wind_turbine_coastal.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.05
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.2
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_wind_turbine_inland.central_producer.ad
+++ b/nodes/energy/energy_power_wind_turbine_inland.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.05
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.2
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/energy/energy_power_wind_turbine_offshore.central_producer.ad
+++ b/nodes/energy/energy_power_wind_turbine_offshore.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.92
 - free_co2_factor = 0.0
 - forecasting_error = 0.05
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.5
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/households/households_collective_chp_biogas.central_producer.ad
+++ b/nodes/households/households_collective_chp_biogas.central_producer.ad
@@ -10,7 +10,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/households/households_collective_chp_network_gas.central_producer.ad
+++ b/nodes/households/households_collective_chp_network_gas.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/households/households_collective_chp_wood_pellets.central_producer.ad
+++ b/nodes/households/households_collective_chp_wood_pellets.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 387.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/households/households_collective_geothermal.converter.ad
+++ b/nodes/households/households_collective_geothermal.converter.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 3672.39293209657
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_cooling_airconditioning_electricity.converter.ad
+++ b/nodes/households/households_cooling_airconditioning_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 560.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_cooling_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_cooling_heatpump_air_water_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 560.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_cooling_heatpump_ground_water_electricity.converter.ad
+++ b/nodes/households/households_cooling_heatpump_ground_water_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 560.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_final_demand_electricity.final_demand.ad
+++ b/nodes/households/households_final_demand_electricity.final_demand.ad
@@ -4,7 +4,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/households/households_heat_network_connection_steam_hot_water.ad
+++ b/nodes/households/households_heat_network_connection_steam_hot_water.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 8760.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_new_houses_heating_savings_from_insulation.ad
+++ b/nodes/households/households_new_houses_heating_savings_from_insulation.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/households/households_old_houses_heating_savings_from_insulation.ad
+++ b/nodes/households/households_old_houses_heating_savings_from_insulation.ad
@@ -5,7 +5,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/households/households_solar_pv_solar_radiation.central_producer.ad
+++ b/nodes/households/households_solar_pv_solar_radiation.central_producer.ad
@@ -8,7 +8,6 @@
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.05
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 1.0e-05
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
@@ -6,7 +6,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2500.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_space_heater_heatpump_add_on_electricity.converter.ad
+++ b/nodes/households/households_space_heater_heatpump_add_on_electricity.converter.ad
@@ -9,7 +9,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2500.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_space_heater_heatpump_add_on_electricity.converter.ad
+++ b/nodes/households/households_space_heater_heatpump_add_on_electricity.converter.ad
@@ -4,7 +4,8 @@
 - input.electricity = 0.285714285714286
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, demand_driven]
+- households_supplied_per_unit = 1.0
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_aluminium_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_aluminium_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_burner_coal.converter.ad
+++ b/nodes/industry/industry_burner_coal.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_burner_crude_oil.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_burner_wood_pellets.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_chemicals_burner_coal.converter.ad
+++ b/nodes/industry/industry_chemicals_burner_coal.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_chemicals_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_chemicals_burner_crude_oil.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_chemicals_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_chemicals_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_chemicals_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_chemicals_burner_wood_pellets.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.central_producer.ad
+++ b/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.1
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/industry/industry_chp_engine_gas_power_fuelmix.central_producer.ad
+++ b/nodes/industry/industry_chp_engine_gas_power_fuelmix.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/industry/industry_chp_turbine_gas_power_fuelmix.central_producer.ad
+++ b/nodes/industry/industry_chp_turbine_gas_power_fuelmix.central_producer.ad
@@ -9,7 +9,6 @@
 - availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/industry/industry_chp_ultra_supercritical_coal.central_producer.ad
+++ b/nodes/industry/industry_chp_ultra_supercritical_coal.central_producer.ad
@@ -11,7 +11,6 @@
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.3
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.1

--- a/nodes/industry/industry_final_demand_electricity.final_demand.ad
+++ b/nodes/industry/industry_final_demand_electricity.final_demand.ad
@@ -4,7 +4,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/industry/industry_other_metals_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_other_metals_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_steel_blastfurnace_burner_coal_gas.converter.ad
+++ b/nodes/industry/industry_steel_blastfurnace_burner_coal_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/industry/industry_steel_electricfurnace_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_steel_electricfurnace_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/other/other_burner_coal.converter.ad
+++ b/nodes/other/other_burner_coal.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/other/other_burner_crude_oil.converter.ad
+++ b/nodes/other/other_burner_crude_oil.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/other/other_burner_network_gas.converter.ad
+++ b/nodes/other/other_burner_network_gas.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/other/other_burner_wood_pellets.converter.ad
+++ b/nodes/other/other_burner_wood_pellets.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2190.0
-- households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/other/other_final_demand_electricity.final_demand.ad
+++ b/nodes/other/other_final_demand_electricity.final_demand.ad
@@ -4,7 +4,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/nodes/transport/transport_car_using_electricity.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 1104.9363103
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - typical_input_capacity = 0.0037

--- a/nodes/transport/transport_final_demand_electricity.final_demand.ad
+++ b/nodes/transport/transport_final_demand_electricity.final_demand.ad
@@ -4,7 +4,6 @@
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - network_capacity_available_in_mw = 0.0

--- a/nodes/transport/transport_truck_using_electricity.converter.ad
+++ b/nodes/transport/transport_truck_using_electricity.converter.ad
@@ -7,7 +7,6 @@
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 1062.99803615952
-- households_supplied_per_unit = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - typical_input_capacity = 0.01


### PR DESCRIPTION
Fixes https://github.com/quintel/etsource/issues/917.

Removed all ```households_supplied_per_unit``` attributes from nodes that not need them. 

The add-on heat pump is an exception to the rule. It should have the 'demand-driven' behaviour (IMO) because if the slider is set to 100%, there should be one in each household. Unfortunately, this does not yet work as expected. https://github.com/quintel/etsource/issues/918 deals with that.