### PR TITLE
Adding query for electricity costs of import to chart 102 (breakdown …

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/import_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/import_in_breakdown_of_total_costs.gql
@@ -1,0 +1,2 @@
+- query = DIVIDE(Q(costs_of_imported_electricity),BILLIONS)
+- unit = bln_euro


### PR DESCRIPTION
…of electricity costs)

This fixes the discrepancy between the electricity costs in chart 48 and chart 102.

The database change needed is to add this query to chart 102. I choose 'light-grey' as the color and used the 'imported_electricity' translation key:

```
INSERT INTO `output_element_series` (`id`, `output_element_id`, `label`, `color`, `order_by`, `group`, `created_at`, `updated_at`, `show_at_first`, `is_target_line`, `target_line_position`, `gquery`)
VALUES
	(NULL, 102, 'imported_electricity', '#CCCCCC', 6, '', NOW(), NOW(), 0, 0, '', 'import_in_breakdown_of_total_costs');
```