### PR TITLE
Added max_demand input for woody biomass for scaled scenarios

### DIFF
--- a/inputs/adjust_scaling/supply/energy_distribution_woody_biomass_both.ad
+++ b/inputs/adjust_scaling/supply/energy_distribution_woody_biomass_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(energy_distribution_woody_biomass), max_demand, USER_INPUT())
+- priority = 10
+- update_period = both


### PR DESCRIPTION
See title. Allows us to tweak the available woody biomass production of a certain region.