### PR TITLE
Correction investment costs cars using electricity, in query

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_170_investment_electric_cars/electric_cars_additional_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_170_investment_electric_cars/electric_cars_additional_costs.gql
@@ -1,2 +1,2 @@
-- query = V(transport_car_using_hydrogen, initial_investment)
+- query = V(transport_car_using_electricity, initial_investment)
 - unit = euro


### PR DESCRIPTION
investment costs for cars using hydrogen were used

Mentioned in:
quintel/etmodel#2360 (comment)