### PR TITLE
Hydrogen gqueries and new hydrogen production chart 169

### DIFF
--- a/edges/transport/transport_final_demand_for_road_hydrogen-transport_car_using_hydrogen@hydrogen.ad
+++ b/edges/transport/transport_final_demand_for_road_hydrogen-transport_car_using_hydrogen@hydrogen.ad
@@ -1,2 +1,3 @@
 - type = share
 - reversed = false
+- groups = [final_demand]

--- a/gqueries/general/carrier_groups/all_carriers/carrier_group_hydrogen.gql
+++ b/gqueries/general/carrier_groups/all_carriers/carrier_group_hydrogen.gql
@@ -1,0 +1,4 @@
+# Carrier group of hydrogen
+
+- query = CARRIER(hydrogen)
+- unit =

--- a/gqueries/general/carrier_groups/final_demand/final_demand_carrier_group_hydrogen.gql
+++ b/gqueries/general/carrier_groups/final_demand/final_demand_carrier_group_hydrogen.gql
@@ -1,0 +1,7 @@
+# Carrier group of 'hydrogen'
+
+- unit = PJ
+- query =
+    CARRIER(
+      hydrogen
+    )

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_agriculture.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in agriculture
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_buildings.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in buildings
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_energy.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in energy
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_households.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in households
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_industry.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in industry
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_other.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in other
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_transport.gql
@@ -1,0 +1,7 @@
+# CO2 of carrier group 'hydrogen' in transport
+
+- unit = tonne
+- query =
+    SUM(
+      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+    ) / THOUSANDS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_agriculture.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_agriculture.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :agriculture"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_buildings.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_buildings.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :buildings"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_energy.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_energy.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :energy"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_households.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_households.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :households"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_industry.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_industry.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :industry"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_other.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_other.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :other"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_transport.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_hydrogen_in_transport.gql
@@ -1,0 +1,15 @@
+# Final demand of the 'hydrogen' carrier group
+
+- unit = PJ
+- query =
+    SUM(
+      V(
+        FILTER(
+          FILTER(
+            LG(final_demand),"sector == :transport"
+          ),
+          hydrogen?
+        ),
+        value
+      )
+    ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/hydrogen_cars_in_use_of_final_demand_in_transport.gql
+++ b/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/hydrogen_cars_in_use_of_final_demand_in_transport.gql
@@ -1,0 +1,6 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      V(transport_car_using_hydrogen,final_demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_agriculture_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_agriculture_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and agriculture
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),"input_of_hydrogen")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_buildings_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_buildings_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and buildings
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(buildings),G(final_demand_group)),"input_of_hydrogen")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_chps_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_chps_prod_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and chps
+
+- unit = PJ
+- query = DIVIDE(SUM(V(Q(heat_producing_converters_sankey), primary_demand_of(hydrogen))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_electricity_prod_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and electricity
+
+- unit = PJ
+- query = DIVIDE(SUM(V(Q(electricity_producing_converters_sankey), primary_demand_of(hydrogen))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_households_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_households_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and households
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(households),G(final_demand_group)),"input_of_hydrogen")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_industry_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_industry_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and industry
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(industry),G(final_demand_group)),"input_of_hydrogen")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_other_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_other_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and other
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(other),G(final_demand_group)),"input_of_hydrogen")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_to_transport_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen and transport
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(SECTOR(transport),G(final_demand_group)),"input_of_hydrogen")),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/biomass_gasification_ccs_in_hydrogen_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/biomass_gasification_ccs_in_hydrogen_production.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(energy_energy_biomass_gasification_ccs_hydrogen,output_of_hydrogen),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/biomass_gasification_in_hydrogen_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/biomass_gasification_in_hydrogen_production.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(energy_biomass_gasification_hydrogen,output_of_hydrogen),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/local_electrolysis_in_hydrogen_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/local_electrolysis_in_hydrogen_production.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(energy_local_electrolysis_hydrogen,output_of_hydrogen),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/steam_methane_reformer_ccs_in_hydrogen_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/steam_methane_reformer_ccs_in_hydrogen_production.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(energy_steam_methane_reformer_ccs_hydrogen,output_of_hydrogen),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/steam_methane_reformer_in_hydrogen_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_169_hydrogen_production/steam_methane_reformer_in_hydrogen_production.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(energy_steam_methane_reformer_hydrogen,output_of_hydrogen),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_43_use_of_transport_fuels/hydrogen_in_use_of_transport_fuels.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_43_use_of_transport_fuels/hydrogen_in_use_of_transport_fuels.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_hydrogen,demand),BILLIONS)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_fossil_hydrogen_in_renewability.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_fossil_hydrogen_in_renewability.gql
@@ -1,0 +1,12 @@
+# Percentage of final demand of hydrogen in renewability
+
+- unit = factor
+- query =
+    100 * SUM(
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), "(1.0 - sustainability_share) * supply_of_hydrogen")
+    ) / 
+    SUM(
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), demand),
+        Q(ambient_heat_pumped_by_heat_pumps),
+        Q(geothermal_own_use_in_sectors)
+    )

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_sustainable_hydrogen_in_renewability.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_49_renewability/final_demand_of_sustainable_hydrogen_in_renewability.gql
@@ -1,0 +1,12 @@
+# Percentage of sustainable part of final demand of hydrogen in renewability
+
+- unit = factor
+- query =
+    100 * SUM(
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_hydrogen")
+    ) / 
+    SUM(
+        V(INTERSECTION(G(final_demand_group),USE(energetic)), demand),
+        Q(ambient_heat_pumped_by_heat_pumps),
+        Q(geothermal_own_use_in_sectors)
+    )


### PR DESCRIPTION
Besides creating new carrier_groups for hydrogen, this PR adds hydrogen gqueries to the following charts

- 23 use of final demand in transport
- 43 use of transport fuels
- 49 renewability of final demand
- 123 sankey
- 146 final demand (MECE)
 - in order to have ETE pick up these gqueries , it was necessary to add a H2 final demand edge to the [final_demand] group
- 165 primary CO2 emissions of final demand
- 169 a new chart for hydrogen production

This 'should' be an exhaustive list of the charts hydrogen for transport needs to be part of; however, with the P2G implementation more gqueries will have to be added (a preliminary set of which I have locally).