### PR TITLE
Relative co2 chart

### DIFF
--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives.gql
@@ -1,0 +1,10 @@
+# CO2 of carrier group 'coal'
+
+- unit = tonne
+- query =
+    SUM(
+      V(G(final_demand_group),primary_demand_of_coal).sum * V(CARRIER(coal), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_coal_gas).sum * V(CARRIER(coal_gas), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_cokes).sum * V(CARRIER(cokes), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_lignite).sum * V(CARRIER(lignite), co2_per_mj)
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives.gql
@@ -1,0 +1,8 @@
+# CO2 of carrier group 'natural_gas'
+
+- unit = tonne
+- query =
+    SUM(
+      V(G(final_demand_group),primary_demand_of_natural_gas).sum * V(CARRIER(natural_gas), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_lng).sum * V(CARRIER(lng), co2_per_mj)
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives.gql
@@ -1,0 +1,12 @@
+# CO2 of carrier group 'crude_oil'
+
+- unit = tonne
+- query =
+    SUM(
+      V(G(final_demand_group),primary_demand_of_crude_oil).sum * V(CARRIER(crude_oil), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_gasoline).sum * V(CARRIER(gasoline), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_diesel).sum * V(CARRIER(diesel), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_kerosene).sum * V(CARRIER(kerosene), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_lpg).sum * V(CARRIER(lpg), co2_per_mj),
+      V(G(final_demand_group),primary_demand_of_heavy_fuel_oil).sum * V(CARRIER(heavy_fuel_oil), co2_per_mj)
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_total.gql
+++ b/gqueries/general/co2/primary_co2_of_total.gql
@@ -1,0 +1,9 @@
+# Primary CO2 of final demand for oil, gas and coal
+
+- unit = tonne
+- query =
+    SUM(
+        Q(primary_co2_of_oil_and_derivatives),
+        Q(primary_co2_of_natural_gas_and_derivatives),
+        Q(primary_co2_of_coal_and_derivatives)
+    )

--- a/gqueries/general/co2/relative_primary_co2_of_coal_and_derivatives.gql
+++ b/gqueries/general/co2/relative_primary_co2_of_coal_and_derivatives.gql
@@ -1,6 +1,6 @@
 - unit = fraction
 - query =
     IF(Q(primary_co2_of_total) > 0.0, 
-        Q(primary_co2_of_coal_and_derivatives) / Q(primary_co2_of_total),
+        100.0 * Q(primary_co2_of_coal_and_derivatives) / Q(primary_co2_of_total),
         0.0
     )

--- a/gqueries/general/co2/relative_primary_co2_of_coal_and_derivatives.gql
+++ b/gqueries/general/co2/relative_primary_co2_of_coal_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = fraction
+- query =
+    IF(Q(primary_co2_of_total) > 0.0, 
+        Q(primary_co2_of_coal_and_derivatives) / Q(primary_co2_of_total),
+        0.0
+    )

--- a/gqueries/general/co2/relative_primary_co2_of_natural_gas_and_derivatives.gql
+++ b/gqueries/general/co2/relative_primary_co2_of_natural_gas_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = fraction
+- query =
+    IF(Q(primary_co2_of_total) > 0.0, 
+        Q(primary_co2_of_natural_gas_and_derivatives) / Q(primary_co2_of_total),
+        0.0
+    )

--- a/gqueries/general/co2/relative_primary_co2_of_natural_gas_and_derivatives.gql
+++ b/gqueries/general/co2/relative_primary_co2_of_natural_gas_and_derivatives.gql
@@ -1,6 +1,6 @@
 - unit = fraction
 - query =
     IF(Q(primary_co2_of_total) > 0.0, 
-        Q(primary_co2_of_natural_gas_and_derivatives) / Q(primary_co2_of_total),
+        100.0 * Q(primary_co2_of_natural_gas_and_derivatives) / Q(primary_co2_of_total),
         0.0
     )

--- a/gqueries/general/co2/relative_primary_co2_of_oil_and_derivatives.gql
+++ b/gqueries/general/co2/relative_primary_co2_of_oil_and_derivatives.gql
@@ -1,6 +1,6 @@
 - unit = fraction
 - query =
     IF(Q(primary_co2_of_total) > 0.0, 
-        Q(primary_co2_of_oil_and_derivatives) / Q(primary_co2_of_total),
+        100.0 * Q(primary_co2_of_oil_and_derivatives) / Q(primary_co2_of_total),
         0.0
     )

--- a/gqueries/general/co2/relative_primary_co2_of_oil_and_derivatives.gql
+++ b/gqueries/general/co2/relative_primary_co2_of_oil_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = fraction
+- query =
+    IF(Q(primary_co2_of_total) > 0.0, 
+        Q(primary_co2_of_oil_and_derivatives) / Q(primary_co2_of_total),
+        0.0
+    )

--- a/gqueries/general/primary_demand/primary_demand_of_coal_and_derivatives.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_coal_and_derivatives.gql
@@ -1,0 +1,8 @@
+- unit = PJ
+- query =
+    SUM(
+      V(G(final_demand_group),primary_demand_of_coal).sum ,
+      V(G(final_demand_group),primary_demand_of_coal_gas).sum,
+      V(G(final_demand_group),primary_demand_of_cokes).sum,
+      V(G(final_demand_group),primary_demand_of_lignite).sum
+    ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_natural_gas_and_derivatives.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_natural_gas_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = PJ
+- query =
+    SUM(
+      V(G(final_demand_group),primary_demand_of_natural_gas).sum,
+      V(G(final_demand_group),primary_demand_of_lng)
+    ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_oil_and_derivatives.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_oil_and_derivatives.gql
@@ -1,0 +1,10 @@
+- unit = PJ
+- query =
+    SUM(
+      V(G(final_demand_group),primary_demand_of_crude_oil).sum,
+      V(G(final_demand_group),primary_demand_of_gasoline).sum,
+      V(G(final_demand_group),primary_demand_of_diesel).sum,
+      V(G(final_demand_group),primary_demand_of_kerosene).sum,
+      V(G(final_demand_group),primary_demand_of_lpg).sum,
+      V(G(final_demand_group),primary_demand_of_heavy_fuel_oil).sum
+    ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_oil_coal_and_gas.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_oil_coal_and_gas.gql
@@ -1,0 +1,7 @@
+- unit = PJ
+- query =
+    SUM(
+      Q(primary_demand_of_oil_and_derivatives),
+      Q(primary_demand_of_coal_and_derivatives),
+      Q(primary_demand_of_natural_gas_and_derivatives)
+    )

--- a/gqueries/general/primary_demand/relative_primary_demand_of_coal_and_derivatives.gql
+++ b/gqueries/general/primary_demand/relative_primary_demand_of_coal_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = fraction
+- query =
+    IF(Q(primary_demand_of_oil_coal_and_gas) > 0.0, 
+        100.0 * Q(primary_demand_of_coal_and_derivatives) / Q(primary_demand_of_oil_coal_and_gas),
+        0.0
+    )

--- a/gqueries/general/primary_demand/relative_primary_demand_of_natural_gas_and_derivatives.gql
+++ b/gqueries/general/primary_demand/relative_primary_demand_of_natural_gas_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = fraction
+- query =
+    IF(Q(primary_demand_of_oil_coal_and_gas) > 0.0, 
+        100.0 * Q(primary_demand_of_natural_gas_and_derivatives) / Q(primary_demand_of_oil_coal_and_gas),
+        0.0
+    )

--- a/gqueries/general/primary_demand/relative_primary_demand_of_oil_and_derivatives.gql
+++ b/gqueries/general/primary_demand/relative_primary_demand_of_oil_and_derivatives.gql
@@ -1,0 +1,6 @@
+- unit = fraction
+- query =
+    IF(Q(primary_demand_of_oil_coal_and_gas) > 0.0, 
+        100.0 * Q(primary_demand_of_oil_and_derivatives) / Q(primary_demand_of_oil_coal_and_gas),
+        0.0
+    )


### PR DESCRIPTION
I've added some queries for charts requested by Gasunie:
![energy_transition_model_-_your_free__independent__comprehensive__fact-based_scenario_builder_](https://cloud.githubusercontent.com/assets/1303760/19974624/5d26dac4-a1e9-11e6-973b-cd7261c89a83.png)

The etmodel translations are to be found here: https://github.com/quintel/etmodel/pull/2294

To add the relevant output element series to the database:
```sql
INSERT INTO `output_element_series` (`id`, `output_element_id`, `label`, `color`, `order_by`, `group`, `created_at`, `updated_at`, `show_at_first`, `is_target_line`, `target_line_position`, `gquery`)
VALUES
	(NULL, 193, 'oil_and_derivatives', '#854321', 1, '', '2016-11-03 13:59:18', '2016-11-03 13:59:18', NULL, NULL, NULL, 'relative_primary_co2_of_oil_and_derivatives'),
	(NULL, 193, 'natural_gas_and_derivatives', '#CCCCCC', 2, '', '2016-08-08 14:36:11', '2016-08-08 14:36:11', NULL, NULL, NULL, 'relative_primary_co2_of_natural_gas_and_derivatives'),
	(NULL, 193, 'coal_and_derivatives', '#333333', 3, '', '2016-08-08 14:36:11', '2016-08-08 14:36:11', NULL, NULL, NULL, 'relative_primary_co2_of_coal_and_derivatives'),
	(NULL, 194, 'oil_and_derivatives', '#854321', 1, '', '2016-11-03 13:59:18', '2016-11-03 13:59:18', NULL, NULL, NULL, 'relative_primary_demand_of_oil_and_derivatives'),
	(NULL, 194, 'natural_gas_and_derivatives', '#CCCCCC', 2, '', '2016-08-08 14:36:11', '2016-08-08 14:36:11', NULL, NULL, NULL, 'relative_primary_demand_of_natural_gas_and_derivatives'),
	(NULL, 194, 'coal_and_derivatives', '#333333', 3, '', '2016-08-08 14:36:11', '2016-08-08 14:36:11', NULL, NULL, NULL, 'relative_primary_demand_of_coal_and_derivatives');
```

To add the output elements:
```sql
INSERT INTO `output_elements` (`id`, `output_element_type_id`, `created_at`, `updated_at`, `under_construction`, `unit`, `percentage`, `group`, `sub_group`, `show_point_label`, `growth_chart`, `key`, `max_axis_value`, `min_axis_value`, `hidden`, `requires_merit_order`)
VALUES
	(NULL, 11, '0000-00-00 00:00:00', '2011-03-10 06:04:34', 0, '%', NULL, 'Overview', NULL, NULL, NULL, 'relative_primary_co2', NULL, NULL, 0, 0),
	(NULL, 11, '0000-00-00 00:00:00', '2011-03-10 06:04:34', 0, '%', NULL, 'Overview', NULL, NULL, NULL, 'relative_primary_demand_of_coal_oil_and_gas', NULL, NULL, 0, 0);

```
