### PR TITLE
Correction of Industry heat production time inconsistency within share_group.

### DIFF
--- a/inputs/adjust_scaling/industry/industry_final_demand_for_chemical_steam_hot_water_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_final_demand_for_chemical_steam_hot_water_share_present.ad
@@ -10,7 +10,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- start_value_gql = present:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
 - unit = %
 - update_period = present

--- a/inputs/adjust_scaling/industry/industry_final_demand_steam_hot_water_share_present.ad
+++ b/inputs/adjust_scaling/industry/industry_final_demand_steam_hot_water_share_present.ad
@@ -10,7 +10,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat) * 100
+- start_value_gql = present:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
 - unit = %
 - update_period = present

--- a/inputs/demand/industry/industry_final_demand_for_chemical_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_steam_hot_water_share.ad
@@ -10,7 +10,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
+- start_value_gql = present:V(industry_final_demand_for_chemical_steam_hot_water,share_of_industry_useful_demand_for_chemical_useable_heat) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future

--- a/inputs/demand/industry/industry_final_demand_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_steam_hot_water_share.ad
@@ -10,7 +10,7 @@
 - max_value = 100.0
 - min_value = 0.0
 - start_value = 3.5
-- start_value_gql = future:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat) * 100
+- start_value_gql = present:V(industry_final_demand_for_heat_steam_hot_water,share_of_industry_useful_demand_useable_heat) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future


### PR DESCRIPTION
See #1091 , closes #1091 . This PR corrects both the 'regular' and `adjust_scaling` inputs by making them time-consistent. 

#1092 , where we discuss of which periods inputs should have their start_value, remains open. 