### PR TITLE
Made households heat network converters demand-driven

### DIFF
--- a/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
@@ -1,11 +1,12 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, demand_driven]
 - output.useable_heat = 1.0
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2500.0
+- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0

--- a/nodes/households/households_water_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_water_heater_district_heating_steam_hot_water.converter.ad
@@ -2,12 +2,12 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, demand_driven]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - full_load_hours = 2500.0
-- households_supplied_per_unit = 0.0
+- households_supplied_per_unit = 1.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
 - part_load_efficiency_penalty = 0.0


### PR DESCRIPTION
As pointed out by Berenschot, the total investment costs for heat networks did not scale properly with the percentage of households that has its space heating and/or hot water supplied by a heat network. @ChaelKruip and I found out that this has to do with the fact that the heat network converters were not in the `demand_driven` group. The commit in this pull request changes this. Say if you set the sliders in the households space heating group such that 50% of the space heating is supplied by a heat network, this means that there are 50% * 7.5 mln = 3.75 mln households equipped with a heat network. The associated investment costs are 3.75 mln connection * 6050 EUR/connection, which is displayed in the investment table under `Households -> District heating`. The investment costs of the primary heat infrastructure scale with the amount of energy that flows through it and is shown as `Households -> Centralised district heating` in the investment table.

As far as I can see this change only impacts the dashboard and investment costs and not the energy flow. I checked the effect on several important scenario, see table below.

| Scenario | Dashboard costs (Beta) (BLN EUR) | Dashboard costs (Beta + this PR) (BLN EUR) |
| --- | --- | --- | --- |
| Blank NL 2050 | 28.8 | 28.9 |
| SER 2023 | 63.9 | 63.9 |
| Urgenda | 51.9 | 52.3 |
| RLI 95% | 55.9 | 56.6 |  

Note that, in the past, we explicitly decided NOT to make the heat network converters demand driven, but no reason is given in this issue: https://github.com/quintel/etengine/issues/304#issuecomment-6149467.