### PR TITLE
HHP insulation formula and input share fix, closes #1008

### DIFF
--- a/inputs/demand/households/households_misc/households_insulation_level_new_houses.ad
+++ b/inputs/demand/households/households_misc/households_insulation_level_new_houses.ad
@@ -4,13 +4,9 @@
 #  
 #  COP = 4.5;
 #
-# This is the efficiency of the gas part of the HHP   
-#    
-#   gas_efficiency = 1.067;
-#
 # This is the initial input.network_gas attribute of the HHP
 #    
-#    initial_fraction_gas_to_heatpump = 0.2;
+#    initial_fraction_gas_to_heatpump = 0.187441424554827;
 #
 # We assume the above fraction goes does to 0.0 in a reciprocal manner (w.r.t. the insulation level (R), as R(initial)/R(final)) for old and new houses separately. We would like this fraction to be in [0,1], hence we map it onto this interval.
 #The minimum value this insulation fraction can have is
@@ -35,13 +31,13 @@
 #
 # Note that we have mapped the insulation fraction for new houses onto [0,1] as well, with the latter number (the minimum isolation level) in fact of old houses [R_new(max), R_old(min_)]. In all fairness, it should be mapped onto [R_new(max), R_new(min)]. To do so we would multiply the insulation_fraction_new_houses with a scaling factor of R_old(R_new(min)). However, this causes a discontinuity and has therefore not been done (but will be improved soon).
 #
-# Here we take a weighted average of the insulation fractions for old and new houses (and add a very small number to make sure that we are not dividing by 0 if all houses are destroyed)
+# Here we take a weighted average of the insulation fractions for old and new houses (and make sure we don't divide by zero when all houses are demolished)
 #    
-#    insulation_fraction_weighted_average = (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses) + 0.0000000000000000001);
+#    insulation_fraction_weighted_average = IF(((INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses))==0), 1.0, (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_old_houses) + INPUT_VALUE(households_number_of_new_houses))); 
 #
 # In this linear formula we let the input.network_gas attribute go from its maximum value (initial_fraction, for `R_old_fin = R_old_min` and `R_new_fin = R_new_min`) to 0 (for `R_old_fin = R_old_max` and `R_new_fin = R_new_max`)) and compensate for the efficiency of the gas part of the HHP since we set the input of the converter
 #    
-#    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average)) / gas_efficiency;
+#    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average));
 #
 # Then we obtain for the new input shares
 #
@@ -58,8 +54,7 @@
 #      UPDATE(INPUT_SLOTS(V(households_space_heater_hybrid_heatpump_air_water_electricity), ambient_heat), conversion, input_conversion_ambient_heat)
 #    ) 
 #
-# This is the end of the explanation of the HHP related queries. TO DO: remove ugly +0.0000000000000000001 and have the query pick up the initial values automatically.
-
+# This is the end of the explanation of the HHP related queries. TO DO:have the query pick up the initial values automatically.
 - priority = 0
 - step_value = 0.1
 - max_value_gql = present:AREA(insulation_level_new_houses_max)
@@ -73,10 +68,8 @@
     saving_fraction = 1.0 - AREA(new_houses_insulation_constant_1) / (USER_INPUT() + AREA(new_houses_insulation_constant_2));
 
     COP = 4.5;
-    
-    gas_efficiency = 1.067;
 
-    initial_fraction_gas_to_heatpump = 0.2;
+    initial_fraction_gas_to_heatpump = 0.187441424554827;
 
     min_insulation_ratio_old_houses = QUERY_PRESENT(-> {AREA(insulation_level_old_houses_min) }) / QUERY_PRESENT(-> {AREA(insulation_level_old_houses_max) });
 
@@ -90,9 +83,9 @@
 
     insulation_fraction_new_houses = (((QUERY_PRESENT(-> {AREA(insulation_level_new_houses_min) }) / USER_INPUT()) - min_insulation_ratio_new_houses) / scaling_factor_new_houses); 
 
-    insulation_fraction_weighted_average = (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses) + 0.0000000000000000001);
+    insulation_fraction_weighted_average = IF(((INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses))==0), 1.0, (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_old_houses) + INPUT_VALUE(households_number_of_new_houses))); 
 
-    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average)) / gas_efficiency;
+    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average));
 
     input_conversion_network_gas = fraction_gas_to_heatpump;
     input_conversion_electricity = (1.0 - fraction_gas_to_heatpump) * 1.0 / COP;

--- a/inputs/demand/households/households_misc/households_insulation_level_old_houses.ad
+++ b/inputs/demand/households/households_misc/households_insulation_level_old_houses.ad
@@ -4,13 +4,9 @@
 #  
 #  COP = 4.5;
 #
-# This is the efficiency of the gas part of the HHP   
-#    
-#   gas_efficiency = 1.067;
-#
 # This is the initial input.network_gas attribute of the HHP
 #    
-#    initial_fraction_gas_to_heatpump = 0.2;
+#    initial_fraction_gas_to_heatpump = 0.187441424554827;
 #
 # We assume the above fraction goes does to 0.0 in a reciprocal manner (w.r.t. the insulation level (R), as R(initial)/R(final)) for old and new houses separately. We would like this fraction to be in [0,1], hence we map it onto this interval.
 #The minimum value this insulation fraction can have is
@@ -35,13 +31,13 @@
 #
 # Note that we have mapped the insulation fraction for new houses onto [0,1] as well, with the latter number (the minimum isolation level) in fact of old houses [R_new(max), R_old(min_)]. In all fairness, it should be mapped onto [R_new(max), R_new(min)]. To do so we would multiply the insulation_fraction_new_houses with a scaling factor of R_old(R_new(min)). However, this causes a discontinuity and has therefore not been done (but will be improved soon).
 #
-# Here we take a weighted average of the insulation fractions for old and new houses (and add a very small number to make sure that we are not dividing by 0 if all houses are destroyed)
+#     Here we take a weighted average of the insulation fractions for old and new houses (and make sure we don't divide by zero when all houses are demolished)
 #    
-#    insulation_fraction_weighted_average = (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses) + 0.0000000000000000001);
+#    insulation_fraction_weighted_average = IF(((INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses))==0), 1.0, (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_old_houses) + INPUT_VALUE(households_number_of_new_houses))); 
 #
 # In this linear formula we let the input.network_gas attribute go from its maximum value (initial_fraction, for `R_old_fin = R_old_min` and `R_new_fin = R_new_min`) to 0 (for `R_old_fin = R_old_max` and `R_new_fin = R_new_max`)) and compensate for the efficiency of the gas part of the HHP since we set the input of the converter
 #    
-#    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average)) / gas_efficiency;
+#    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average));
 #
 # Then we obtain for the new input shares
 #
@@ -58,7 +54,7 @@
 #      UPDATE(INPUT_SLOTS(V(households_space_heater_hybrid_heatpump_air_water_electricity), ambient_heat), conversion, input_conversion_ambient_heat)
 #    ) 
 #
-# This is the end of the explanation of the HHP related queries. TO DO: remove ugly +0.0000000000000000001 and have the query pick up the initial values automatically.
+# This is the end of the explanation of the HHP related queries. TO DO: have the query pick up the initial values automatically.
 
 - priority = 0
 - step_value = 0.1
@@ -74,9 +70,7 @@
 
  	  COP = 4.5;
 
-    gas_efficiency = 1.067;
-
-    initial_fraction_gas_to_heatpump = 0.2;
+    initial_fraction_gas_to_heatpump = 0.187441424554827;
 
     min_insulation_ratio_old_houses = QUERY_PRESENT(-> {AREA(insulation_level_old_houses_min) }) / QUERY_PRESENT(-> {AREA(insulation_level_old_houses_max) });
 
@@ -90,9 +84,9 @@
 
     insulation_fraction_new_houses = (((QUERY_PRESENT(-> {AREA(insulation_level_new_houses_min) }) / INPUT_VALUE(households_insulation_level_new_houses)) - min_insulation_ratio_new_houses) / scaling_factor_new_houses); 
 
-    insulation_fraction_weighted_average = (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses) + 0.0000000000000000001);
+    insulation_fraction_weighted_average = IF(((INPUT_VALUE(households_number_of_new_houses) + INPUT_VALUE(households_number_of_old_houses))==0), 1.0, (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_old_houses) + INPUT_VALUE(households_number_of_new_houses)));
 
-    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average)) / gas_efficiency;
+    fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average));
 
     input_conversion_network_gas = fraction_gas_to_heatpump;
     input_conversion_electricity = (1.0 - fraction_gas_to_heatpump) * 1.0 / COP;

--- a/inputs/demand/households/households_misc/households_number_of_new_houses.ad
+++ b/inputs/demand/households/households_misc/households_number_of_new_houses.ad
@@ -7,10 +7,8 @@
   total_cost = cost_per_new_house * USER_INPUT() * 1_000_000;
 
   COP = 4.5;
-    
-  gas_efficiency = 1.067;
 
-  initial_fraction_gas_to_heatpump = 0.2;
+  initial_fraction_gas_to_heatpump = 0.187441424554827;
 
   min_insulation_ratio_old_houses = QUERY_PRESENT(-> {AREA(insulation_level_old_houses_min) }) / QUERY_PRESENT(-> {AREA(insulation_level_old_houses_max) });
 
@@ -24,9 +22,9 @@
 
   insulation_fraction_new_houses = (((QUERY_PRESENT(-> {AREA(insulation_level_new_houses_min) }) / INPUT_VALUE(households_insulation_level_new_houses)) - min_insulation_ratio_new_houses) / scaling_factor_new_houses); 
 
-  insulation_fraction_weighted_average = (insulation_fraction_new_houses * USER_INPUT() + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_old_houses) + USER_INPUT() + 0.0000000000000000001);
+  insulation_fraction_weighted_average = IF(((USER_INPUT() + INPUT_VALUE(households_number_of_old_houses))==0), 1.0, (insulation_fraction_new_houses * USER_INPUT() + insulation_fraction_old_houses * INPUT_VALUE(households_number_of_old_houses)) / (INPUT_VALUE(households_number_of_old_houses) + USER_INPUT()));
 
-  fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average)) / gas_efficiency;
+  fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average));
 
   input_conversion_network_gas = fraction_gas_to_heatpump;
   input_conversion_electricity = (1.0 - fraction_gas_to_heatpump) * 1.0 / COP;

--- a/inputs/demand/households/households_misc/households_number_of_old_houses.ad
+++ b/inputs/demand/households/households_misc/households_number_of_old_houses.ad
@@ -7,10 +7,8 @@
   total_cost = cost_per_old_house * USER_INPUT() * 1_000_000;
 
   COP = 4.5;
-    
-  gas_efficiency = 1.067;
 
-  initial_fraction_gas_to_heatpump = 0.2;
+  initial_fraction_gas_to_heatpump = 0.187441424554827;
 
   min_insulation_ratio_old_houses = QUERY_PRESENT(-> {AREA(insulation_level_old_houses_min) }) / QUERY_PRESENT(-> {AREA(insulation_level_old_houses_max) });
 
@@ -24,9 +22,9 @@
 
   insulation_fraction_new_houses = (((QUERY_PRESENT(-> {AREA(insulation_level_new_houses_min) }) / INPUT_VALUE(households_insulation_level_new_houses)) - min_insulation_ratio_new_houses) / scaling_factor_new_houses); 
 
-  insulation_fraction_weighted_average = (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * USER_INPUT()) / (INPUT_VALUE(households_number_of_new_houses) + USER_INPUT() + 0.0000000000000000001);
+  insulation_fraction_weighted_average = IF(((INPUT_VALUE(households_number_of_new_houses) + USER_INPUT())==0), 1.0, (insulation_fraction_new_houses * INPUT_VALUE(households_number_of_new_houses) + insulation_fraction_old_houses * USER_INPUT()) / (INPUT_VALUE(households_number_of_new_houses) + USER_INPUT()));
 
-  fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average)) / gas_efficiency;
+  fraction_gas_to_heatpump = (initial_fraction_gas_to_heatpump - initial_fraction_gas_to_heatpump * (1 - insulation_fraction_weighted_average));
 
   input_conversion_network_gas = fraction_gas_to_heatpump;
   input_conversion_electricity = (1.0 - fraction_gas_to_heatpump) * 1.0 / COP;

--- a/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -1,11 +1,13 @@
 - use = energetic
 - energy_balance_group = technologies
-- input.ambient_heat = 0.622222222222222
-- input.electricity = 0.177777777777778
-- input.network_gas = 0.2
+- input.ambient_heat = 0.631990003124024
+- input.electricity = 0.18056857232115
+- input.network_gas = 0.187441424554827
 - output.cooling = 0.0
 - output.loss = elastic
-- output.useable_heat = 1.067
+- output.useable_heat.ambient_heat = 1
+- output.useable_heat.electricity = 1
+- output.useable_heat.network_gas = 1.067
 - groups = [cost_heat_pumps, demand_driven, heat_production]
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -1,11 +1,13 @@
 - use = energetic
 - energy_balance_group = technologies
-- input.ambient_heat = 0.466666666666667
-- input.electricity = 0.233333333333333
-- input.network_gas = 0.3
+- input.ambient_heat = 0.444444444444445
+- input.electricity = 0.222222222222222
+- input.network_gas = 0.333333333333333
 - output.cooling = 0.0
 - output.loss = elastic
-- output.useable_heat = 0.9
+- output.useable_heat.ambient_heat = 1
+- output.useable_heat.electricity = 1
+- output.useable_heat.network_gas = 0.9
 - groups = [cost_heat_pumps, demand_driven, heat_production]
 - availability = 0.0
 - free_co2_factor = 0.0


### PR DESCRIPTION
This PR fixes some bugs:

- previously, the HHP insulation formula had a discontinuity since it divided a quantity mapped on [0,1] by  the efficiency of the gas part of the HHP. Now, we no longer divide by this and the mapping is continuous and smooth.
- previously, the HHP insulation formula had a fudge factor, this PR replaces it with an IF-statement and closes #1008 
- previously, the input.network_gas attribute of the HHP was in fact the share of heat output delivered by the gas part of the HHP. Now we divide by the gas_efficiency to obtain the correct input.network_gas.