### PR TITLE
Linked FCE attributes to quintel/etdataset@67b51dcb5cb28409cffa17d558dc0b2bc82eca1a

### DIFF
--- a/datasets/nl/fce/bio_ethanol.yml
+++ b/datasets/nl/fce/bio_ethanol.yml
@@ -7,7 +7,6 @@
   :co2_conversion_per_mj: 0.0
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.6
-
 :sugar_cane:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0143

--- a/datasets/nl/fce/biodiesel.yml
+++ b/datasets/nl/fce/biodiesel.yml
@@ -7,7 +7,6 @@
   :co2_conversion_per_mj: 0.0
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.2
-
 :palm_oil:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0147

--- a/datasets/nl/fce/coal.yml
+++ b/datasets/nl/fce/coal.yml
@@ -7,7 +7,6 @@
   :co2_conversion_per_mj: 0.088163
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.153
-
 :east_asia:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00485538
@@ -16,7 +15,6 @@
   :co2_conversion_per_mj: 0.0983293
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.124
-
 :eastern_europe:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0107564
@@ -25,7 +23,6 @@
   :co2_conversion_per_mj: 0.103616
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.088
-
 :north_america:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00365593
@@ -34,7 +31,6 @@
   :co2_conversion_per_mj: 0.0874464
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.169
-
 :russia:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0119648
@@ -43,7 +39,6 @@
   :co2_conversion_per_mj: 0.0992456
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.0
-
 :south_africa:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00412425
@@ -52,7 +47,6 @@
   :co2_conversion_per_mj: 0.0901655
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.263
-
 :south_america:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00051643

--- a/datasets/nl/fce/greengas.yml
+++ b/datasets/nl/fce/greengas.yml
@@ -1,8 +1,8 @@
 ---
 :greengas:
   :co2_exploration_per_mj: 0.0
-  :co2_extraction_per_mj: 0.0178266
-  :co2_treatment_per_mj: 0.00166162
+  :co2_extraction_per_mj: 0.0178265801598422
+  :co2_treatment_per_mj: 0.00166161730695152
   :co2_transportation_per_mj: 0.0
   :co2_conversion_per_mj: 0.0
   :co2_waste_treatment_per_mj: 0.0

--- a/datasets/nl/fce/lng.yml
+++ b/datasets/nl/fce/lng.yml
@@ -3,35 +3,31 @@
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
   :co2_treatment_per_mj: 0.0049
-  :co2_transportation_per_mj: 0.00156067
-  :co2_conversion_per_mj: 0.05545221
+  :co2_transportation_per_mj: 0.00156067486597288
+  :co2_conversion_per_mj: 0.0554522120024543
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.0
-
 :norway:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
   :co2_treatment_per_mj: 0.0049
-  :co2_transportation_per_mj: 0.00142293
-  :co2_conversion_per_mj: 0.05549596
+  :co2_transportation_per_mj: 0.00142292934019654
+  :co2_conversion_per_mj: 0.0554959589339704
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.41509434
-
+  :start_value: 0.415094339622641
 :qatar:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
   :co2_treatment_per_mj: 0.0049
   :co2_transportation_per_mj: 0.0034
-  :co2_conversion_per_mj: 0.05566664
+  :co2_conversion_per_mj: 0.0556666439496815
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.58490566
-
+  :start_value: 0.584905660377358
 :trinidad:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
   :co2_treatment_per_mj: 0.0049
-  :co2_transportation_per_mj: 0.00248361
-  :co2_conversion_per_mj: 0.05556477
+  :co2_transportation_per_mj: 0.00248360630166901
+  :co2_conversion_per_mj: 0.0555647714096
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.0
-  

--- a/datasets/nl/fce/natural_gas.yml
+++ b/datasets/nl/fce/natural_gas.yml
@@ -7,7 +7,6 @@
   :co2_conversion_per_mj: 0.0567541
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.0
-
 :netherlands:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
@@ -16,7 +15,6 @@
   :co2_conversion_per_mj: 0.0552117
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.9
-
 :norway:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
@@ -25,7 +23,6 @@
   :co2_conversion_per_mj: 0.0566487
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.05
-
 :russia:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0

--- a/datasets/nl/fce/wood_pellets.yml
+++ b/datasets/nl/fce/wood_pellets.yml
@@ -1,9 +1,9 @@
 ---
 :wood_pellets:
   :co2_exploration_per_mj: 0.0
-  :co2_extraction_per_mj: 0.001147042
+  :co2_extraction_per_mj: 0.00114704171551667
   :co2_treatment_per_mj: 0.0
   :co2_transportation_per_mj: 0.00808119813549124
-  :co2_conversion_per_mj: 2.86483699077522e-05
+  :co2_conversion_per_mj: 0.0
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 1.0


### PR DESCRIPTION
The commit in this pull request links the FCE attributes on ETSource to the relevant ETDataset commit. Note that two things changed:
- Some FCE attribute value get more significant digits as they rely on a calculation in the relevant carrier source analysis
- The blank line between the FCE attributes from different origins has disappeared. This is caused by the Rake task that is used to export the FCE attributes and should give no problems.