### PR TITLE
Fixed input statement to be in line with other input statements in this share group; fixes failing turk

### DIFF
--- a/inputs/demand/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
@@ -1,4 +1,8 @@
-- query = UPDATE(LINK(households_water_heater_heatpump_air_water_electricity,households_useful_demand_for_hot_water_after_solar_heater_and_add_on), share, DIVIDE(USER_INPUT(),100))
+- query =
+    UPDATE(
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      share, USER_INPUT() / 100.0
+    )
 - share_group = hot_water_households
 - priority = 0
 - max_value = 100.0


### PR DESCRIPTION
After the mechanical turk failed I noticed that the input statement for `households_water_heater_heatpump_air_water_electricity` (which caused the failing spec) looked different from the others in the `water_heater` share group. I updated the input statement to be in line with the others. Locally the Turk passes again.