### PR TITLE
Created share updating inputs to tweak buildings appliances energy flows

### DIFF
--- a/inputs/adjust_scaling/buildings/buildings_appliances_coal_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_coal_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_appliances_coal), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_coal_share_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_coal_share_both.ad
@@ -1,0 +1,15 @@
+- query =
+    EACH(
+      UPDATE(LINK(buildings_appliances_coal,buildings_useful_demand_for_appliances), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(buildings_useful_demand_for_appliances,buildings_appliances_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(buildings_useful_demand_for_appliances)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = buildings_appliances_both
+- priority = 10
+- max_value = 100.0
+- min_value = 0.0
+- start_value_gql = present:V(buildings_appliances_coal,share_of_buildings_useful_demand_for_appliances) * 100
+- step_value = 0.1
+- unit = %
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_crude_oil_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_crude_oil_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_appliances_crude_oil), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_crude_oil_share_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_crude_oil_share_both.ad
@@ -1,0 +1,15 @@
+- query =
+    EACH(
+      UPDATE(LINK(buildings_appliances_crude_oil,buildings_useful_demand_for_appliances), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(buildings_useful_demand_for_appliances,buildings_appliances_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(buildings_useful_demand_for_appliances)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = buildings_appliances_both
+- priority = 10
+- max_value = 100.0
+- min_value = 0.0
+- start_value_gql = present:V(buildings_appliances_crude_oil,share_of_buildings_useful_demand_for_appliances) * 100
+- step_value = 0.1
+- unit = %
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_electricity_share_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_electricity_share_both.ad
@@ -1,0 +1,15 @@
+- query =
+    EACH(
+      UPDATE(LINK(buildings_appliances_electricity,buildings_useful_demand_for_appliances), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(buildings_useful_demand_for_appliances,buildings_appliances_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(buildings_useful_demand_for_appliances)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = buildings_appliances_both
+- priority = 10
+- max_value = 100.0
+- min_value = 0.0
+- start_value_gql = present:V(buildings_appliances_electricity,share_of_buildings_useful_demand_for_appliances) * 100
+- step_value = 0.1
+- unit = %
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_network_gas_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_network_gas_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_appliances_network_gas), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_network_gas_share_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_network_gas_share_both.ad
@@ -1,0 +1,15 @@
+- query =
+    EACH(
+      UPDATE(LINK(buildings_appliances_network_gas,buildings_useful_demand_for_appliances), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(buildings_useful_demand_for_appliances,buildings_appliances_electricity), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(buildings_useful_demand_for_appliances)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = buildings_appliances_both
+- priority = 10
+- max_value = 100.0
+- min_value = 0.0
+- start_value_gql = present:V(buildings_appliances_network_gas,share_of_buildings_useful_demand_for_appliances) * 100
+- step_value = 0.1
+- unit = %
+- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_wood_pellets_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_wood_pellets_both.ad
@@ -1,3 +1,0 @@
-- query = UPDATE(V(buildings_appliances_wood_pellets), demand, USER_INPUT())
-- priority = 10
-- update_period = both

--- a/inputs/adjust_scaling/buildings/buildings_appliances_wood_pellets_share_both.ad
+++ b/inputs/adjust_scaling/buildings/buildings_appliances_wood_pellets_share_both.ad
@@ -1,0 +1,15 @@
+- query =
+    EACH(
+      UPDATE(LINK(buildings_appliances_wood_pellets,buildings_useful_demand_for_appliances), share, DIVIDE(USER_INPUT(),100)),
+      UPDATE(LINK(buildings_useful_demand_for_appliances,buildings_appliances_network_gas), share,
+        ->{SUM(NEG(SUM(V(EXCLUDE(INPUT_LINKS(V(buildings_useful_demand_for_appliances)),UPDATE_COLLECTION()), share))), 1)}
+      )
+    )
+- share_group = buildings_appliances_both
+- priority = 10
+- max_value = 100.0
+- min_value = 0.0
+- start_value_gql = present:V(buildings_appliances_wood_pellets,share_of_buildings_useful_demand_for_appliances) * 100
+- step_value = 0.1
+- unit = %
+- update_period = both


### PR DESCRIPTION
This is a follow-up to https://github.com/quintel/etsource/pull/1120 . This PR features inputs that set the shares of all carrier-specific (e.g. `network_gas`) appliances of the total appliances. With the existing <a href="https://github.com/quintel/etsource/blob/master/inputs/adjust_scaling/buildings/buildings_useful_demand_appliances_both.ad">input</a> it is possible to tweak the total UD of appliances. It is therefore possible to tweak the FD for every carrier for appliances through the combination of these inputs.

Notifying @dennisschoenmakers @ChaelKruip @jorisberkhout 