### PR TITLE
Fixed dashboard cost correction

### DIFF
--- a/gqueries/output_elements/dashboard/dashboard_total_cost_correction.gql
+++ b/gqueries/output_elements/dashboard/dashboard_total_cost_correction.gql
@@ -43,13 +43,21 @@
         households_water_heater_micro_chp_network_gas,
         "initial_investment_per(:converter) / technical_lifetime"
       ).sum,
-      Q(buildings_collective_heatpump_water_water_ts_electricity_future_in_investment_cost_table),
-      Q(buildings_heatpump_air_water_network_gas_future_in_investment_cost_table),
-      Q(households_heater_combined_network_gas_future_in_investment_cost_table),
-      Q(households_heatpump_ground_water_electricity_future_in_investment_cost_table),
-      Q(households_heater_micro_chp_network_gas_future_in_investment_cost_table),
-      Q(households_heater_district_heating_steam_hot_water_future_in_investment_cost_table),
-      Q(households_heater_heatpump_air_water_electricity_future_in_investment_cost_table),
-      Q(households_heater_hybrid_heatpump_air_water_electricity_future_in_investment_cost_table)
+      Q(buildings_collective_heatpump_water_water_ts_electricity_future_in_investment_cost_table) / 
+      V(buildings_space_heater_collective_heatpump_water_water_ts_electricity, technical_lifetime),
+      Q(buildings_heatpump_air_water_network_gas_future_in_investment_cost_table) / 
+      V(buildings_space_heater_heatpump_air_water_network_gas, technical_lifetime),
+      Q(households_heater_combined_network_gas_future_in_investment_cost_table) / 
+      V(households_space_heater_combined_network_gas, technical_lifetime),
+      Q(households_heatpump_ground_water_electricity_future_in_investment_cost_table) / 
+      V(households_space_heater_heatpump_ground_water_electricity, technical_lifetime),
+      Q(households_heater_micro_chp_network_gas_future_in_investment_cost_table) / 
+      V(households_space_heater_micro_chp_network_gas, technical_lifetime),
+      Q(households_heater_district_heating_steam_hot_water_future_in_investment_cost_table) / 
+      V(households_space_heater_district_heating_steam_hot_water, technical_lifetime),
+      Q(households_heater_heatpump_air_water_electricity_future_in_investment_cost_table) / 
+      V(households_space_heater_heatpump_air_water_electricity, technical_lifetime),
+      Q(households_heater_hybrid_heatpump_air_water_electricity_future_in_investment_cost_table) / 
+      V(households_space_heater_hybrid_heatpump_air_water_electricity, technical_lifetime)
     )
 - unit = euro

--- a/gqueries/output_elements/dashboard/dashboard_total_cost_correction.gql
+++ b/gqueries/output_elements/dashboard/dashboard_total_cost_correction.gql
@@ -44,20 +44,20 @@
         "initial_investment_per(:converter) / technical_lifetime"
       ).sum,
       Q(buildings_collective_heatpump_water_water_ts_electricity_future_in_investment_cost_table) / 
-      V(buildings_space_heater_collective_heatpump_water_water_ts_electricity, technical_lifetime),
+      V(buildings_space_heater_collective_heatpump_water_water_ts_electricity, technical_lifetime) * BILLIONS,
       Q(buildings_heatpump_air_water_network_gas_future_in_investment_cost_table) / 
-      V(buildings_space_heater_heatpump_air_water_network_gas, technical_lifetime),
+      V(buildings_space_heater_heatpump_air_water_network_gas, technical_lifetime) * BILLIONS,
       Q(households_heater_combined_network_gas_future_in_investment_cost_table) / 
-      V(households_space_heater_combined_network_gas, technical_lifetime),
+      V(households_space_heater_combined_network_gas, technical_lifetime) * BILLIONS,
       Q(households_heatpump_ground_water_electricity_future_in_investment_cost_table) / 
-      V(households_space_heater_heatpump_ground_water_electricity, technical_lifetime),
+      V(households_space_heater_heatpump_ground_water_electricity, technical_lifetime) * BILLIONS,
       Q(households_heater_micro_chp_network_gas_future_in_investment_cost_table) / 
-      V(households_space_heater_micro_chp_network_gas, technical_lifetime),
+      V(households_space_heater_micro_chp_network_gas, technical_lifetime) * BILLIONS,
       Q(households_heater_district_heating_steam_hot_water_future_in_investment_cost_table) / 
-      V(households_space_heater_district_heating_steam_hot_water, technical_lifetime),
+      V(households_space_heater_district_heating_steam_hot_water, technical_lifetime) * BILLIONS,
       Q(households_heater_heatpump_air_water_electricity_future_in_investment_cost_table) / 
-      V(households_space_heater_heatpump_air_water_electricity, technical_lifetime),
+      V(households_space_heater_heatpump_air_water_electricity, technical_lifetime) * BILLIONS,
       Q(households_heater_hybrid_heatpump_air_water_electricity_future_in_investment_cost_table) / 
-      V(households_space_heater_hybrid_heatpump_air_water_electricity, technical_lifetime)
+      V(households_space_heater_hybrid_heatpump_air_water_electricity, technical_lifetime) * BILLIONS
     )
 - unit = euro


### PR DESCRIPTION
As noticed by Niki from Berenschot, the dashboard cost item gives strange results. She illustrated this with a scenario that has quite some electric heat pump and around 30 BLN EUR of investment costs in these heatpumps. By setting the investment costs in electric heat pumps to -100%, they become free and you would expect the investment costs to drop to 0 EUR, which is indeed what you see in the investment table. The dashboard cost item however drops by only 600 MLN EUR, which is strange as the 30 BLN EUR divided by 15 years (the lifetime of heat pumps) results in 2 BLN EUR / yr, way more than 600 MLN EUR.

I traced the error down to the `dashboard_total_cost_correction.gql`, which did two things wrong:
- some of the subqueries return a value in euros, while others return a value in billion euros
- the results of the subqueries in the second half of the correction query should be divided by the technical lifetime

I have corrected both errors in this pull request, which solves the aforementioned strange results in the dashboard cost item.

One point remains open: the dashboard cost correction only corrects the investment costs. The dashboard cost item does, however, also take into account the cost of capital, which is **not** corrected. The error we make by doing this is small and the only solutions I can think of are very cumbersome. I would therefore suggest to leave that issue for now.





