### PR TITLE
Restored previously deleted mech_turk query which was used in multiple tests

### DIFF
--- a/gqueries/mechanical_turk/merit_order/energy_power_ultra_supercritical_coal_demand.gql
+++ b/gqueries/mechanical_turk/merit_order/energy_power_ultra_supercritical_coal_demand.gql
@@ -1,0 +1,4 @@
+# Demand of energy_power_ultra_supercritical_coal_demand
+
+- unit = MJ
+- query = V(energy_power_ultra_supercritical_coal,demand)


### PR DESCRIPTION
The `energy_power_ultra_supercritical_coal_demand` mech_turk query was replaced with `energy_power_supercritical_coal_demand` in quintel/etsource@449ad3c04103fc3dc7e630491322d08f61e7a4 . However, it was used in multiple mech_turk tests, so this PR restores it.