### PR TITLE
Made check for dashboard costs more robust

### DIFF
--- a/gqueries/general/costs/total_costs.gql
+++ b/gqueries/general/costs/total_costs.gql
@@ -9,7 +9,7 @@
         Q(total_costs_of_energy_sector),
         Q(costs_of_non_energetic_demand),
         Q(costs_of_flexibility),
-        IF(EQUALS(AREA(area), nl) || EQUALS(AREA(area), nl2012),
+        IF(AREA(use_network_calculations),
             -> { Q(network_total_costs) },
             0
         )


### PR DESCRIPTION
What else do we have these area attributes for? ;)

I confirmed locally that this does not change the outcome of several scenarios:
- default NL scenario
- Urgenda
- SER 2023
- Germany BAU scenario
- That infamous scenario based on the `nl2012` dataset