### PR TITLE
Fix input present

### DIFF
--- a/inputs/adjust_scaling/households_space_heater_combined_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/households_space_heater_combined_network_gas_share_present.ad
@@ -1,4 +1,4 @@
-- query = UPDATE(LINK(households_space_heater_combined_network_gas,households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on), share, DIVIDE(USER_INPUT(),100))
+- query = UPDATE(LINK(households_space_heater_combined_network_gas,households_useful_demand_for_space_heating_after_insulation_and_solar_heater), share, DIVIDE(USER_INPUT(),100))
 - share_group = heating_households_present
 - priority = 0
 - max_value = 100.0

--- a/inputs/adjust_scaling/households_space_heater_combined_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/households_space_heater_combined_network_gas_share_present.ad
@@ -3,7 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_combined_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
+- start_value_gql = present:V(households_space_heater_combined_network_gas,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater) * 100
 - step_value = 0.1
 - unit = %
 - update_period = present

--- a/inputs/adjust_scaling/households_space_heater_wood_pellets_share_present.ad
+++ b/inputs/adjust_scaling/households_space_heater_wood_pellets_share_present.ad
@@ -1,4 +1,4 @@
-- query = UPDATE(LINK(households_space_heater_wood_pellets,households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on), share, DIVIDE(USER_INPUT(),100))
+- query = UPDATE(LINK(households_space_heater_wood_pellets,households_useful_demand_for_space_heating_after_insulation_and_solar_heater), share, DIVIDE(USER_INPUT(),100))
 - share_group = heating_households_present
 - priority = 0
 - max_value = 100.0

--- a/inputs/adjust_scaling/households_space_heater_wood_pellets_share_present.ad
+++ b/inputs/adjust_scaling/households_space_heater_wood_pellets_share_present.ad
@@ -3,7 +3,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = present:V(households_space_heater_wood_pellets,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater_and_add_on) * 100
+- start_value_gql = present:V(households_space_heater_wood_pellets,share_of_households_useful_demand_for_space_heating_after_insulation_and_solar_heater) * 100
 - step_value = 0.1
 - unit = %
 - update_period = present


### PR DESCRIPTION
The input statements in `adjust_scaling` had not been updated after the removal of the add-on heat pump. This fixes that.

````
inputs/adjust_scaling/households_space_heater_combined_network_gas_share_present.ad
inputs/adjust_scaling/households_space_heater_wood_pellets_share_present.ad
````
