### PR TITLE
Added queries necessary for HHP mech_turk tests

### DIFF
--- a/gqueries/mechanical_turk/demand/turk_hhp_ambient_heat_input_share.gql
+++ b/gqueries/mechanical_turk/demand/turk_hhp_ambient_heat_input_share.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_heatpump_air_water_electricity, ambient_heat_input_conversion)
+- unit = 

--- a/gqueries/mechanical_turk/demand/turk_hhp_cop_constant.gql
+++ b/gqueries/mechanical_turk/demand/turk_hhp_cop_constant.gql
@@ -1,0 +1,5 @@
+- query = 
+   SUM(V(households_space_heater_hybrid_heatpump_air_water_electricity, ambient_heat_input_conversion),
+   V(households_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion)
+   ) / V(households_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion)
+- unit = 

--- a/gqueries/mechanical_turk/demand/turk_hhp_electricity_input_share.gql
+++ b/gqueries/mechanical_turk/demand/turk_hhp_electricity_input_share.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion)
+- unit = 

--- a/gqueries/mechanical_turk/demand/turk_hhp_network_gas_input_share.gql
+++ b/gqueries/mechanical_turk/demand/turk_hhp_network_gas_input_share.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_heatpump_air_water_electricity, network_gas_input_conversion)
+- unit = 


### PR DESCRIPTION
Gqueries necessary for new `mech_turk` tests for hybrid heatpumps added in https://github.com/quintel/mechanical_turk/pull/80 .