### PR TITLE
Adding input for energy_heater_for_heat_network_geothermal

### DIFF
--- a/inputs/supply/number_of/number_of_energy_heater_for_heat_network_geothermal.ad
+++ b/inputs/supply/number_of/number_of_energy_heater_for_heat_network_geothermal.ad
@@ -1,0 +1,13 @@
+- query =
+    EACH(
+      UPDATE(V(energy_heater_for_heat_network_geothermal), number_of_units, USER_INPUT()),
+      UPDATE(OUTPUT_LINKS(V(energy_heater_for_heat_network_geothermal),constant), share, V(energy_heater_for_heat_network_geothermal, production_based_on_number_of_heat_units)),
+    )
+- priority = 0
+- max_value = 100.0
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(SUM(V(G(final_demand_group),input_of_steam_hot_water)),V(energy_heater_for_heat_network_geothermal,typical_heat_production_per_unit)),2.0))
+- min_value = 0.0
+- start_value_gql = present:V(energy_heater_for_heat_network_geothermal,number_of_units)
+- step_value = 0.1
+- unit = #
+- update_period = future


### PR DESCRIPTION
This closes https://github.com/quintel/etsource/issues/1130

To add the slider to the database:
```sql
INSERT INTO `input_elements` (`id`, `key`, `share_group`, `step_value`, `created_at`, `updated_at`, `unit`, `fixed`, `comments`, `interface_group`, `command_type`, `related_converter`, `slide_id`, `position`)
VALUES
	(NULL, 'number_of_energy_heater_for_heat_network_geothermal', '', 0.1, '2016-05-31 08:24:23', '2016-05-31 08:24:23', '#', 0, '', '', 'value', 'energy_heater_for_heat_network_geothermal', 60, 1);
```