### PR TITLE
Removed FCE gas_from_middle_east

### DIFF
--- a/datasets/nl/fce/natural_gas.yml
+++ b/datasets/nl/fce/natural_gas.yml
@@ -8,15 +8,6 @@
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.0
 
-:middle_east:
-  :co2_exploration_per_mj: 0.0
-  :co2_extraction_per_mj: 0.0
-  :co2_treatment_per_mj: 0.00610845
-  :co2_transportation_per_mj: 0.00268084
-  :co2_conversion_per_mj: 0.0569819
-  :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.0
-
 :netherlands:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0

--- a/inputs/modules/gas_fce/gas_from_middle_east_share.ad
+++ b/inputs/modules/gas_fce/gas_from_middle_east_share.ad
@@ -1,9 +1,0 @@
-- query = UPDATE_FCE(CARRIER(natural_gas),middle_east,USER_INPUT() / 100)
-- share_group = gas_fce
-- priority = 0
-- max_value = 100.0
-- min_value = 0.0
-- start_value_gql = present:FCE_START_VALUE(natural_gas, middle_east) * 100
-- step_value = 0.1
-- unit = %
-- update_period = future

--- a/presets/watt_nu/2012/ref_scenario_watt_nu_2012.ad
+++ b/presets/watt_nu/2012/ref_scenario_watt_nu_2012.ad
@@ -74,7 +74,6 @@
 - user_values.energy_mixer_for_gas_power_fuel_natural_gas_share = 84.6
 - user_values.energy_steel_hisarna_transformation_coal_woodpellets_share = 0.0
 - user_values.gas_from_algeria_share = 0.0
-- user_values.gas_from_middle_east_share = 0.0
 - user_values.gas_from_nederlands_share = 90.0
 - user_values.gas_from_norway_share = 5.0
 - user_values.gas_from_russia_share = 5.0

--- a/presets/watt_nu/2013/marc_cornelissen.ad
+++ b/presets/watt_nu/2013/marc_cornelissen.ad
@@ -87,7 +87,6 @@
 - user_values.employment_local_fraction = 44.4
 - user_values.energy_steel_hisarna_transformation_coal_woodpellets_share = 12.0
 - user_values.gas_from_algeria_share = 0.0
-- user_values.gas_from_middle_east_share = 0.0
 - user_values.gas_from_nederlands_share = 74.074074
 - user_values.gas_from_norway_share = 12.962963
 - user_values.gas_from_russia_share = 12.962963


### PR DESCRIPTION
The FCE gas_from_middle_east is in fact not natural gas, but LNG (from Qatar). Since we already have a slider for the latter and make a distinction between pipeline natural gas and liquefied natural gas, we decide to delete this share in https://github.com/quintel/etmodel/issues/1953. In this PR, the FCE gas_from_middle_east_share is removed from ETSource.