### PR TITLE
GLD Scenario V2 required inputs for adjust scaling

### DIFF
--- a/inputs/adjust_scaling/buildings/buildings_useful_demand_appliances_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_useful_demand_appliances_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(buildings_useful_demand_for_appliances), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/buildings/buildings_useful_demand_light_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_useful_demand_light_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(buildings_useful_demand_light), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/households/households_useful_demand_cooking_per_person_both.ad
+++ b/inputs/adjust_scaling/households/households_useful_demand_cooking_per_person_both.ad
@@ -1,0 +1,12 @@
+- query =
+    UPDATE(
+      V(households_useful_demand_cooking_useable_heat), preset_demand, USER_INPUT()
+    )
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/households/households_useful_demand_hot_water_both.ad
+++ b/inputs/adjust_scaling/households/households_useful_demand_hot_water_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(households_useful_demand_hot_water), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/households/households_useful_demand_lighting_both.ad
+++ b/inputs/adjust_scaling/households/households_useful_demand_lighting_both.ad
@@ -1,0 +1,12 @@
+- query =
+    UPDATE(
+      V(households_useful_demand_light), preset_demand, USER_INPUT()
+    )
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_aluminium_production_both.ad
+++ b/inputs/adjust_scaling/industry/industry_aluminium_production_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_aluminium_production), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_steel_production_both.ad
+++ b/inputs/adjust_scaling/industry/industry_steel_production_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_steel_production), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_crude_oil_non_energetic_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_crude_oil_non_energetic_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_for_chemical_crude_oil_non_energetic), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_electricity_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_electricity_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_for_chemical_electricity), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 10.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_network_gas_non_energetic_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_network_gas_non_energetic_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_for_chemical_network_gas_non_energetic), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_other_non_energetic_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_other_non_energetic_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_for_chemical_coal_non_energetic,industry_useful_demand_for_chemical_wood_pellets_non_energetic), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_useable_heat_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_chemical_useable_heat_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_for_chemical_useable_heat), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_other_crude_oil_non_energetic_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_other_crude_oil_non_energetic_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_crude_oil_non_energetic), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_other_electricity_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_other_electricity_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_electricity), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 10.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_other_network_gas_non_energetic_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_other_network_gas_non_energetic_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_network_gas_non_energetic,industry_useful_demand_coal_non_energetic,industry_useful_demand_wood_pellets_non_energetic), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y

--- a/inputs/adjust_scaling/industry/industry_useful_demand_for_other_useable_heat_both.ad
+++ b/inputs/adjust_scaling/industry/industry_useful_demand_for_other_useable_heat_both.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(industry_useful_demand_useable_heat), preset_demand, USER_INPUT())
+- priority = 10
+- max_value = 5.0
+- min_value = -5.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = both
+- update_type = %y


### PR DESCRIPTION
This PR contains several input statements necessary for version 2 of the GLD scaled scenario with priority 10 for `update_period = both`.

In addition, I created a `buildings_useful_demand_light_both` and `buildings_useful_demand_appliances_both` input statement, to make it possible to tweak these UDs independently, as the current `buildings_useful_demand_electricity_both` updates both lighting and appliances demand (the latter also including carriers _other than_ electricity). If that poses a significant discrepancy, I will make some `buildings_final_demand_for_appliances_[CARRIER]` inputs later to deal with the last point.