### PR TITLE
Made economic multiplier immune to scaling of scenario 

### DIFF
--- a/inputs/modules/employment/employment_economic_multiplier.ad
+++ b/inputs/modules/employment/employment_economic_multiplier.ad
@@ -5,3 +5,4 @@
 - start_value_gql = present:AREA(economic_multiplier)
 - step_value = 0.1
 - update_period = both
+- unit = x


### PR DESCRIPTION
by setting unit = x

Fixes https://github.com/quintel/etmodel/issues/1900