### PR TITLE
Updated availability for various converters

### DIFF
--- a/nodes/energy/energy_heater_for_heat_network_coal.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_coal.central_producer.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.72
 - groups = [central_production, cost_traditional_heat, heat_production]
-- availability = 0.0
+- availability = 0.25
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_crude_oil.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_crude_oil.central_producer.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.72
 - groups = [central_production, cost_traditional_heat, heat_production]
-- availability = 0.0
+- availability = 0.25
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_lignite.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_lignite.central_producer.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.72
 - groups = [central_production, cost_traditional_heat, heat_production]
-- availability = 0.0
+- availability = 0.25
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_network_gas.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_network_gas.central_producer.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.74
 - groups = [central_production, cost_traditional_heat, heat_production]
-- availability = 0.0
+- availability = 0.25
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_waste_mix.central_producer.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.74
 - groups = [central_production, cost_traditional_heat, heat_production]
-- availability = 0.0
+- availability = 0.25
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.0

--- a/nodes/energy/energy_heater_for_heat_network_wood_pellets.central_producer.ad
+++ b/nodes/energy/energy_heater_for_heat_network_wood_pellets.central_producer.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.812
 - groups = [central_production, cost_traditional_heat, heat_production]
-- availability = 0.0
+- availability = 0.25
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.0

--- a/nodes/energy/energy_power_hydro_mountain.central_producer.ad
+++ b/nodes/energy/energy_power_hydro_mountain.central_producer.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - groups = [preset_demand, central_production, cost_electricity_production, electricity_production, primary_energy_demand, sustainable_production, dispatchable_production]
 - merit_order.type = dispatchable
-- availability = 0.33
+- availability = 0.51
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 100.0

--- a/nodes/energy/energy_power_nuclear_gen2_uranium_oxide.central_producer.ad
+++ b/nodes/energy/energy_power_nuclear_gen2_uranium_oxide.central_producer.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - groups = [preset_demand, central_production, cost_electricity_production, electricity_production, merit_order_converters_for_dashboard, dispatchable_production]
 - merit_order.type = dispatchable
-- availability = 0.87
+- availability = 0.89
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 5.0

--- a/nodes/energy/energy_power_ultra_supercritical_cofiring_coal.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_cofiring_coal.central_producer.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - groups = [preset_demand, central_production, cost_electricity_production, electricity_production, dispatchable_production]
 - merit_order.type = dispatchable
-- availability = 0.88
+- availability = 0.90
 - free_co2_factor = 0.0
 - forecasting_error = 0.0
 - land_use_per_unit = 0.3


### PR DESCRIPTION
I updated the availability according to the FLH(present) provided by the Power and heat plant analysis. The availability was updated as follows:

Converter | FLH (Present) | Previous availability  | Updated availability
------------ | ------------|------------- | -------------
energy_power_nuclear_gen2_uranium_oxide | 7800 | 0.87 |0.89
energy_power_hydro_mountain | 4492 | 0.33 | 0.51
energy_power_ultra_supercritical_cofiring_coal | 7900 | 0.88 |0.90
energy_heater_for_heat_network_coal | 2190| 0.00 | 0.25
energy_heater_for_heat_network_network_gas | 2190 | 0.00 | 0.25
energy_heater_for_heat_network_lignite | 2190 | 0.00 | 0.25
energy_heater_for_heat_network_wood_pellets | 2190 | 0.00 | 0.25
energy_heater_for_heat_network_waste_mix | 2190 | 0.00 | 0.25
energy_heater_for_heat_network_crude_oil | 2190 | 0.00 | 0.25
 

Note in 2013 the energy_power_nuclear_gen2_uranium_oxide ran at 5700 FLH and thus there is no longer a discrepancy with availability. However from the 2012 we know that this power plant can run at 7800 FLH and thus availability was adjusted to match the possible FLHs.

Fixes #1936