### PR TITLE
Replaced energy_power_ultra_supercritical_coal_demand with energy_power_supercritical_coal_demand

### DIFF
--- a/gqueries/mechanical_turk/merit_order/energy_power_supercritical_coal_demand.gql
+++ b/gqueries/mechanical_turk/merit_order/energy_power_supercritical_coal_demand.gql
@@ -1,0 +1,4 @@
+# Demand of energy_power_supercritical_coal_demand
+
+- unit = MJ
+- query = V(energy_power_supercritical_coal,demand)

--- a/gqueries/mechanical_turk/merit_order/energy_power_ultra_supercritical_coal_demand.gql
+++ b/gqueries/mechanical_turk/merit_order/energy_power_ultra_supercritical_coal_demand.gql
@@ -1,4 +1,0 @@
-# Demand of energy_power_ultra_supercritical_coal
-
-- unit = MJ
-- query = V(energy_power_ultra_supercritical_coal,demand)


### PR DESCRIPTION
 for mech_turk merit order test, line 130.