### PR TITLE
Included flexibility options in excess events chart

### DIFF
--- a/gqueries/output_elements/output_series/d3_175_merit_order_excess_events/number_of_excess_events.gql
+++ b/gqueries/output_elements/output_series/d3_175_merit_order_excess_events/number_of_excess_events.gql
@@ -3,10 +3,6 @@
     GRAPH(),
     group_of_excess_events((1..24).to_a, [
       :energy_flexibility_curtailment_electricity,
-      :energy_export_electricity,
-      :households_flexibility_p2h_electricity,
-      :energy_flexibility_p2g_electricity,
-      :transport_car_using_electricity,
-      :households_flexibility_p2p_electricity
+      :energy_export_electricity
     ])
   )


### PR DESCRIPTION
This fixes https://github.com/quintel/etmodel/issues/2188.