### PR TITLE
Adding district heaters to the etmoses group

### DIFF
--- a/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = [cost_traditional_heat, heat_production, demand_driven]
+- groups = [cost_traditional_heat, heat_production, demand_driven, etmoses]
 - output.useable_heat = 1.0
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/households/households_water_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_water_heater_district_heating_steam_hot_water.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_traditional_heat, heat_production, demand_driven]
+- groups = [cost_traditional_heat, heat_production, demand_driven, etmoses]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0


### PR DESCRIPTION
This adds the heat network to the etmoses group. Needed to make etmoses_space_heating_buffer_demand.gql work properly. 