### PR TITLE
Add network costs to dashboard item for nl2012 dataset

### DIFF
--- a/gqueries/general/costs/total_costs.gql
+++ b/gqueries/general/costs/total_costs.gql
@@ -9,7 +9,7 @@
         Q(total_costs_of_energy_sector),
         Q(costs_of_non_energetic_demand),
         Q(costs_of_flexibility),
-        IF(EQUALS(AREA(area), nl) || EQUALS(AREA(area), nl2012)),
+        IF(EQUALS(AREA(area), nl) || EQUALS(AREA(area), nl2012),
             -> { Q(network_total_costs) },
             0
         )

--- a/gqueries/general/costs/total_costs.gql
+++ b/gqueries/general/costs/total_costs.gql
@@ -9,7 +9,7 @@
         Q(total_costs_of_energy_sector),
         Q(costs_of_non_energetic_demand),
         Q(costs_of_flexibility),
-        IF(EQUALS(AREA(area),nl),
+        IF(EQUALS(AREA(area), nl) || EQUALS(AREA(area), nl2012)),
             -> { Q(network_total_costs) },
             0
         )


### PR DESCRIPTION
The Gquery that is used to determine the dashboard costs checks if the dataset on which the scenario is based is for the Netherlands. If so, the network costs are added. The same should be done for scenarios that are based on the nl2012 dataset. I have added this check to the relevant Gquery. This resolves the inconsistency between the dashboard item and the sum of the items in the `Costs` table for scenarios based on the nl2012 dataset.