### PR TITLE
Removed unnecessary update queries for EVs for loss conversion

### DIFF
--- a/inputs/demand/transport/transport_efficiency/transport_car_using_electricity_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_car_using_electricity_efficiency.ad
@@ -1,8 +1,6 @@
 - query =
     EACH(
-     UPDATE( OUTPUT_SLOTS(V(transport_car_using_electricity),loss), conversion, USER_INPUT()),
      UPDATE( OUTPUT_SLOTS(V(transport_car_using_electricity),car_kms), conversion, USER_INPUT()),
-     UPDATE( OUTPUT_SLOTS(V(transport_truck_using_electricity),loss), conversion, USER_INPUT()),
      UPDATE( OUTPUT_SLOTS(V(transport_truck_using_electricity),truck_kms), conversion, USER_INPUT())
     )
 - priority = 0


### PR DESCRIPTION
As spotted by @jorisberkhout , the EV efficiency improvement input statement updates the loss output of `transport_car_using_electricity` and `transport_truck_using_electricity`. Since they have the attribute
``` 
output.loss = elastic
```

manipulating it with some numbers does not have any effect.