### PR TITLE
Removed bio_oil and bio_ethanol from initial_updates_preset_demands input statement

### DIFF
--- a/inputs/misc/initial_updates_preset_demands.ad
+++ b/inputs/misc/initial_updates_preset_demands.ad
@@ -1,10 +1,6 @@
 - query =
     EACH(
       UPDATE(
-        V(energy_production_bio_oil), preset_demand,
-        TIME_SERIE_VALUE(energy_production_bio_oil,preset_demand,USER_INPUT())
-      ),
-      UPDATE(
         V(energy_extraction_natural_gas), preset_demand,
         TIME_SERIE_VALUE(energy_extraction_natural_gas,preset_demand,USER_INPUT())
       ),
@@ -15,10 +11,6 @@
       UPDATE(
         V(energy_extraction_coal), preset_demand,
         TIME_SERIE_VALUE(energy_extraction_coal,preset_demand,USER_INPUT())
-      ),
-      UPDATE(
-        V(energy_production_bio_ethanol), preset_demand,
-        TIME_SERIE_VALUE(energy_production_bio_ethanol,preset_demand,USER_INPUT())
       ),
       UPDATE(
         V(energy_extraction_uranium_oxide), preset_demand,


### PR DESCRIPTION
Since there are no timecurves for `bio_oil` and `bio_ethanol`, their production is always updated to 0. With this PR their production is assumed to stay constant and equal to the production of the initial year. 
Closes #1093 .