### PR TITLE
Update inputs & queries to reflect addition of P2H node

### DIFF
--- a/gqueries/general/shares/share_of_coal_boiler_in_hot_water_produced_in_households.gql
+++ b/gqueries/general/shares/share_of_coal_boiler_in_hot_water_produced_in_households.gql
@@ -1,4 +1,4 @@
 # Returns how much of the hot water demand of households is provided by coal-powered heaters
 
-- query = V(households_water_heater_coal,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_coal,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor

--- a/gqueries/general/shares/share_of_combined_network_gas_in_hot_water_produced_in_households.gql
+++ b/gqueries/general/shares/share_of_combined_network_gas_in_hot_water_produced_in_households.gql
@@ -1,4 +1,4 @@
 # Returns how much of the hot water demand of households is provided by combined network gas-powered water heaters
 
-- query = V(households_water_heater_combined_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_combined_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor

--- a/gqueries/input_elements/start_value/share_of_electric_boiler_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_electric_boiler_in_hot_water_production_in_households.gql
@@ -1,2 +1,2 @@
-- query = V(households_water_heater_resistive_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_resistive_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor

--- a/gqueries/input_elements/start_value/share_of_fuel_cell_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_fuel_cell_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_fuel_cell_chp_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_fuel_cell_chp_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_fuel_cell

--- a/gqueries/input_elements/start_value/share_of_gas_boiler_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_gas_boiler_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_gas_boiler

--- a/gqueries/input_elements/start_value/share_of_heat_network_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_heat_network_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_heat_network

--- a/gqueries/input_elements/start_value/share_of_heatpump_ground_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_heatpump_ground_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_heatpump_ground

--- a/gqueries/input_elements/start_value/share_of_micro_chp_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_micro_chp_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_micro_chp_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_micro_chp_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_micro_chp

--- a/gqueries/input_elements/start_value/share_of_oil_boiler_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_oil_boiler_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_crude_oil,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_crude_oil,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_oil_boiler

--- a/gqueries/input_elements/start_value/share_of_wood_stove_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_wood_stove_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_wood_pellets,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on)
+- query = V(households_water_heater_wood_pellets,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
 - unit = factor
 - deprecated_key = hot_water_share_wood_stove

--- a/inputs/demand/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
+++ b/inputs/demand/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
@@ -7,7 +7,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_add_on) * 100
+- start_value_gql = present:V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future


### PR DESCRIPTION
Updates start_value queries which expected a link between a converter and `..._after_solar_heater_and_add_on`. Those converters now link to `..._after_solar_heater_and_p2h`.

This pull request fixes the queries and should restore the correct start values for hot water sliders.