### PR TITLE
Rake task for decrypting energy balances uses a multi-user secure way

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -308,32 +308,21 @@ desc <<-DESC
   Decrypts the energy balance for every area.
 DESC
 task :decrypt do
-  if ENV['ETS_PASSWORD']
-    puts 'Using password from ETS_PASSWORD environment variable'
-    password = ENV['ETS_PASSWORD'].strip
-  elsif File.exists?('.password')
+  if File.exists?('.password')
     puts "Using password that is stored in .password..."
-    password = File.read('.password').strip
+    puts "Start Decrypting..."
+    Dir.glob('datasets/*').each do |area|
+      if File.exists?("#{ area }/energy_balance.gpg")
+        puts "* #{ area }"
+        cmd = "gpg --batch --yes --no-use-agent --passphrase-file .password" +
+              " --output #{ area }/energy_balance.csv --decrypt #{ area }/energy_balance.gpg"
+        puts `#{ cmd }`
+      end
+    end
+    puts "Done!"
   else
-    puts "File .password not found in root."
-    puts "Please Enter Passphrase to decrypt files:"
-    password = $stdin.gets.strip
+    puts "ERROR: File .password not found in current directory!"
   end
-
-  puts "Start Decrypting..."
-  Dir.glob('datasets/*').each do |area|
-    if File.exists?("#{ area }/energy_balance.gpg")
-      puts "* #{ area }"
-      cmd = "gpg --passphrase-fd 0 -d #{ area }/energy_balance.gpg > #{ area }/energy_balance.csv"
-      pipe = IO.popen(cmd, 'r+')
-      pipe.print(password)
-      pipe.close_write
-      puts pipe.read
-      pipe.close
-     end
-  end
-
-  puts "Done!"
 end
 
 desc <<-DESC

--- a/Rakefile
+++ b/Rakefile
@@ -324,8 +324,12 @@ task :decrypt do
   Dir.glob('datasets/*').each do |area|
     if File.exists?("#{ area }/energy_balance.gpg")
       puts "* #{ area }"
-      cmd = "echo '#{ password }' | gpg --passphrase-fd 0 -d #{ area }/energy_balance.gpg > #{ area }/energy_balance.csv"
-      puts `#{ cmd }`
+      cmd = "gpg --passphrase-fd 0 -d #{ area }/energy_balance.gpg > #{ area }/energy_balance.csv"
+      pipe = IO.popen(cmd, 'r+')
+      pipe.print(password)
+      pipe.close_write
+      puts pipe.read
+      pipe.close
      end
   end
 


### PR DESCRIPTION
The old method was not secure on multi-user machines since the secret
password showed up in the (world-readable) process list while executing the task