### PR TITLE
Added compressed gas edge to final demand edge group

### DIFF
--- a/edges/transport/transport_final_demand_for_road_compressed_network_gas-transport_road_mixer_compressed_network_gas@compressed_network_gas.ad
+++ b/edges/transport/transport_final_demand_for_road_compressed_network_gas-transport_road_mixer_compressed_network_gas@compressed_network_gas.ad
@@ -1,2 +1,3 @@
 - type = share
 - reversed = false
+- groups = [final_demand]


### PR DESCRIPTION
As this edge was missing from the final demand edge group, the energy flowing through this edge (in the form of compressed natural gas) did not show up in the final demand mekko.