### PR TITLE
Allow P2H energy to flow into useful demand node

### DIFF
--- a/edges/households/households_flexibility_p2h_electricity-households_useful_demand_for_hot_water_for_houses_with_p2h@useable_heat.ad
+++ b/edges/households/households_flexibility_p2h_electricity-households_useful_demand_for_hot_water_for_houses_with_p2h@useable_heat.ad
@@ -1,4 +1,4 @@
 - type = share
-- reversed = false
+- reversed = true
 
 ~ child_share = SHARE(residences_useful_demand_for_hot_water_for_houses_with_p2h_child_share, households_flexibility_p2h_electricity)

--- a/edges/households/households_useful_demand_for_hot_water_after_solar_heater_and_p2h-households_useful_demand_for_hot_water_for_houses_with_p2h@useable_heat.ad
+++ b/edges/households/households_useful_demand_for_hot_water_after_solar_heater_and_p2h-households_useful_demand_for_hot_water_for_houses_with_p2h@useable_heat.ad
@@ -1,4 +1,4 @@
-- type = share
+- type = flexible
 - reversed = false
 
 ~ child_share = SHARE(residences_useful_demand_for_hot_water_for_houses_with_p2h_child_share, households_useful_demand_for_hot_water_after_solar_heater_and_p2h)


### PR DESCRIPTION
### Merit order off

##### 0% P2H

<img width="766" alt="mo-off-0" src="https://cloud.githubusercontent.com/assets/4383/12893806/3b3c6fe6-ce8b-11e5-9880-71815ad0086e.png">

##### 100% P2H

<img width="763" alt="mo-off" src="https://cloud.githubusercontent.com/assets/4383/12893724/b780f780-ce8a-11e5-896f-c81660359082.png">

### Merit order on

##### 0% P2H

<img width="761" alt="0-pct" src="https://cloud.githubusercontent.com/assets/4383/12893729/c180b90a-ce8a-11e5-820a-89588207c908.png">

##### 50% P2H

<img width="762" alt="50-pct" src="https://cloud.githubusercontent.com/assets/4383/12893732/c6ceab74-ce8a-11e5-9d3a-e945194b412d.png">

##### 100% P2H

<img width="763" alt="100-pct" src="https://cloud.githubusercontent.com/assets/4383/12893743/d607e1e6-ce8a-11e5-83dd-b260222a4fa1.png">

--

Closes quintel/etmodel#2032