### PR TITLE
GLD V4 required inputs for scaling.

### DIFF
--- a/inputs/adjust_scaling/industry/industry_burner_coal_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_burner_coal_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_burner_coal,industry_useful_demand_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_useable_heat,industry_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = ind_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 5.5
+- start_value_gql = present:V(industry_burner_coal,share_of_industry_useful_demand_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_burner_crude_oil_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_burner_crude_oil_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_burner_crude_oil,industry_useful_demand_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_useable_heat,industry_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = ind_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 24.5
+- start_value_gql = present:V(industry_burner_crude_oil,share_of_industry_useful_demand_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_burner_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_burner_network_gas_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_burner_network_gas,industry_useful_demand_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_useable_heat,industry_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = ind_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 42.5
+- start_value_gql = present:V(industry_burner_network_gas,share_of_industry_useful_demand_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_burner_wood_pellets_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_burner_wood_pellets_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_burner_wood_pellets,industry_useful_demand_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_useable_heat,industry_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = ind_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 3.5
+- start_value_gql = present:V(industry_burner_wood_pellets,share_of_industry_useful_demand_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_chemicals_burner_coal_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_chemicals_burner_coal_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_chemicals_burner_coal,industry_useful_demand_for_chemical_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_for_chemical_useable_heat,industry_chemicals_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_for_chemical_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = chemical_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 5.5
+- start_value_gql = present:V(industry_chemicals_burner_coal,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_chemicals_burner_crude_oil_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_chemicals_burner_crude_oil_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_chemicals_burner_crude_oil,industry_useful_demand_for_chemical_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_for_chemical_useable_heat,industry_chemicals_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_for_chemical_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = chemical_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 24.5
+- start_value_gql = present:V(industry_chemicals_burner_crude_oil,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_chemicals_burner_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_chemicals_burner_network_gas_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_chemicals_burner_network_gas,industry_useful_demand_for_chemical_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_for_chemical_useable_heat,industry_chemicals_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_for_chemical_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = chemical_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 42.5
+- start_value_gql = present:V(industry_chemicals_burner_network_gas,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_chemicals_burner_wood_pellets_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_chemicals_burner_wood_pellets_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_chemicals_burner_wood_pellets,industry_useful_demand_for_chemical_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_for_chemical_useable_heat,industry_chemicals_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_for_chemical_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = chemical_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 3.5
+- start_value_gql = present:V(industry_chemicals_burner_wood_pellets,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_final_demand_for_chemical_steam_hot_water_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_final_demand_for_chemical_steam_hot_water_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_final_demand_for_chemical_steam_hot_water,industry_useful_demand_for_chemical_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_for_chemical_useable_heat,industry_chemicals_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_for_chemical_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = chemical_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 3.5
+- start_value_gql = future:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/industry_final_demand_steam_hot_water_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_final_demand_steam_hot_water_share_present.ad
@@ -1,0 +1,16 @@
+- query =
+    EACH(
+      UPDATE(LINK(industry_final_demand_for_heat_steam_hot_water,industry_useful_demand_useable_heat), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(industry_useful_demand_useable_heat,industry_burner_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(industry_useful_demand_useable_heat)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = ind_heat_present
+- priority = 1
+- max_value = 100.0
+- min_value = 0.0
+- start_value = 3.5
+- start_value_gql = future:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat) * 100
+- step_value = 0.1
+- unit = %
+- update_period = present

--- a/inputs/adjust_scaling/industry/number_of_industry_chp_combined_cycle_gas_power_fuelmix_present.ad
+++ b/inputs/adjust_scaling/industry/number_of_industry_chp_combined_cycle_gas_power_fuelmix_present.ad
@@ -1,0 +1,17 @@
+# The max value is dynamically determined by how many CHPs would be build if all of the electricity demand would be supplied by this specific CHP.
+#
+# The max value field is taken from the Excel model, but is overrided by the dynamic field, so not used.
+
+- query =
+    EACH(
+      UPDATE(V(industry_chp_combined_cycle_gas_power_fuelmix), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(industry_chp_combined_cycle_gas_power_fuelmix),constant), share, V(industry_chp_combined_cycle_gas_power_fuelmix, production_based_on_number_of_units)),
+    )
+- priority = 1
+- max_value = 30500.0
+- max_value_gql = future:MAX(1.0,DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_combined_cycle_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit)))
+- min_value = 0.0
+- start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/industry/number_of_industry_chp_engine_gas_power_fuelmix_present.ad
+++ b/inputs/adjust_scaling/industry/number_of_industry_chp_engine_gas_power_fuelmix_present.ad
@@ -1,0 +1,17 @@
+# The max value is dynamically determined by how many CHPs would be build if all of the electricity demand would be supplied by this specific CHP.
+#
+# The max value field is taken from the Excel model, but is overrided by the dynamic field, so not used.
+
+- query =
+    EACH(
+      UPDATE(V(industry_chp_engine_gas_power_fuelmix), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(industry_chp_engine_gas_power_fuelmix),constant), share, V(industry_chp_engine_gas_power_fuelmix, production_based_on_number_of_units)),
+    )
+- priority = 1
+- max_value = 20.0
+- max_value_gql = future:MAX(1.0,DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_engine_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit)))
+- min_value = 0.0
+- start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/industry/number_of_industry_chp_turbine_gas_power_fuelmix_present.ad
+++ b/inputs/adjust_scaling/industry/number_of_industry_chp_turbine_gas_power_fuelmix_present.ad
@@ -1,0 +1,17 @@
+# The max value is dynamically determined by how many CHPs would be build if all of the electricity demand would be supplied by this specific CHP.
+#
+# The max value field is taken from the Excel model, but is overrided by the dynamic field, so not used.
+
+- query =
+    EACH(
+      UPDATE(V(industry_chp_turbine_gas_power_fuelmix), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(industry_chp_turbine_gas_power_fuelmix),constant), share, V(industry_chp_turbine_gas_power_fuelmix, production_based_on_number_of_units)),
+    )
+- priority = 1
+- max_value = 20.0
+- max_value_gql = future:MAX(1.0,DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_turbine_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit)))
+- min_value = 0.0
+- start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_chp_combined_cycle_network_gas_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_chp_combined_cycle_network_gas_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_chp_combined_cycle_network_gas), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_chp_combined_cycle_network_gas), preset_demand_by_electricity_production, V(energy_chp_combined_cycle_network_gas, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 100000000.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_combined_cycle_network_gas,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = future:V(energy_chp_combined_cycle_network_gas,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_chp_supercritical_waste_mix_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_chp_supercritical_waste_mix_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_chp_supercritical_waste_mix), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_chp_supercritical_waste_mix), preset_demand_by_electricity_production, V(energy_chp_supercritical_waste_mix, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,DIVIDE( DIVIDE( Q(total_electricity_produced), V(energy_chp_supercritical_waste_mix,maximum_yearly_electricity_production_per_unit) ), 10 ))
+- min_value = 0.0
+- start_value_gql = present:V(energy_chp_supercritical_waste_mix,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_chp_ultra_supercritical_coal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_chp_ultra_supercritical_coal_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_chp_ultra_supercritical_coal), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_chp_ultra_supercritical_coal), preset_demand_by_electricity_production, V(energy_chp_ultra_supercritical_coal, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 1000.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_chp_ultra_supercritical_coal,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_chp_ultra_supercritical_cofiring_coal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_chp_ultra_supercritical_cofiring_coal_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_chp_ultra_supercritical_cofiring_coal), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_chp_ultra_supercritical_cofiring_coal), preset_demand_by_electricity_production, V(energy_chp_ultra_supercritical_cofiring_coal, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 1000.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_chp_ultra_supercritical_cofiring_coal,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_chp_ultra_supercritical_cofiring_coal,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_heater_for_heat_network_network_gas_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_heater_for_heat_network_network_gas_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_heater_for_heat_network_network_gas), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(energy_heater_for_heat_network_network_gas),constant), share, V(energy_heater_for_heat_network_network_gas, production_based_on_number_of_heat_units)),
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(SUM(V(G(final_demand_group),input_of_steam_hot_water)),V(energy_heater_for_heat_network_network_gas,typical_heat_production_per_unit)),2.0))
+- min_value = 0.0
+- start_value_gql = present:V(energy_heater_for_heat_network_network_gas,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_heater_for_heat_network_waste_mix_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_heater_for_heat_network_waste_mix_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_heater_for_heat_network_waste_mix), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(energy_heater_for_heat_network_waste_mix),constant), share, V(energy_heater_for_heat_network_waste_mix, production_based_on_number_of_heat_units)),
+    )
+- priority = 1
+- max_value = 5000.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(SUM(V(G(final_demand_group),input_of_steam_hot_water)),V(energy_heater_for_heat_network_waste_mix,typical_heat_production_per_unit)),2.0))
+- min_value = 0.0
+- start_value_gql = present:V(energy_heater_for_heat_network_waste_mix,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_heater_for_heat_network_wood_pellets_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_heater_for_heat_network_wood_pellets_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_heater_for_heat_network_wood_pellets), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(energy_heater_for_heat_network_wood_pellets),constant), share, V(energy_heater_for_heat_network_wood_pellets, production_based_on_number_of_heat_units)),
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(2,DIVIDE(SUM(V(G(final_demand_group),input_of_steam_hot_water)),V(energy_heater_for_heat_network_wood_pellets,typical_heat_production_per_unit))))
+- min_value = 0.0
+- start_value_gql = present:V(energy_heater_for_heat_network_wood_pellets,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_combined_cycle_coal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_combined_cycle_coal_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_combined_cycle_coal), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_combined_cycle_coal), preset_demand_by_electricity_production, V(energy_power_combined_cycle_coal, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_coal,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_combined_cycle_coal,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_combined_cycle_network_gas_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_combined_cycle_network_gas_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_combined_cycle_network_gas), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_combined_cycle_network_gas), preset_demand_by_electricity_production, V(energy_power_combined_cycle_network_gas, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_combined_cycle_network_gas,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_combined_cycle_network_gas,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_hydro_river_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_hydro_river_present.ad
@@ -3,11 +3,11 @@
       UPDATE(V(energy_power_hydro_river), number_of_units, USER_INPUT()),
       UPDATE(L(energy_power_hydro_river), preset_demand_by_electricity_production, V(energy_power_hydro_river, production_based_on_number_of_units))
     )
-- priority = 10
+- priority = 1
 - max_value = 12.0
 - max_value_gql = present:MAX(1.0,DIVIDE(Q(total_electricity_produced),V(energy_power_hydro_river,typical_electricity_production_per_unit)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_hydro_river,number_of_units)
 - step_value = 0.1
 - unit = #
-- update_period = both
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_nuclear_gen2_uranium_oxide_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_nuclear_gen2_uranium_oxide_present.ad
@@ -1,0 +1,14 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_nuclear_gen2_uranium_oxide), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_nuclear_gen2_uranium_oxide), preset_demand_by_electricity_production, V(energy_power_nuclear_gen2_uranium_oxide, production_based_on_number_of_units))
+    )
+- priority = 0
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_nuclear_gen3_uranium_oxide,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_nuclear_gen2_uranium_oxide,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = future
+- dependent_on = has_old_technologies

--- a/inputs/adjust_scaling/supply/number_of_energy_power_nuclear_gen2_uranium_oxide_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_nuclear_gen2_uranium_oxide_present.ad
@@ -3,12 +3,12 @@
       UPDATE(V(energy_power_nuclear_gen2_uranium_oxide), number_of_units, USER_INPUT()),
       UPDATE(L(energy_power_nuclear_gen2_uranium_oxide), preset_demand_by_electricity_production, V(energy_power_nuclear_gen2_uranium_oxide, production_based_on_number_of_units))
     )
-- priority = 0
+- priority = 1
 - max_value = 300.0
 - max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_nuclear_gen3_uranium_oxide,maximum_yearly_electricity_production_per_unit)),2))
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_nuclear_gen2_uranium_oxide,number_of_units)
 - step_value = 0.1
 - unit = #
-- update_period = future
+- update_period = present
 - dependent_on = has_old_technologies

--- a/inputs/adjust_scaling/supply/number_of_energy_power_supercritical_coal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_supercritical_coal_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_supercritical_coal), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_supercritical_coal), preset_demand_by_electricity_production, V(energy_power_supercritical_coal, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_supercritical_coal ,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_supercritical_coal ,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_ultra_supercritical_coal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_ultra_supercritical_coal_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_ultra_supercritical_coal), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_ultra_supercritical_coal), preset_demand_by_electricity_production, V(energy_power_ultra_supercritical_coal, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_ultra_supercritical_coal,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_ultra_supercritical_cofiring_coal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_ultra_supercritical_cofiring_coal_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_ultra_supercritical_cofiring_coal), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_ultra_supercritical_cofiring_coal), preset_demand_by_electricity_production, V(energy_power_ultra_supercritical_cofiring_coal, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_cofiring_coal,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_ultra_supercritical_cofiring_coal,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_ultra_supercritical_network_gas_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_ultra_supercritical_network_gas_present.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_power_ultra_supercritical_network_gas), number_of_units, USER_INPUT()),
+      UPDATE(L(energy_power_ultra_supercritical_network_gas), preset_demand_by_electricity_production, V(energy_power_ultra_supercritical_network_gas, production_based_on_number_of_units))
+    )
+- priority = 1
+- max_value = 300.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(Q(total_electricity_produced),V(energy_power_ultra_supercritical_network_gas,maximum_yearly_electricity_production_per_unit)),2))
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_ultra_supercritical_network_gas,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_coastal_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_coastal_present.ad
@@ -3,12 +3,12 @@
       UPDATE(V(energy_power_wind_turbine_coastal), number_of_units, USER_INPUT()),
       UPDATE(L(energy_power_wind_turbine_coastal), preset_demand_by_electricity_production, V(energy_power_wind_turbine_coastal, production_based_on_number_of_units))
     )
-- priority = 10
+- priority = 1
 - max_value = 300.0
 - max_value_gql = present:MAX(1.0,DIVIDE(AREA(coast_line),V(energy_power_wind_turbine_coastal, land_use_per_unit)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_coastal,number_of_units)
 - step_value = 0.1
 - unit = #
-- update_period = both
+- update_period = present
 - dependent_on = has_coastline

--- a/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_inland_both.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_inland_both.ad
@@ -3,11 +3,11 @@
       UPDATE(V(energy_power_wind_turbine_inland), number_of_units, USER_INPUT()),
       UPDATE(L(energy_power_wind_turbine_inland), preset_demand_by_electricity_production, V(energy_power_wind_turbine_inland, production_based_on_number_of_units))
     )
-- priority = 0
+- priority = 10
 - max_value = 300.0
 - max_value_gql = present:MAX(1.0,DIVIDE(AREA(onshore_suitable_for_wind),V(energy_power_wind_turbine_inland,land_use_per_unit)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_inland,number_of_units)
 - step_value = 0.1
 - unit = #
-- update_period = future
+- update_period = both

--- a/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_inland_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_inland_present.ad
@@ -3,11 +3,11 @@
       UPDATE(V(energy_power_wind_turbine_inland), number_of_units, USER_INPUT()),
       UPDATE(L(energy_power_wind_turbine_inland), preset_demand_by_electricity_production, V(energy_power_wind_turbine_inland, production_based_on_number_of_units))
     )
-- priority = 10
+- priority = 1
 - max_value = 300.0
 - max_value_gql = present:MAX(1.0,DIVIDE(AREA(onshore_suitable_for_wind),V(energy_power_wind_turbine_inland,land_use_per_unit)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_inland,number_of_units)
 - step_value = 0.1
 - unit = #
-- update_period = both
+- update_period = present

--- a/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_offshore_present.ad
+++ b/inputs/adjust_scaling/supply/number_of_energy_power_wind_turbine_offshore_present.ad
@@ -3,12 +3,12 @@
       UPDATE(V(energy_power_wind_turbine_offshore), number_of_units, USER_INPUT()),
       UPDATE(L(energy_power_wind_turbine_offshore), preset_demand_by_electricity_production, V(energy_power_wind_turbine_offshore, production_based_on_number_of_units))
     )
-- priority = 10
+- priority = 1
 - max_value = 300.0
 - max_value_gql = present:MAX(1.0,DIVIDE(AREA(offshore_suitable_for_wind),V(energy_power_wind_turbine_offshore, land_use_per_unit)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_power_wind_turbine_offshore,number_of_units)
 - step_value = 0.1
 - unit = #
-- update_period = both
+- update_period = present
 - dependent_on = has_coastline


### PR DESCRIPTION
Added some industry and supply present inputs and switched wind and water input statement's `update_period` to present (instead of both), for consistency.

See also https://github.com/quintel/etsource/pull/1088 .