### PR TITLE
Cooling network in buildings removal of unused shares

### DIFF
--- a/datasets/br/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/br/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,2.00000000000000E-01
 buildings_cooling_collective_heatpump_water_water_ts_electricity,8.00000000000000E-01
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/de/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/de/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,1.00000000000000E+00
 buildings_cooling_collective_heatpump_water_water_ts_electricity,0.00000000000000E+00
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/es/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/es/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,1.00000000000000E+00
 buildings_cooling_collective_heatpump_water_water_ts_electricity,0.00000000000000E+00
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/eu/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/eu/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,1.00000000000000E+00
 buildings_cooling_collective_heatpump_water_water_ts_electricity,0.00000000000000E+00
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/example/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/example/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,9.79853479853480E-01
 buildings_cooling_collective_heatpump_water_water_ts_electricity,2.01465201465201E-02
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/fr/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/fr/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,1.00000000000000E+00
 buildings_cooling_collective_heatpump_water_water_ts_electricity,0.00000000000000E+00
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/nl/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/nl/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,9.79853479853480E-01
 buildings_cooling_collective_heatpump_water_water_ts_electricity,2.01465201465201E-02
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/pl/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/pl/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,1.00000000000000E+00
 buildings_cooling_collective_heatpump_water_water_ts_electricity,0.00000000000000E+00
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/datasets/uk/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
+++ b/datasets/uk/shares/buildings_final_demand_for_cooling_electricity_parent_share.csv
@@ -1,4 +1,3 @@
 key,share
 buildings_cooling_airconditioning_electricity,1.00000000000000E+00
 buildings_cooling_collective_heatpump_water_water_ts_electricity,0.00000000000000E+00
-buildings_cooling_collective_cooling_network_electricity,0.00000000000000E+00

--- a/gqueries/general/energy_use/electricity_used_in_heatpumps.gql
+++ b/gqueries/general/energy_use/electricity_used_in_heatpumps.gql
@@ -11,7 +11,6 @@
       households_space_heater_heatpump_air_water_electricity,
       buildings_cooling_airconditioning_electricity,
       buildings_cooling_collective_heatpump_water_water_ts_electricity,
-      buildings_cooling_collective_cooling_network_electricity,
       input_of_electricity
     ).sum/BILLIONS
 - deprecated_key = heatpumps_input_of_electricity


### PR DESCRIPTION
Complements the efforts of quintel/etsource@740517324954e3d00307dd322e921adab7016341 , in which the `buildings_cooling_collective_cooling_network_electricity` converter was deleted. 

- Removed `buildings_cooling_collective_cooling_network_electricity` from `electricity_used_in_heatpumps`gquery
- Removed unused `buildings_cooling_collective_cooling_network_electricity` share from `buildings_final_demand_for_cooling_electricity_parent_share` for every country.
