### PR TITLE
New and rewritten gqueries as a result of the LNG and Bio LNG addition

### DIFF
--- a/gqueries/general/carrier_groups/all_carriers/carrier_group_biomass_products.gql
+++ b/gqueries/general/carrier_groups/all_carriers/carrier_group_biomass_products.gql
@@ -1,4 +1,4 @@
 # Carrier group of biomass products
 
-- query = CARRIER(greengas, biodiesel, bio_ethanol, bio_oil, biogas, torrified_biomass_pellets, wood_pellets, corn, manure, woody_biomass, biogenic_waste)
+- query = CARRIER(greengas, biodiesel, bio_ethanol, bio_lng, bio_oil, biogas, torrified_biomass_pellets, wood_pellets, corn, manure, woody_biomass, biogenic_waste)
 - unit =

--- a/gqueries/general/carrier_groups/all_carriers/carrier_group_useful_demand.gql
+++ b/gqueries/general/carrier_groups/all_carriers/carrier_group_useful_demand.gql
@@ -1,4 +1,4 @@
 # Carrier group of useful_demand
 
-- query = CARRIER(useable_heat, cooling, car_kms, truck_kms, light, not_defined, savings)
+- query = CARRIER(useable_heat, cooling, car_kms, shipping_kms, truck_kms, light, not_defined, savings)
 - unit =

--- a/gqueries/general/carrier_groups/final_demand/final_demand_carrier_group_biomass_products.gql
+++ b/gqueries/general/carrier_groups/final_demand/final_demand_carrier_group_biomass_products.gql
@@ -5,5 +5,6 @@
     CARRIER(
       biodiesel,
       bio_ethanol,
-      wood_pellets
+      wood_pellets,
+      bio_lng
     )

--- a/gqueries/general/carrier_groups/final_demand/final_demand_carrier_group_natural_gas_and_derivatives.gql
+++ b/gqueries/general/carrier_groups/final_demand/final_demand_carrier_group_natural_gas_and_derivatives.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     CARRIER(
-      network_gas
+      network_gas,
+      lng
     )

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_agriculture.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_buildings.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")        
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_energy.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_households.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_industry.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_other.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_transport.gql
@@ -5,5 +5,6 @@
     SUM(
       V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
       V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")          
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_agriculture.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_buildings.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_energy.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")         
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_households.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_industry.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_other.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")       
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_transport.gql
@@ -3,5 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
     ) / THOUSANDS

--- a/gqueries/general/energy_use/biomass_derivatives_used_for_heating_in_buildings.gql
+++ b/gqueries/general/energy_use/biomass_derivatives_used_for_heating_in_buildings.gql
@@ -7,6 +7,7 @@
       V(Q(heating_converters_in_buildings),input_of_greengas),
       V(Q(heating_converters_in_buildings),input_of_biodiesel),
       V(Q(heating_converters_in_buildings),input_of_bio_ethanol),
+      V(Q(heating_converters_in_buildings),input_of_bio_lng),
       V(Q(heating_converters_in_buildings),input_of_biogas),
       Q(share_of_greengas_in_gas_network)*V(Q(heating_converters_in_buildings),input_of_network_gas).sum
     )

--- a/gqueries/general/energy_use/fossil_energy_used_for_heating_in_buildings.gql
+++ b/gqueries/general/energy_use/fossil_energy_used_for_heating_in_buildings.gql
@@ -6,6 +6,7 @@
       V(Q(heating_converters_in_buildings),input_of_coal),
       V(Q(heating_converters_in_buildings),input_of_crude_oil),
       PRODUCT(Q(share_of_natural_gas_in_gas_network),SUM(V(Q(heating_converters_in_buildings),"input_of_network_gas + input_of_gas_power_fuelmix"))),
+      V(Q(heating_converters_in_buildings),input_of_lng),
       V(Q(heating_converters_in_buildings),input_of_diesel),
       V(Q(heating_converters_in_buildings),input_of_gasoline),
       V(Q(heating_converters_in_buildings),input_of_lignite),

--- a/gqueries/general/energy_use/fossil_energy_used_for_hot_water_in_households.gql
+++ b/gqueries/general/energy_use/fossil_energy_used_for_hot_water_in_households.gql
@@ -7,6 +7,7 @@
       "input_of_coal + 
       input_of_crude_oil + 
       input_of_network_gas * (1.0 - sustainability_share) + 
+      input_of_lng +
       input_of_diesel + 
       input_of_gasoline + 
       input_of_lignite "),

--- a/gqueries/general/energy_use/renewables_used_for_hot_water_in_households.gql
+++ b/gqueries/general/energy_use/renewables_used_for_hot_water_in_households.gql
@@ -10,7 +10,8 @@
       input_of_solar_radiation + 
       input_of_greengas + 
       input_of_biodiesel + 
-      input_of_bio_ethanol + 
+      input_of_bio_ethanol +
+      input_of_bio_lng + 
       input_of_biogas + 
       input_of_network_gas * sustainability_share"
       ),

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_chemical_industry.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_chemical_industry.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          INTERSECTION(
+            LG(final_demand),LG(chemical_industry)
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_chemical_industry_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_chemical_industry_energetic.gql
@@ -38,5 +38,17 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(chemical_industry)
+            ),
+            energetic?
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_chemical_industry_non_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_chemical_industry_non_energetic.gql
@@ -38,5 +38,17 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(chemical_industry)
+            ),
+            "! energetic?"
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_metal_industry.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_metal_industry.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          INTERSECTION(
+            LG(final_demand),LG(metal_industry)
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_metal_industry_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_metal_industry_energetic.gql
@@ -38,5 +38,17 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(metal_industry)
+            ),
+            energetic?
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_metal_industry_non_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_metal_industry_non_energetic.gql
@@ -38,5 +38,17 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(metal_industry)
+            ),
+            "! energetic?"
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_other_industry.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_other_industry.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          INTERSECTION(
+            LG(final_demand),LG(other_industry)
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_other_industry_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_other_industry_energetic.gql
@@ -38,5 +38,17 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(other_industry)
+            ),
+            energetic?
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_other_industry_non_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_biomass_products_in_other_industry_non_energetic.gql
@@ -38,5 +38,17 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(other_industry)
+            ),
+            "! energetic?"
+          ),
+          bio_lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_chemical_industry.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_chemical_industry.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          INTERSECTION(
+            LG(final_demand),LG(chemical_industry)
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_chemical_industry_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_chemical_industry_energetic.gql
@@ -14,5 +14,17 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(chemical_industry)
+            ),
+            energetic?
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_chemical_industry_non_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_chemical_industry_non_energetic.gql
@@ -14,5 +14,17 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(chemical_industry)
+            ),
+            "! energetic?"
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_metal_industry.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_metal_industry.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          INTERSECTION(
+            LG(final_demand),LG(metal_industry)
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_metal_industry_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_metal_industry_energetic.gql
@@ -14,5 +14,17 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(metal_industry)
+            ),
+            energetic?
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_metal_industry_non_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_metal_industry_non_energetic.gql
@@ -14,5 +14,17 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(metal_industry)
+            ),
+            "! energetic?"
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_other_industry.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_other_industry.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          INTERSECTION(
+            LG(final_demand),LG(other_industry)
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_other_industry_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_other_industry_energetic.gql
@@ -14,5 +14,17 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(other_industry)
+            ),
+            energetic?
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_other_industry_non_energetic.gql
+++ b/gqueries/general/final_demand/industry/final_demand_of_natural_gas_and_derivatives_in_other_industry_non_energetic.gql
@@ -14,5 +14,17 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            INTERSECTION(
+              LG(final_demand),LG(other_industry)
+            ),
+            "! energetic?"
+          ),
+          lng?
+        ),
+        value
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_agriculture.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_agriculture.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :agriculture"
+          ),
+          bio_lng?
+        ),
+        value
+      )        
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_buildings.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_buildings.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :buildings"
+          ),
+          bio_lng?
+        ),
+        value
+      )       
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_energy.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_energy.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :energy"
+          ),
+          bio_lng?
+        ),
+        value
       )      
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_households.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_households.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :households"
+          ),
+          bio_lng?
+        ),
+        value
+      )         
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_industry.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_industry.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :industry"
+          ),
+          bio_lng?
+        ),
+        value
+      )        
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_other.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_other.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :other"
+          ),
+          bio_lng?
+        ),
+        value
+      )        
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_transport.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_biomass_products_in_transport.gql
@@ -29,5 +29,14 @@
           wood_pellets?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :transport"
+          ),
+          bio_lng?
+        ),
+        value
+      )       
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_agriculture.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_agriculture.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :agriculture"
+          ),
+          lng?
+        ),
+        value
+      )       
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_buildings.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_buildings.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :buildings"
+          ),
+          lng?
+        ),
+        value
+      )       
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_energy.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_energy.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :energy"
+          ),
+          lng?
+        ),
+        value
       )      
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_households.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_households.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :households"
+          ),
+          lng?
+        ),
+        value
+      )        
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_industry.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_industry.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :industry"
+          ),
+          lng?
+        ),
+        value
+      )       
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_other.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_other.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :other"
+          ),
+          lng?
+        ),
+        value
+      )       
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_transport.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_transport.gql
@@ -11,5 +11,14 @@
           network_gas?
         ),
         value
-      )      
+      ),
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :transport"
+          ),
+          lng?
+        ),
+        value
+      )        
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products.gql
@@ -6,6 +6,7 @@
       V(G(heat_production),input_of_greengas),
       V(G(heat_production),input_of_biodiesel),
       V(G(heat_production),input_of_bio_ethanol),
+      V(G(heat_production),input_of_bio_lng),
       V(G(heat_production),input_of_bio_oil),
       V(G(heat_production),input_of_biogas),
       V(G(heat_production),input_of_torrified_biomass_pellets),

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_agriculture.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_agriculture.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(agriculture)
         ),
         input_of_wood_pellets
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(agriculture)
+        ),
+        input_of_bio_lng
       )      
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_buildings.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_buildings.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(buildings)
         ),
         input_of_wood_pellets
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(buildings)
+        ),
+        input_of_bio_lng
+      )        
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_energy.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_energy.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(energy)
         ),
         input_of_wood_pellets
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(energy)
+        ),
+        input_of_bio_lng
+      )         
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_households.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_households.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(households)
         ),
         input_of_wood_pellets
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(households)
+        ),
+        input_of_bio_lng
+      )       
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_industry.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_industry.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(industry)
         ),
         input_of_wood_pellets
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(industry)
+        ),
+        input_of_bio_lng
+      )       
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_other.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_other.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(other)
         ),
         input_of_wood_pellets
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(other)
+        ),
+        input_of_bio_lng
       )      
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products_in_transport.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products_in_transport.gql
@@ -20,5 +20,11 @@
           G(heat_production),SECTOR(transport)
         ),
         input_of_wood_pellets
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(transport)
+        ),
+        input_of_bio_lng
+      )       
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_agriculture.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_agriculture.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(agriculture)
         ),
         input_of_network_gas
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(agriculture)
+        ),
+        input_of_lng
+      )          
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_buildings.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_buildings.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(buildings)
         ),
         input_of_network_gas
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(buildings)
+        ),
+        input_of_lng
+      )         
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_energy.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_energy.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(energy)
         ),
         input_of_network_gas
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(energy)
+        ),
+        input_of_lng
+      )        
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_households.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_households.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(households)
         ),
         input_of_network_gas
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(households)
+        ),
+        input_of_lng
+      )       
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_industry.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_industry.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(industry)
         ),
         input_of_network_gas
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(industry)
+        ),
+        input_of_lng
+      )        
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_other.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_other.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(other)
         ),
         input_of_network_gas
-      )      
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(other)
+        ),
+        input_of_lng
+      )         
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_transport.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives_in_transport.gql
@@ -8,5 +8,11 @@
           G(heat_production),SECTOR(transport)
         ),
         input_of_network_gas
+      ),
+      V(
+        INTERSECTION(
+          G(heat_production),SECTOR(transport)
+        ),
+        input_of_lng
       )      
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_agriculture.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_agriculture.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_buildings.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_buildings.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_energy_sector.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_energy_sector.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(energy),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(energy),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(energy),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(energy),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_households.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_households.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(households),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(households),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(households),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(households),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_industry.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_industry.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(industry),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(industry),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(industry),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(industry),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_other_sector.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_other_sector.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(other),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(other),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(other),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(other),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_transport.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_transport.gql
@@ -3,7 +3,8 @@
     DIVIDE(
       SUM(
         V(INTERSECTION(SECTOR(transport),G(final_demand_group)),primary_demand_of_biodiesel),
-        V(INTERSECTION(SECTOR(transport),G(final_demand_group)),primary_demand_of_bio_ethanol)
+        V(INTERSECTION(SECTOR(transport),G(final_demand_group)),primary_demand_of_bio_ethanol),
+        V(INTERSECTION(SECTOR(transport),G(final_demand_group)),primary_demand_of_bio_lng)
       ),
       BILLIONS
     )

--- a/gqueries/general/shares/greengas_from_distribution_gas_network.gql
+++ b/gqueries/general/shares/greengas_from_distribution_gas_network.gql
@@ -1,0 +1,4 @@
+# The amount of greengas that is put into the national gas network
+
+- unit = PJ
+- query = (V(energy_national_gas_network_natural_gas,input_of_greengas) - V(energy_regasification_bio_lng,output_of_greengas)) / BILLIONS

--- a/gqueries/general/shares/greengas_from_regasification_gas_network.gql
+++ b/gqueries/general/shares/greengas_from_regasification_gas_network.gql
@@ -1,0 +1,4 @@
+# The amount of greengas that is put into the national gas network
+
+- unit = PJ
+- query = V(energy_regasification_bio_lng,output_of_greengas) / BILLIONS

--- a/gqueries/general/shares/natural_gas_from_regasification_in_gas_network.gql
+++ b/gqueries/general/shares/natural_gas_from_regasification_in_gas_network.gql
@@ -1,0 +1,4 @@
+# The amount of natural gas that is put into the national gas network
+
+- unit = PJ
+- query = V(energy_regasification_lng,output_of_natural_gas) / BILLIONS

--- a/gqueries/general/shares/natural_gas_from_treatment_in_gas_network.gql
+++ b/gqueries/general/shares/natural_gas_from_treatment_in_gas_network.gql
@@ -1,0 +1,4 @@
+# The amount of natural gas that is put into the national gas network
+
+- unit = PJ
+- query = (V(energy_national_gas_network_natural_gas,input_of_natural_gas) - V(energy_regasification_lng,output_of_natural_gas)) / BILLIONS

--- a/gqueries/general/shares/share_of_renewables_in_heat_produced_in_buildings.gql
+++ b/gqueries/general/shares/share_of_renewables_in_heat_produced_in_buildings.gql
@@ -3,7 +3,7 @@
 - query =
     DIVIDE(
       SUM(
-    	SUM(V(Q(heating_converters_in_buildings),"input_of_wood_pellets + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_biogas + input_of_ambient_heat + input_of_solar_radiation + input_of_solar_thermal + input_of_geothermal")),
+    	SUM(V(Q(heating_converters_in_buildings),"input_of_wood_pellets + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_biogas + input_of_ambient_heat + input_of_solar_radiation + input_of_solar_thermal + input_of_geothermal")),
         PRODUCT(SUM(V(Q(heating_converters_in_buildings),"input_of_network_gas + input_of_gas_power_fuelmix")),Q(share_of_greengas_in_gas_network))
         ),
       Q(energy_used_for_heating_in_buildings)

--- a/gqueries/modules/energymixer/share_of_total_costs_assigned_to_biomass.gql
+++ b/gqueries/modules/energymixer/share_of_total_costs_assigned_to_biomass.gql
@@ -12,6 +12,7 @@
       V(G(final_demand_group), primary_demand_of_greengas),
       V(G(final_demand_group), primary_demand_of_biodiesel),
       V(G(final_demand_group), primary_demand_of_bio_ethanol),
+      V(G(final_demand_group), primary_demand_of_bio_lng),
       V(G(final_demand_group), primary_demand_of_bio_oil),
       V(G(final_demand_group), primary_demand_of_biogas),
       V(G(final_demand_group), primary_demand_of_electricity)

--- a/gqueries/output_elements/output_series/bezier_110_source_of_district_heating_in_households/biomass_products_used_for_district_heating_in_residences.gql
+++ b/gqueries/output_elements/output_series/bezier_110_source_of_district_heating_in_households/biomass_products_used_for_district_heating_in_residences.gql
@@ -6,6 +6,7 @@
       V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_greengas),
       V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_biodiesel),
       V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_bio_ethanol),
+      V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_bio_lng),
       V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_bio_oil),
       V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_biogas),
       V(CHILDREN(V(households_final_demand_steam_hot_water)),input_of_torrified_biomass_pellets),

--- a/gqueries/output_elements/output_series/bezier_119_source_of_district_heating_in_buildings/biomass_products_used_for_district_heating_in_buildings.gql
+++ b/gqueries/output_elements/output_series/bezier_119_source_of_district_heating_in_buildings/biomass_products_used_for_district_heating_in_buildings.gql
@@ -6,6 +6,7 @@
       V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_greengas),
       V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_biodiesel),
       V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_bio_ethanol),
+      V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_bio_lng),
       V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_bio_oil),
       V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_biogas),
       V(CHILDREN(V(buildings_final_demand_steam_hot_water)),input_of_torrified_biomass_pellets),

--- a/gqueries/output_elements/output_series/bezier_151_source_of_heat_in_industry_chemical/biomass_products_used_for_heating_in_chemical_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_151_source_of_heat_in_industry_chemical/biomass_products_used_for_heating_in_chemical_industry.gql
@@ -5,5 +5,6 @@
     SUM(
       V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_biodiesel),
       V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_bio_ethanol),
-      V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_wood_pellets)
+      V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_wood_pellets),
+      V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_bio_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_151_source_of_heat_in_industry_chemical/natural_gas_and_derivatives_used_for_heating_in_chemical_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_151_source_of_heat_in_industry_chemical/natural_gas_and_derivatives_used_for_heating_in_chemical_industry.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_network_gas)
+      V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_network_gas),
+      V(CHILDREN(V(industry_useful_demand_for_chemical_useable_heat)),input_of_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_154_source_of_heat_in_industry_other/biomass_products_used_for_heating_in_other_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_154_source_of_heat_in_industry_other/biomass_products_used_for_heating_in_other_industry.gql
@@ -5,5 +5,6 @@
     SUM(
       V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_biodiesel),
       V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_bio_ethanol),
-      V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_wood_pellets)
+      V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_wood_pellets),
+      V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_bio_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_154_source_of_heat_in_industry_other/natural_gas_and_derivatives_used_for_heating_in_other_industry.gql
+++ b/gqueries/output_elements/output_series/bezier_154_source_of_heat_in_industry_other/natural_gas_and_derivatives_used_for_heating_in_other_industry.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_network_gas)
+      V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_network_gas),
+      V(CHILDREN(V(industry_useful_demand_useable_heat)),input_of_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_trucks_in_use_of_final_demand_in_transport.gql
+++ b/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_trucks_in_use_of_final_demand_in_transport.gql
@@ -6,6 +6,7 @@
           transport_truck_using_compressed_natural_gas,
           transport_truck_using_diesel_mix,
           transport_truck_using_gasoline_mix,
+          transport_truck_using_lng_mix,
           final_demand)
       ),
     BILLIONS

--- a/gqueries/output_elements/output_series/bezier_30_source_of_heat_in_agriculture/biomass_products_used_for_heating_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/bezier_30_source_of_heat_in_agriculture/biomass_products_used_for_heating_in_agriculture.gql
@@ -5,5 +5,6 @@
     SUM(
       V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_biodiesel),
       V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_bio_ethanol),
-      V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_wood_pellets)      
+      V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_wood_pellets),
+      V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_bio_lng)          
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_30_source_of_heat_in_agriculture/natural_gas_and_derivatives_used_for_heating_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/bezier_30_source_of_heat_in_agriculture/natural_gas_and_derivatives_used_for_heating_in_agriculture.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_network_gas)      
+      V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_network_gas),
+      V(CHILDREN(V(agriculture_useful_demand_useable_heat)),input_of_lng)       
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/biomass_products_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/biomass_products_used_for_heating_in_households.gql
@@ -5,5 +5,6 @@
     SUM(
       V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_biodiesel),
       V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_bio_ethanol),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_wood_pellets)      
+      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_wood_pellets),
+      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_bio_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/natural_gas_and_derivatives_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/natural_gas_and_derivatives_used_for_heating_in_households.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_network_gas)      
+      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_network_gas),
+      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on)),input_of_lng)      
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/biomass_products_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/biomass_products_used_for_hot_water_in_households.gql
@@ -5,5 +5,6 @@
     SUM(
       V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_biodiesel),
       V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_bio_ethanol),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_wood_pellets)      
+      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_wood_pellets),
+      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_bio_lng)      
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/natural_gas_and_derivatives_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/natural_gas_and_derivatives_used_for_hot_water_in_households.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_network_gas)      
+      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_network_gas),
+      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_lng)      
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_70_source_of_heat_in_buildings/biomass_products_used_for_heat_in_buildings.gql
+++ b/gqueries/output_elements/output_series/bezier_70_source_of_heat_in_buildings/biomass_products_used_for_heat_in_buildings.gql
@@ -5,5 +5,6 @@
     SUM(
       V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_biodiesel),
       V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_bio_ethanol),
-      V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_wood_pellets)      
+      V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_wood_pellets),
+      V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_bio_lng)      
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_70_source_of_heat_in_buildings/natural_gas_and_derivatives_used_for_heat_in_buildings.gql
+++ b/gqueries/output_elements/output_series/bezier_70_source_of_heat_in_buildings/natural_gas_and_derivatives_used_for_heat_in_buildings.gql
@@ -3,5 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_network_gas)      
+      V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_network_gas),
+      V(CHILDREN(V(buildings_useful_demand_for_space_heating_after_insulation)),input_of_lng)      
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_agriculture.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in agriculture sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_buildings.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_buildings.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in buildings sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_energy.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_energy.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in energy sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_households.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_households.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in households sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(households)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_industry.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_industry.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in industry sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_other.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_other.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in other sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(other)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_transport.gql
+++ b/gqueries/output_elements/output_series/mekko_166_primary_demand_of_biomass/primary_demand_of_bio_lng_in_transport.gql
@@ -1,0 +1,7 @@
+# Use of bio_oil in transport sector
+
+- unit = PJ
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_demand_of_bio_lng
+    ).sum / BILLIONS

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_agriculture.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in agriculture sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_buildings.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_buildings.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in buildings sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_energy.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_energy.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in energy sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_households.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_households.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in households sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(households)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_industry.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_industry.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in industry sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_other.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_other.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in other sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(other)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_transport.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_bio_lng_in_transport.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of bio_oil in transport sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_demand_of_bio_lng
+    ).sum / V(CARRIER(bio_lng), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_agriculture.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in agriculture sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_buildings.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_buildings.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in buildings sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_energy.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_energy.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in energy sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_households.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_households.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in households sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(households)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_industry.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_industry.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in industry sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_other.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_other.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in other sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(other)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_transport.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogas_in_transport.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogas in transport sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_demand_of_biogas
+    ).sum / V(CARRIER(biogas), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_agriculture.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in agriculture sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_buildings.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_buildings.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in buildings sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_energy.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_energy.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in energy sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_households.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_households.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in households sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(households)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_industry.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_industry.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in industry sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_other.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_other.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in other sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(other)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_transport.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_biogenic_waste_in_transport.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of biogenic_waste in transport sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_demand_of_biogenic_waste
+    ).sum / V(CARRIER(biogenic_waste), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_agriculture.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in agriculture sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_buildings.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_buildings.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in buildings sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_energy.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_energy.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in energy sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_households.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_households.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in households sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(households)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_industry.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_industry.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in industry sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_other.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_other.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in other sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(other)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_transport.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_manure_in_transport.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of manure in transport sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_demand_of_manure
+    ).sum / V(CARRIER(manure), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_agriculture.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in agriculture sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_buildings.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_buildings.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in buildings sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_energy.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_energy.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in energy sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_households.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_households.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in households sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(households)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_industry.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_industry.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in industry sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_other.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_other.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in other sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(other)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_transport.gql
+++ b/gqueries/output_elements/output_series/mekko_168_bio_footprint/bio_footprint_of_woody_biomass_in_transport.gql
@@ -1,0 +1,7 @@
+# Bio-footprint of woody_biomass in transport sector
+
+- unit = km2
+- query =
+    V(
+        INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_demand_of_woody_biomass
+    ).sum / V(CARRIER(woody_biomass), typical_production_per_km2)

--- a/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_agriculture_in_mekko_of_primary_demand.gql
+++ b/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_agriculture_in_mekko_of_primary_demand.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),primary_demand_of_lng)),BILLIONS)

--- a/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_buildings_in_mekko_of_primary_demand.gql
+++ b/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_buildings_in_mekko_of_primary_demand.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),primary_demand_of_lng)),BILLIONS)

--- a/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_households_in_mekko_of_primary_demand.gql
+++ b/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_households_in_mekko_of_primary_demand.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(households),G(final_demand_group)),primary_demand_of_lng)),BILLIONS)

--- a/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_industry_in_mekko_of_primary_demand.gql
+++ b/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_industry_in_mekko_of_primary_demand.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(industry),G(final_demand_group)),INTERSECTION(SECTOR(energy),G(final_demand_group)),primary_demand_of_lng)),BILLIONS)

--- a/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_other_in_mekko_of_primary_demand.gql
+++ b/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_other_in_mekko_of_primary_demand.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(other),G(final_demand_group)),primary_demand_of_lng)),BILLIONS)

--- a/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_transport_in_mekko_of_primary_demand.gql
+++ b/gqueries/output_elements/output_series/mekko_52_primary_demand/lng_transport_in_mekko_of_primary_demand.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(transport),G(final_demand_group)),primary_demand_of_lng)),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_agriculture_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_agriculture_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and agriculture
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_buildings_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_buildings_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and buildings
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_chps_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_chps_prod_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and chps
 
 - unit = PJ
-- query = DIVIDE(SUM(V(Q(heat_producing_converters_sankey), primary_demand_of(non_biogenic_waste, greengas , biodiesel , bio_ethanol , bio_oil , biogas , torrified_biomass_pellets , wood_pellets , corn , manure , wood , biogenic_waste , woody_biomass , waste_mix))),BILLIONS)
+- query = DIVIDE(SUM(V(Q(heat_producing_converters_sankey), primary_demand_of(non_biogenic_waste, greengas , biodiesel , bio_ethanol , bio_lng , bio_oil , biogas , torrified_biomass_pellets , wood_pellets , corn , manure , wood , biogenic_waste , woody_biomass , waste_mix))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_electricity_prod_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and electricity
 
 - unit = PJ
-- query = DIVIDE(SUM(V(Q(electricity_producing_converters_sankey), primary_demand_of(non_biogenic_waste, greengas , biodiesel , bio_ethanol , bio_oil , biogas , torrified_biomass_pellets , wood_pellets , corn , manure , wood , biogenic_waste , woody_biomass , waste_mix))),BILLIONS)
+- query = DIVIDE(SUM(V(Q(electricity_producing_converters_sankey), primary_demand_of(non_biogenic_waste, greengas , biodiesel , bio_ethanol , bio_lng , bio_oil , biogas , torrified_biomass_pellets , wood_pellets , corn , manure , wood , biogenic_waste , woody_biomass , waste_mix))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_households_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_households_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and households
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(households),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(households),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_industry_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_industry_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and industry
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(industry),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(industry),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_other_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_other_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and other
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(other),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(other),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_transport_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and transport
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(transport),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(transport),G(final_demand_group)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrified_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass + input_of_waste_mix")),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_43_use_of_transport_fuels/bio_lng_in_use_of_transport_fuels.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_43_use_of_transport_fuels/bio_lng_in_use_of_transport_fuels.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_bio_lng,demand),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_43_use_of_transport_fuels/lng_in_use_of_transport_fuels.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_43_use_of_transport_fuels/lng_in_use_of_transport_fuels.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_lng,demand),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_biomass_products_in_renewability.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_biomass_products_in_renewability.gql
@@ -5,7 +5,8 @@
     100 * SUM(
         V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_biodiesel"),
         V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_bio_ethanol"),
-        V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_wood_pellets")
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_wood_pellets"),
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_bio_lng")
     ) / 
     SUM(
         V(INTERSECTION(G(final_demand_group),USE(energetic)), demand),

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_fossil_natural_gas_and_derivatives_in_renewability.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_fossil_natural_gas_and_derivatives_in_renewability.gql
@@ -3,7 +3,8 @@
 - unit = factor
 - query =
     100 * SUM(
-        V(INTERSECTION(G(final_demand_group),USE(energetic)), "(1.0 - sustainability_share) * supply_of_network_gas")
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), "(1.0 - sustainability_share) * supply_of_network_gas"),
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), "(1.0 - sustainability_share) * supply_of_lng")
     ) / 
     SUM(
         V(INTERSECTION(G(final_demand_group),USE(energetic)), demand),

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/primary_demand_of_biomass_products_in_renewability.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/primary_demand_of_biomass_products_in_renewability.gql
@@ -6,6 +6,7 @@
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_greengas),
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_biodiesel),
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_bio_ethanol),
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_bio_lng),
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_bio_oil),
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_torrified_biomass_pellets),
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_wood_pellets),

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/primary_demand_of_natural_gas_and_derivatives_in_renewability.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/primary_demand_of_natural_gas_and_derivatives_in_renewability.gql
@@ -4,7 +4,8 @@
 - query =
     100 * SUM(
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_natural_gas),
-        V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_compressed_network_gas)
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_compressed_network_gas),
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand_of_lng)
     ) / 
     SUM(
         V(INTERSECTION(G(final_demand_group),USE(energetic)), primary_demand),

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/greengas_from_distribution_in_gas_network_mix.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/greengas_from_distribution_in_gas_network_mix.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = Q(greengas_from_distribution_gas_network)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/greengas_from_regasification_in_gas_network_mix.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/greengas_from_regasification_in_gas_network_mix.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = Q(greengas_from_regasification_gas_network)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/natural_gas_from_regasification_in_gas_network_mix.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/natural_gas_from_regasification_in_gas_network_mix.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = Q(natural_gas_from_regasification_in_gas_network)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/natural_gas_from_treatment_in_gas_network_mix.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_77_gas_network_mix/natural_gas_from_treatment_in_gas_network_mix.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = Q(natural_gas_from_treatment_in_gas_network)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/biomass_in_source_of_electricity_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/biomass_in_source_of_electricity_production.gql
@@ -4,6 +4,7 @@
     SUM(
     Q(electricity_produced_from_torrified_biomass_pellets),
     Q(electricity_produced_from_wood_pellets),
-    Q(electricity_produced_from_bio_oil)
+    Q(electricity_produced_from_bio_oil),
+    (electricity_produced_from_bio_lng)
     )
     ,BILLIONS)

--- a/gqueries/output_elements/output_series/waterfall_47_present_energy_imports/lng_value_in_present_energy_imports.gql
+++ b/gqueries/output_elements/output_series/waterfall_47_present_energy_imports/lng_value_in_present_energy_imports.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = present:DIVIDE(V(energy_import_lng, output_of_lng),BILLIONS)

--- a/gqueries/output_elements/output_series/waterfall_76_future_energy_imports/lng_in_future_energy_imports.gql
+++ b/gqueries/output_elements/output_series/waterfall_76_future_energy_imports/lng_in_future_energy_imports.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = future:DIVIDE(V(energy_import_lng, output_of_lng),BILLIONS)

--- a/nodes/energy/energy_import_bio_lng.ad
+++ b/nodes/energy/energy_import_bio_lng.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = import
-- groups = [energy_import, energy_import_export, primary_energy_demand]
+- groups = [energy_import, energy_import_export, primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0


### PR DESCRIPTION
All gqueries, as generated by the query generation and added (and checked) manually. The last commit contains newly generated gqueries (from the script) which are not a result of the bio lng and lng addition and have probably been deleted beforehand - it is therefore 'optional'.

Assigned to the gquery wizard, @ChaelKruip , but  re-assign at will.