### PR TITLE
Made inputs update the demand of appliances (instead of the FD) in buildings sector

### DIFF
--- a/inputs/adjust_scaling/buildings/buildings_appliances_coal_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_coal_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_appliances_coal), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_crude_oil_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_crude_oil_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_appliances_crude_oil), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_network_gas_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_network_gas_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_appliances_network_gas), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_wood_pellets_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_wood_pellets_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(V(buildings_appliances_wood_pellets), demand, USER_INPUT())
+- priority = 10
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_coal_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_coal_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_final_demand_for_appliances_coal), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_crude_oil_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_crude_oil_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_final_demand_for_appliances_crude_oil), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_network_gas_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_network_gas_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_final_demand_for_appliances_network_gas), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_wood_pellets_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_final_demand_for_appliances_wood_pellets_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_final_demand_for_appliances_wood_pellets), demand, USER_INPUT())
-- priority = 10
-- update_period = both


### PR DESCRIPTION
This is a follow-up to https://github.com/quintel/etsource/pull/1118 . Setting the demand of some FD converters in the buildings sector to zero was reflected in the dashboard, but not in the graph. Nodes between the FD and UD still had non-zero demand. This PR is an attempt to fix that.