### PR TITLE
Gqueries for refinery sankey

### DIFF
--- a/gqueries/output_elements/output_series/refinery_189/crude_oil_extraction_to_refinery_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/crude_oil_extraction_to_refinery_in_sankey.gql
@@ -1,0 +1,6 @@
+# Query for refinery sankey: connection between extraction of crude oil and refinery
+
+- unit = PJ
+- query =
+    DIVIDE(V(industry_refinery_transformation_crude_oil, input_of_crude_oil),BILLIONS) * 
+      V(energy_extraction_crude_oil, share_of_energy_distribution_crude_oil)

--- a/gqueries/output_elements/output_series/refinery_189/crude_oil_import_to_refinery_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/crude_oil_import_to_refinery_in_sankey.gql
@@ -1,0 +1,6 @@
+# Query for refinery sankey: connection between import of crude oil and refinery
+
+- unit = PJ
+- query =
+    DIVIDE(V(industry_refinery_transformation_crude_oil, input_of_crude_oil),BILLIONS) * 
+      V(energy_import_crude_oil, share_of_energy_distribution_crude_oil)

--- a/gqueries/output_elements/output_series/refinery_189/diesel_distribution_to_energy_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/diesel_distribution_to_energy_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of diesel in the energy sector
+
+- unit = PJ
+- query = DIVIDE(V(energy_power_engine_diesel, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/diesel_distribution_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/diesel_distribution_to_export_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and export of diesel
+
+- unit = PJ
+- query = DIVIDE(V(energy_export_diesel, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/diesel_distribution_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/diesel_distribution_to_transport_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of diesel in transport
+
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_diesel, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/diesel_import_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/diesel_import_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between import and distribution of diesel
+
+- unit = PJ
+- query = DIVIDE(V(energy_import_diesel, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/diesel_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/diesel_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of diesel
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_diesel), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/gasoline_distribution_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/gasoline_distribution_to_export_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and export of gasoline
+
+- unit = PJ
+- query = DIVIDE(V(energy_export_gasoline, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/gasoline_distribution_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/gasoline_distribution_to_transport_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of gasoline in transport
+
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_gasoline, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/gasoline_import_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/gasoline_import_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between import and distribution of gasoline
+
+- unit = PJ
+- query = DIVIDE(V(energy_import_gasoline, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/gasoline_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/gasoline_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of gasoline
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_gasoline), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/hfo_distribution_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/hfo_distribution_to_export_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and export of heavy fuel oil
+
+- unit = PJ
+- query = DIVIDE(V(energy_export_heavy_fuel_oil, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/hfo_distribution_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/hfo_distribution_to_transport_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of heavy fuel oil in transport
+
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_of_heavy_fuel_oil, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/hfo_import_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/hfo_import_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between import and distribution of heavy fuel oil
+
+- unit = PJ
+- query = DIVIDE(V(energy_import_heavy_fuel_oil, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/hfo_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/hfo_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refeinry and distribution of heavy fuel oil
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_heavy_fuel_oil), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/kerosene_distribution_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/kerosene_distribution_to_export_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and export of kerosene
+
+- unit = PJ
+- query = DIVIDE(V(energy_export_kerosene, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/kerosene_distribution_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/kerosene_distribution_to_transport_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of kerosene in transport
+
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_kerosene, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/kerosene_import_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/kerosene_import_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between import and distribution of kerosene
+
+- unit = PJ
+- query = DIVIDE(V(energy_import_kerosene, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/kerosene_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/kerosene_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of kerosene
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_kerosene), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/lpg_distribution_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/lpg_distribution_to_export_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and export of lpg
+
+- unit = PJ
+- query = DIVIDE(V(energy_export_lpg, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/lpg_distribution_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/lpg_distribution_to_transport_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of lpg in transport
+
+- unit = PJ
+- query = DIVIDE(V(transport_final_demand_lpg, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/lpg_import_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/lpg_import_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between import and distribution of lpg
+
+- unit = PJ
+- query = DIVIDE(V(energy_import_lpg, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/lpg_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/lpg_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of lpg
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_lpg), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/oil_products_distribution_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/oil_products_distribution_to_export_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and export of oil products
+
+- unit = PJ
+- query = DIVIDE(V(energy_export_oil_products, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/oil_products_distribution_to_industry_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/oil_products_distribution_to_industry_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of oil products in industry
+
+- unit = PJ
+- query = DIVIDE(V(industry_final_demand_for_chemical_other_crude_oil_non_energetic, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/oil_products_import_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/oil_products_import_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between import and distribution of oil_products
+
+- unit = PJ
+- query = DIVIDE(V(industry_final_demand_for_chemical_crude_oil_non_energetic, demand), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/oil_products_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/oil_products_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of oil products
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_oil_products), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/refinery_gas_distribution_to_industry_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/refinery_gas_distribution_to_industry_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between distribution and use of refinery gas in industry
+
+- unit = PJ
+- query = DIVIDE(V(industry_locally_available_refinery_gas_for_chemical, demand), BILLIONS) 

--- a/gqueries/output_elements/output_series/refinery_189/refinery_gas_refinery_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/refinery_gas_refinery_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of refinery gas
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_refinery_gas), BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/refinery_heat_input_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/refinery_heat_input_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between heat input and refinery
+
+- unit = PJ
+- query = DIVIDE(V(industry_useful_demand_for_chemical_refineries_useable_heat, demand),BILLIONS)

--- a/gqueries/output_elements/output_series/refinery_189/refinery_loss_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/refinery_loss_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and loss
+
+- unit = PJ
+- query = DIVIDE(V(industry_refinery_transformation_crude_oil, output_of_loss),BILLIONS)


### PR DESCRIPTION
The commit in this pull request contains the gqueries that are required for the new refinery sankey type chart, see quintel/etmodel#2201.