### PR TITLE
Adding biocoal input to central coal-fired heater

### DIFF
--- a/edges/energy/energy_distribution_torrified_biomass_pellets-energy_heater_for_heat_network_coal@torrified_biomass_pellets.ad
+++ b/edges/energy/energy_distribution_torrified_biomass_pellets-energy_heater_for_heat_network_coal@torrified_biomass_pellets.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/inputs/supply/coal_plant_fuel/co_firing_biocoal_share.ad
+++ b/inputs/supply/coal_plant_fuel/co_firing_biocoal_share.ad
@@ -1,5 +1,6 @@
 - query =
     EACH(
+      UPDATE( INPUT_SLOTS(V(energy_heater_for_heat_network_coal), torrified_biomass_pellets), conversion, USER_INPUT() / 100.0 ),
       UPDATE( INPUT_SLOTS(V(energy_power_ultra_supercritical_coal), torrified_biomass_pellets), conversion, USER_INPUT() / 100.0 ),
       UPDATE( INPUT_SLOTS(V(energy_chp_ultra_supercritical_coal), torrified_biomass_pellets),   conversion, USER_INPUT() / 100.0 ),
       UPDATE( INPUT_SLOTS(V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite), torrified_biomass_pellets),   conversion, USER_INPUT() / 100.0 ),

--- a/inputs/supply/coal_plant_fuel/co_firing_coal_share.ad
+++ b/inputs/supply/coal_plant_fuel/co_firing_coal_share.ad
@@ -1,5 +1,6 @@
 - query =
     EACH(
+      UPDATE( INPUT_SLOTS(V(energy_heater_for_heat_network_coal), coal), conversion, USER_INPUT() / 100.0 ),
       UPDATE( INPUT_SLOTS(V(energy_power_ultra_supercritical_coal), coal), conversion, USER_INPUT() / 100.0 ),
       UPDATE( INPUT_SLOTS(V(energy_chp_ultra_supercritical_coal), coal),   conversion, USER_INPUT() / 100.0 ),
       UPDATE( INPUT_SLOTS(V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite), lignite), conversion, USER_INPUT() / 100.0 ),      

--- a/nodes/energy/energy_heater_for_heat_network_coal.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_coal.central_producer.ad
@@ -22,3 +22,7 @@
 - construction_time = 0.0
 - technical_lifetime = 15.0
 - wacc = 0.1
+
+~ input.coal = 1.0
+
+~ input.torrified_biomass_pellets = 0.0


### PR DESCRIPTION
The commits in the pull request do:
- connect the central coal-fired heater to the distribution of torrified biomass pellets
- make the (bio)coal sliders update the input shares of this central coal-fired heater

This closes https://github.com/quintel/etmodel/issues/2203.