### PR TITLE
Transport efficiency improvement input statements correction

### DIFF
--- a/inputs/demand/transport/transport_efficiency/transport_useful_demand_planes_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_useful_demand_planes_efficiency.ad
@@ -1,4 +1,4 @@
-- query = UPDATE(V(transport_useful_demand_planes), preset_demand, NEG(USER_INPUT()))
+- query = UPDATE( OUTPUT_SLOTS(V(transport_plane_using_bio_ethanol,transport_plane_using_gasoline,transport_plane_using_kerosene)), conversion, USER_INPUT())
 - priority = 0
 - max_value = 3.0
 - min_value = 0.0

--- a/inputs/demand/transport/transport_efficiency/transport_useful_demand_ships_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_useful_demand_ships_efficiency.ad
@@ -1,4 +1,4 @@
-- query = UPDATE(V(transport_useful_demand_ship_kms), preset_demand, NEG(USER_INPUT()))
+- query = UPDATE( OUTPUT_SLOTS(V(transport_ship_using_diesel_mix,transport_ship_using_lng_mix)), conversion, USER_INPUT())
 - priority = 0
 - max_value = 3.0
 - min_value = 0.0

--- a/inputs/demand/transport/transport_efficiency/transport_useful_demand_trains_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_useful_demand_trains_efficiency.ad
@@ -1,4 +1,4 @@
-- query = UPDATE(V(transport_useful_demand_trains), preset_demand, NEG(USER_INPUT()))
+- query = UPDATE( OUTPUT_SLOTS(V(transport_train_using_diesel,transport_train_using_electricity,transport_train_using_coal)), conversion, USER_INPUT())
 - priority = 0
 - max_value = 3.0
 - min_value = 0.0


### PR DESCRIPTION
Currently, the efficiency improvement sliders for trains, planes and ships do not behave as they should: they decrease the useful demand rather than improve the efficiency. This can be seen from the current statement on <a href="https://github.com/quintel/etsource/blob/master/inputs/demand/transport/transport_efficiency/transport_useful_demand_planes_efficiency.ad" >master</a>. This is the exact opposite of what happens 
in  the <a href="https://github.com/quintel/etsource/blob/master/inputs/demand/transport/transport_plane/transport_useful_demand_planes.ad" >mobility growth</a> input statement, where the useful demand is updated.

However, the fundamental point is here that efficiency improvement should not change the useful demand, i.e. in this case the kms driven. Efficiency improvements should ultimately change the demand of the specific technology converter, its output is still the same (i.e., the quantity required to meet the same useful demand). In other words, cars do not start driving more when their efficiencies increase - their fuel requirements are just smaller.

Cars and trucks already had correct efficiency improvement input statements.
