### PR TITLE
Added typical_input_capacity attribute to all hydrogen production converters

### DIFF
--- a/nodes/energy/energy_biomass_gasification_ccs_hydrogen.ad
+++ b/nodes/energy/energy_biomass_gasification_ccs_hydrogen.ad
@@ -12,6 +12,7 @@
 - full_load_hours = 7884.0
 - land_use_per_unit = 0.202343
 - takes_part_in_ets = 1.0
+- typical_input_capacity = 481.663452794312
 - initial_investment = 144005991.803279
 - ccs_investment = 88119813.2969035
 - cost_of_installing = 0.0

--- a/nodes/energy/energy_biomass_gasification_hydrogen.ad
+++ b/nodes/energy/energy_biomass_gasification_hydrogen.ad
@@ -12,6 +12,7 @@
 - full_load_hours = 7884.0
 - land_use_per_unit = 0.202343
 - takes_part_in_ets = 1.0
+- typical_input_capacity = 468.080752390134
 - initial_investment = 144005991.803279
 - ccs_investment = 0.0
 - cost_of_installing = 0.0

--- a/nodes/energy/energy_compressor_hydrogen.ad
+++ b/nodes/energy/energy_compressor_hydrogen.ad
@@ -11,6 +11,7 @@
 - full_load_hours = 6570.0
 - land_use_per_unit = 1.134e-05
 - takes_part_in_ets = 0.0
+- typical_input_capacity = 1.12093333333333
 - initial_investment = 159375.891840152
 - ccs_investment = 0.0
 - cost_of_installing = 0.0

--- a/nodes/energy/energy_local_electrolysis_hydrogen.ad
+++ b/nodes/energy/energy_local_electrolysis_hydrogen.ad
@@ -12,6 +12,7 @@
 - full_load_hours = 7533.6
 - land_use_per_unit = 2.1306e-05
 - takes_part_in_ets = 0.0
+- typical_input_capacity = 0.739583333333333
 - initial_investment = 493466.435161111
 - ccs_investment = 0.0
 - cost_of_installing = 0.0

--- a/nodes/energy/energy_steam_methane_reformer_ccs_hydrogen.ad
+++ b/nodes/energy/energy_steam_methane_reformer_ccs_hydrogen.ad
@@ -11,6 +11,7 @@
 - full_load_hours = 7500.0
 - land_use_per_unit = 0.0323558161449898
 - takes_part_in_ets = 1.0
+- typical_input_capacity = 513.021323760201
 - initial_investment = 160000000.0
 - ccs_investment = 106508725.865209
 - cost_of_installing = 0.0

--- a/nodes/energy/energy_steam_methane_reformer_hydrogen.ad
+++ b/nodes/energy/energy_steam_methane_reformer_hydrogen.ad
@@ -11,6 +11,7 @@
 - full_load_hours = 7500.0
 - land_use_per_unit = 0.0323558161449898
 - takes_part_in_ets = 1.0
+- typical_input_capacity = 504.470968364198
 - initial_investment = 160000000.0
 - ccs_investment = 0.0
 - cost_of_installing = 0.0


### PR DESCRIPTION
 based on quintel/etdataset@cf4798cf3bebe0662937400b05ed2c1766d90cc1

For more information, see https://github.com/quintel/etdataset/pull/664 . This makes the `number_of_units` calculation functional for all hydrogen production technologies.