### PR TITLE
Transport gqueries for Bezier 23 correction

### DIFF
--- a/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/electricity_trains_in_use_of_final_demand_in_transport.gql
+++ b/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/electricity_trains_in_use_of_final_demand_in_transport.gql
@@ -1,6 +1,6 @@
 - unit = PJ
 - query =
     DIVIDE(
-      V(transport_final_demand_for_rail_electricity,final_demand),
+      V(transport_train_using_electricity,final_demand),
       BILLIONS
     )

--- a/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_domestic_flights_in_use_of_final_demand_in_transport.gql
+++ b/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_domestic_flights_in_use_of_final_demand_in_transport.gql
@@ -1,6 +1,13 @@
 - unit = PJ
 - query =
     DIVIDE(
-      V(transport_useful_demand_planes,final_demand),
+      SUM(
+        V(
+          transport_plane_using_bio_ethanol,
+          transport_plane_using_gasoline,
+          transport_plane_using_kerosene,
+          final_demand
+        )
+      ),
       BILLIONS
     )

--- a/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_inland_navigation_in_use_of_final_demand_in_transport.gql
+++ b/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_inland_navigation_in_use_of_final_demand_in_transport.gql
@@ -1,6 +1,12 @@
 - unit = PJ
 - query =
     DIVIDE(
-      V(transport_useful_demand_ship_kms,final_demand),
+      SUM(
+        V(
+          transport_ship_using_diesel_mix,
+          transport_ship_using_lng_mix,
+          final_demand
+        )
+      ),
       BILLIONS
     )

--- a/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_trains_in_use_of_final_demand_in_transport.gql
+++ b/gqueries/output_elements/output_series/bezier_23_use_of_final_demand_in_transport/fuel_trains_in_use_of_final_demand_in_transport.gql
@@ -1,10 +1,12 @@
 - unit = PJ
 - query =
-    SUM(
-      DIVIDE(
-        V(transport_useful_demand_trains,final_demand),
-        BILLIONS
+    DIVIDE(
+      SUM(
+        V(
+          transport_train_using_coal,
+          transport_train_using_diesel,
+          final_demand
+        )
       ),
-        NEG(Q(electricity_trains_in_use_of_final_demand_in_transport)
-      )
+      BILLIONS
     )


### PR DESCRIPTION
As discussed in the issue mentioned below, this PR fixes the gqueries for chart 23 'use of final demand in transport' which used to ask for the final demand of the *useful demand* and now correctly ask for the final demand of the respective technologies. Tested locally and closes https://github.com/quintel/etmodel/issues/2079 .