### PR TITLE
Removed biofootprint from energy_production_woody_biomass (this node …

### DIFF
--- a/nodes/energy/energy_production_woody_biomass.ad
+++ b/nodes/energy/energy_production_woody_biomass.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [bio_footprint_calculation, mining_and_extraction, primary_energy_demand]
+- groups = [mining_and_extraction, primary_energy_demand]
 - free_co2_factor = 0.0


### PR DESCRIPTION
…should not contribute to the biofootprint)

Fixes https://github.com/quintel/etsource/issues/972

@AlexanderWirtz why should energy_production_woody_biomass not contribute to the bio-footprint again?