### PR TITLE
Includes LNG truck in the efficiency improvement truck input statement

### DIFF
--- a/inputs/demand/transport/transport_efficiency/transport_truck_using_compressed_natural_gas_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_truck_using_compressed_natural_gas_efficiency.ad
@@ -1,4 +1,4 @@
-- query = UPDATE( OUTPUT_SLOTS(V(transport_truck_using_compressed_natural_gas,transport_truck_using_diesel_mix,transport_truck_using_gasoline_mix),truck_kms), conversion, USER_INPUT())
+- query = UPDATE( OUTPUT_SLOTS(V(transport_truck_using_compressed_natural_gas,transport_truck_using_diesel_mix,transport_truck_using_gasoline_mix, transport_truck_using_lng_mix),truck_kms), conversion, USER_INPUT())
 - priority = 0
 - max_value = 3.0
 - min_value = 0.0


### PR DESCRIPTION
As spotted by John, the LNG truck was not included in the truck efficiency improvement slider. In this pull request, the LNG truck is added to that input statement.