### PR TITLE
Prevent double counting output losses in storage

### DIFF
--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_curtailment_electricity_usage_twh.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_curtailment_electricity_usage_twh.gql
@@ -1,2 +1,2 @@
-- query = V(energy_flexibility_curtailment_electricity, demand) / MJ_PER_MWH / MILLIONS
+- query = Q(energy_curtailment_electricity_demand) / MJ_PER_MWH * 1000
 - unit = MWh

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_export_electricity_usage_twh.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_export_electricity_usage_twh.gql
@@ -1,2 +1,2 @@
-- query = V(energy_export_electricity, demand) / MJ_PER_MWH / MILLIONS
+- query = Q(energy_export_electricity_demand) / MJ_PER_MWH * 1000
 - unit = TWh

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_p2g_electricity_demand.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_p2g_electricity_demand.gql
@@ -1,2 +1,2 @@
-- query = V(energy_flexibility_p2g_electricity, demand) / BILLIONS
+- query = V(energy_flexibility_p2g_electricity, "hydrogen_output_conversion * demand") / BILLIONS
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_p2g_electricity_usage_twh.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_p2g_electricity_usage_twh.gql
@@ -1,2 +1,2 @@
-- query = V(energy_flexibility_p2g_electricity, demand) / MJ_PER_MWH / MILLIONS
+- query = Q(energy_flexibility_p2g_electricity_demand) / MJ_PER_MWH * 1000
 - unit = TWh

--- a/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2h_electricity_demand.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2h_electricity_demand.gql
@@ -1,2 +1,2 @@
-- query = V(households_flexibility_p2h_electricity, demand) / BILLIONS
+- query = V(households_flexibility_p2h_electricity, "useable_heat_output_conversion * demand") / BILLIONS
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2h_electricity_usage_twh.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2h_electricity_usage_twh.gql
@@ -1,2 +1,2 @@
-- query = V(households_flexibility_p2h_electricity, demand) / MJ_PER_MWH / MILLIONS
+- query = Q(households_flexibility_p2h_electricity_demand) / MJ_PER_MWH * 1000
 - unit = MWh

--- a/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2p_electricity_demand.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2p_electricity_demand.gql
@@ -1,2 +1,2 @@
-- query = V(households_flexibility_p2p_electricity, demand) / BILLIONS
+- query = V(households_flexibility_p2p_electricity, "electricity_output_conversion * demand") / BILLIONS
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2p_electricity_usage_twh.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2p_electricity_usage_twh.gql
@@ -1,2 +1,2 @@
-- query = V(households_flexibility_p2p_electricity, demand) / MJ_PER_MWH / MILLIONS
+- query = Q(households_flexibility_p2p_electricity_demand ) / MJ_PER_MWH * 1000
 - unit = MWh

--- a/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_demand.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_demand.gql
@@ -1,2 +1,2 @@
-- query = V(transport_car_flexibility_p2p_electricity, demand) / BILLIONS
+- query = V(transport_car_flexibility_p2p_electricity, "electricity_output_conversion * demand") / BILLIONS
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_usage_twh.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_usage_twh.gql
@@ -1,2 +1,2 @@
-- query = V(transport_car_flexibility_p2p_electricity, demand) / MJ_PER_MWH / MILLIONS
+- query = Q(transport_car_using_electricity_demand) / MJ_PER_MWH * 1000
 - unit = MWh

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_converted_to_gas.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_converted_to_gas.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = V(energy_flexibility_p2g_electricity, demand) / BILLIONS
+- query = V(energy_flexibility_p2g_electricity, "hydrogen_output_conversion * demand") / BILLIONS

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_converted_to_heat.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_converted_to_heat.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = V(households_flexibility_p2h_electricity, demand) / BILLIONS
+- query = V(households_flexibility_p2h_electricity, "useable_heat_output_conversion * demand") / BILLIONS

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_stored_in_EV.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_stored_in_EV.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = V(transport_car_flexibility_p2p_electricity, demand) / BILLIONS
+- query = V(transport_car_flexibility_p2p_electricity, "electricity_output_conversion * demand") / BILLIONS

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_stored_in_batteries.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_stored_in_batteries.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = V(households_flexibility_p2p_electricity, demand) / BILLIONS
+- query = V(households_flexibility_p2p_electricity, "electricity_output_conversion * demand ") / BILLIONS


### PR DESCRIPTION
Ref quintel/etmodel#2070

Storage loss queries account for the input and output losses of storage technologies. Demand queries were querying the `demand` of the storage converters, which is the amount of energy after input loss, but *before* output loss. Therefore, output losses were being counted twice.

This PR changes the queries to show the amount of storage energy *after* all loss has been subtracted.