### PR TITLE
Added inputs to tweak the demand of several carriers used by appliances

### DIFF
--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_coal_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_coal_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_final_demand_for_appliances_coal), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_crude_oil_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_crude_oil_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_final_demand_for_appliances_crude_oil), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_network_gas_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_network_gas_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_final_demand_for_appliances_network_gas), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_wood_pellets_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_wood_pellets_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_final_demand_for_appliances_wood_pellets), demand, USER_INPUT())
+- priority = 10
+- update_period = both


### PR DESCRIPTION
Our interface (ETModel) does not allow the user to alter all energy flows. For scaled scenarios these unchangeable flows can become quite noticeable: appliances in the buildings sector have a non-zero demand for coal, wood pellets, crude oil and network gas. This PR features inputs (`update_period = both`) which allow us to 'reduce' and remove these energy flows in the present and future simultaneously.