### PR TITLE
Make conditionals in gqueries more robust

### DIFF
--- a/gqueries/output_elements/dashboard/households_heater_combined_network_gas_total_cost_for_correction.gql
+++ b/gqueries/output_elements/dashboard/households_heater_combined_network_gas_total_cost_for_correction.gql
@@ -1,12 +1,12 @@
-# investment costs of households_space_heater_combined_network_gas 
+# investment costs of households_space_heater_combined_network_gas
 # and households_water_heater_combined_network_gas
 # IF newly built (green field approach)
 # Corrected for double counting
 
 - query =
     IF(
-        QUERY_FUTURE(households_space_heater_combined_network_gas_future_in_investment_cost_table) > 
-        QUERY_FUTURE(households_water_heater_combined_network_gas_future_in_investment_cost_table),
+        QUERY_FUTURE(households_space_heater_combined_network_gas_future_in_investment_cost_table) -
+        QUERY_FUTURE(households_water_heater_combined_network_gas_future_in_investment_cost_table) > 1e-6,
         V(households_space_heater_combined_network_gas,fixed_costs_per(:converter)),
         V(households_water_heater_combined_network_gas,fixed_costs_per(:converter))
     )

--- a/gqueries/output_elements/output_series/table_142_investments/households_heater_combined_network_gas_present_in_investment_cost_table.gql
+++ b/gqueries/output_elements/output_series/table_142_investments/households_heater_combined_network_gas_present_in_investment_cost_table.gql
@@ -1,12 +1,12 @@
-# investment costs of households_space_heater_combined_network_gas 
+# investment costs of households_space_heater_combined_network_gas
 # and households_water_heater_combined_network_gas
 # IF newly built (green field approach)
 # Corrected for double counting
 
 - query =
     present:IF(
-        QUERY_FUTURE(households_space_heater_combined_network_gas_future_in_investment_cost_table) > 
-        QUERY_FUTURE(households_water_heater_combined_network_gas_future_in_investment_cost_table),
+        QUERY_FUTURE(households_space_heater_combined_network_gas_future_in_investment_cost_table) -
+        QUERY_FUTURE(households_water_heater_combined_network_gas_future_in_investment_cost_table) > 1e-6,
         Q(households_space_heater_combined_network_gas_present_in_investment_cost_table),
         Q(households_water_heater_combined_network_gas_present_in_investment_cost_table)
     )


### PR DESCRIPTION
Rationale: If the values are basically identical, we
still want to have a determinate outcome - even in
case of rounding errors