### PR TITLE
Created and input statement to set the number_of_cars AREA attribute …

### DIFF
--- a/inputs/adjust_scaling/number_of_cars_both.ad
+++ b/inputs/adjust_scaling/number_of_cars_both.ad
@@ -1,0 +1,3 @@
+- query = UPDATE(AREA(), number_of_cars, USER_INPUT())
+- priority = 8
+- update_period = both


### PR DESCRIPTION
…for both future and present, after realizing a scaled scenario retains the future number_of_cars attribute from scaling even when the present attribute is updated. This makes sense, but is not immediately apparent as the energy demand does not depend on this attribute. The front-end therefore shows no change.