### PR TITLE
Network cost queries

### DIFF
--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_sd.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(sd))
             ) * V(energy_power_lv_network_electricity,simult_sd)
                 * V(energy_power_transformer_lv_mv_electricity,simult_sd)
                 * V(energy_power_mv_distribution_network_electricity, simult_sd)

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_sd.gql
@@ -5,11 +5,13 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) })
-                        *V(energy_power_lv_network_electricity,simult_sd)
-                        *V(energy_power_transformer_lv_mv_electricity,simult_sd)
-                        *V(energy_power_mv_distribution_network_electricity, simult_sd)
-                        *V(energy_power_mv_transport_network_electricity,simult_sd)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+            ) * V(energy_power_lv_network_electricity,simult_sd)
+                * V(energy_power_transformer_lv_mv_electricity,simult_sd)
+                * V(energy_power_mv_distribution_network_electricity, simult_sd)
+                * V(energy_power_mv_transport_network_electricity,simult_sd)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_sd*peak_load_in_mw")) })
                     *V(energy_power_mv_distribution_network_electricity, simult_sd)

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_se.gql
@@ -2,15 +2,16 @@
 # This Gquery takes into account all technologies below the HV/MV network and their simultaneousnesses
 # If the additional peak load in the future scenario is lower than in the present scenario, this Gquery returns 0.0
 
-
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) })
-                        *V(energy_power_lv_network_electricity,simult_se)
-                        *V(energy_power_transformer_lv_mv_electricity,simult_se)
-                        *V(energy_power_mv_distribution_network_electricity, simult_se)
-                        *V(energy_power_mv_transport_network_electricity,simult_se)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+            ) * V(energy_power_lv_network_electricity,simult_se)
+                * V(energy_power_transformer_lv_mv_electricity,simult_se)
+                * V(energy_power_mv_distribution_network_electricity, simult_se)
+                * V(energy_power_mv_transport_network_electricity,simult_se)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_se*peak_load_in_mw")) })
                     *V(energy_power_mv_distribution_network_electricity, simult_se)

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_se.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(se))
             ) * V(energy_power_lv_network_electricity,simult_se)
                 * V(energy_power_transformer_lv_mv_electricity,simult_se)
                 * V(energy_power_mv_distribution_network_electricity, simult_se)

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_wd.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(wd))
             ) * V(energy_power_lv_network_electricity,simult_wd)
                 * V(energy_power_transformer_lv_mv_electricity,simult_wd)
                 * V(energy_power_mv_distribution_network_electricity, simult_wd)

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_wd.gql
@@ -2,21 +2,22 @@
 # This Gquery takes into account all technologies below the HV/MV network and their simultaneousnesses
 # If the additional peak load in the future scenario is lower than in the present scenario, this Gquery returns 0.0
 
-
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) })
-                        *V(energy_power_lv_network_electricity,simult_sd)
-                        *V(energy_power_transformer_lv_mv_electricity,simult_sd)
-                        *V(energy_power_mv_distribution_network_electricity, simult_sd)
-                        *V(energy_power_mv_transport_network_electricity,simult_sd)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+            ) * V(energy_power_lv_network_electricity,simult_wd)
+                * V(energy_power_transformer_lv_mv_electricity,simult_wd)
+                * V(energy_power_mv_distribution_network_electricity, simult_wd)
+                * V(energy_power_mv_transport_network_electricity,simult_wd)
             ,
-            QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_sd*peak_load_in_mw")) })
-                    *V(energy_power_mv_distribution_network_electricity, simult_sd)
-                    *V(energy_power_mv_transport_network_electricity,simult_sd)
+            QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_wd*peak_load_in_mw")) })
+                    *V(energy_power_mv_distribution_network_electricity, simult_wd)
+                    *V(energy_power_mv_transport_network_electricity,simult_wd)
             ,
-            QUERY_DELTA( -> {SUM(V(Q(network_hv_mv_trafo_converters),"simult_sd*peak_load_in_mw")) })
+            QUERY_DELTA( -> {SUM(V(Q(network_hv_mv_trafo_converters),"simult_wd*peak_load_in_mw")) })
         ),
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_we.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(we))
             ) * V(energy_power_lv_network_electricity,simult_we)
                 * V(energy_power_transformer_lv_mv_electricity,simult_we)
                 * V(energy_power_mv_distribution_network_electricity, simult_we)

--- a/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/hv_mv_trafo/network_hv_mv_trafo_peak_load_we.gql
@@ -5,11 +5,13 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) })
-                        *V(energy_power_lv_network_electricity,simult_we)
-                        *V(energy_power_transformer_lv_mv_electricity,simult_we)
-                        *V(energy_power_mv_distribution_network_electricity, simult_we)
-                        *V(energy_power_mv_transport_network_electricity,simult_we)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+            ) * V(energy_power_lv_network_electricity,simult_we)
+                * V(energy_power_transformer_lv_mv_electricity,simult_we)
+                * V(energy_power_mv_distribution_network_electricity, simult_we)
+                * V(energy_power_mv_transport_network_electricity,simult_we)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_we*peak_load_in_mw")) })
                     *V(energy_power_mv_distribution_network_electricity, simult_we)

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_sd.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(sd))
         ),
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_sd.gql
@@ -4,7 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+        ),
         0.0
     )
 - unit = MW

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_se.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(se))
         ),
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_se.gql
@@ -4,7 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+        ),
         0.0
     )
 - unit = MW

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_wd.gql
@@ -4,7 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+        ),
         0.0
     )
 - unit = MW

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_wd.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(wd))
         ),
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_we.gql
@@ -4,7 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+        ),
         0.0
     )
 - unit = MW

--- a/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/lv_net/network_lv_net_peak_load_we.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(we))
         ),
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_sd.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(sd))
             )       * V(energy_power_lv_network_electricity,simult_sd)
                     * V(energy_power_transformer_lv_mv_electricity,simult_sd)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_sd.gql
@@ -5,9 +5,11 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_sd)
-                    *V(energy_power_transformer_lv_mv_electricity,simult_we)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+            )       * V(energy_power_lv_network_electricity,simult_sd)
+                    * V(energy_power_transformer_lv_mv_electricity,simult_sd)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_sd*peak_load_in_mw")) })
         ),

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_se.gql
@@ -5,9 +5,11 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_se)
-                    *V(energy_power_transformer_lv_mv_electricity,simult_we)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+            )       * V(energy_power_lv_network_electricity,simult_se)
+                    * V(energy_power_transformer_lv_mv_electricity,simult_se)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_se*peak_load_in_mw")) })
         ),

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_se.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(se))
             )       * V(energy_power_lv_network_electricity,simult_se)
                     * V(energy_power_transformer_lv_mv_electricity,simult_se)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_wd.gql
@@ -5,9 +5,11 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_wd)
-                    *V(energy_power_transformer_lv_mv_electricity,simult_we)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+            ) * V(energy_power_lv_network_electricity,simult_wd)
+                *V(energy_power_transformer_lv_mv_electricity,simult_wd)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_wd*peak_load_in_mw")) })
         ),

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_wd.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(wd))
             ) * V(energy_power_lv_network_electricity,simult_wd)
               * V(energy_power_transformer_lv_mv_electricity,simult_wd)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_wd.gql
@@ -9,7 +9,7 @@
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
                 GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
             ) * V(energy_power_lv_network_electricity,simult_wd)
-                *V(energy_power_transformer_lv_mv_electricity,simult_wd)
+              * V(energy_power_transformer_lv_mv_electricity,simult_wd)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_wd*peak_load_in_mw")) })
         ),

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_we.gql
@@ -4,7 +4,10 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) })
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+            ) 
                     *V(energy_power_lv_network_electricity,simult_we)
                     *V(energy_power_transformer_lv_mv_electricity,simult_we)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_we.gql
@@ -1,15 +1,15 @@
 # This Gquery calculates the additional peak load as a result of the electrical technologies that are installed in a scenario for a winter evening
 # Required new MV-distribution network capacity during
 # If the additional peak load in the future scenario is lower than in the present scenario, this Gquery returns 0.0
+
 - query =
     MAX(
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
                 GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
-            ) 
-                    *V(energy_power_lv_network_electricity,simult_we)
-                    *V(energy_power_transformer_lv_mv_electricity,simult_we)
+            ) * V(energy_power_lv_network_electricity,simult_we)
+              * V(energy_power_transformer_lv_mv_electricity,simult_we)
             ,
             QUERY_DELTA( -> {SUM(V(Q(network_mv_d_net_converters),"simult_we*peak_load_in_mw")) })
         ),

--- a/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_d_net/network_mv_d_net_peak_load_we.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(we))
             ) * V(energy_power_lv_network_electricity,simult_we)
               * V(energy_power_transformer_lv_mv_electricity,simult_we)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_sd.gql
@@ -4,8 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_sd)
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+        ) * V(energy_power_lv_network_electricity,simult_sd)
         ,
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_sd.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(sd))
         ) * V(energy_power_lv_network_electricity,simult_sd)
         ,
         0.0

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_se.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(se))
         ) * V(energy_power_lv_network_electricity,simult_se)
         ,
         0.0

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_se.gql
@@ -4,8 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_se)
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+        ) * V(energy_power_lv_network_electricity,simult_se)
         ,
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_wd.gql
@@ -4,8 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_wd)
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+        ) * V(energy_power_lv_network_electricity,simult_wd)
         ,
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_wd.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(wd))
         ) * V(energy_power_lv_network_electricity,simult_wd)
         ,
         0.0

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_we.gql
@@ -4,8 +4,10 @@
 
 - query =
     MAX(
-        QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_we)
+        SUM(
+            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
+            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+        ) * V(energy_power_lv_network_electricity,simult_we)
         ,
         0.0
     )

--- a/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_lv_trafo/network_mv_lv_trafo_peak_load_we.gql
@@ -6,7 +6,7 @@
     MAX(
         SUM(
             QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
-            GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+            V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(we))
         ) * V(energy_power_lv_network_electricity,simult_we)
         ,
         0.0

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_sd.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(sd))
             )       *V(energy_power_lv_network_electricity,simult_sd)
                     *V(energy_power_transformer_lv_mv_electricity,simult_sd)
                     *V(energy_power_mv_distribution_network_electricity, simult_sd)

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_sd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_sd.gql
@@ -5,8 +5,10 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_sd)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_sd*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_sd)
+            )       *V(energy_power_lv_network_electricity,simult_sd)
                     *V(energy_power_transformer_lv_mv_electricity,simult_sd)
                     *V(energy_power_mv_distribution_network_electricity, simult_sd)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_se.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(se))
             )       *V(energy_power_lv_network_electricity,simult_se)
                     *V(energy_power_transformer_lv_mv_electricity,simult_se)
                     *V(energy_power_mv_distribution_network_electricity, simult_se)

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_se.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_se.gql
@@ -5,8 +5,10 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_se)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_se*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_se)
+            )       *V(energy_power_lv_network_electricity,simult_se)
                     *V(energy_power_transformer_lv_mv_electricity,simult_se)
                     *V(energy_power_mv_distribution_network_electricity, simult_se)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_wd.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(wd))
             )       *V(energy_power_lv_network_electricity,simult_wd)
                     *V(energy_power_transformer_lv_mv_electricity,simult_wd)
                     *V(energy_power_mv_distribution_network_electricity, simult_wd)

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_wd.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_wd.gql
@@ -5,8 +5,10 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_wd)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_wd*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_wd)
+            )       *V(energy_power_lv_network_electricity,simult_wd)
                     *V(energy_power_transformer_lv_mv_electricity,simult_wd)
                     *V(energy_power_mv_distribution_network_electricity, simult_wd)
             ,

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_we.gql
@@ -7,7 +7,7 @@
         SUM(
             SUM(
                 QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
-                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+                V(GRAPH(), peak_load_of_explicitly_modelled_lv_technologies(we))
             )       *V(energy_power_lv_network_electricity,simult_we)
                     *V(energy_power_transformer_lv_mv_electricity,simult_we)
                     *V(energy_power_mv_distribution_network_electricity, simult_we)

--- a/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_we.gql
+++ b/gqueries/modules/network/network_impact_calculations/mv_t_net/network_mv_t_net_peak_load_we.gql
@@ -5,8 +5,10 @@
 - query =
     MAX(
         SUM(
-            QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) })
-                    *V(energy_power_lv_network_electricity,simult_we)
+            SUM(
+                QUERY_DELTA( -> {SUM(V(Q(network_lv_net_converters),"simult_we*peak_load_in_mw")) }),
+                GRAPH(peak_load_of_explicitly_modelled_lv_technologies_we)
+            )       *V(energy_power_lv_network_electricity,simult_we)
                     *V(energy_power_transformer_lv_mv_electricity,simult_we)
                     *V(energy_power_mv_distribution_network_electricity, simult_we)
             ,


### PR DESCRIPTION
This updates the network cost queries to include the explicitly-modelled technologies (EVs, household space heating, household hot water).

@ChaelKruip: **I've not merged this myself because I'd appreciate a quick sanity check from yourself.** I created a scenario using my local ETE/ETS and compared it with a live scenario. The only change from default settings was to increase household electric heaters from the default 1.2%, up to 100%.

![investment2](https://cloud.githubusercontent.com/assets/4383/26110228/a535b986-3a49-11e7-9c34-c6bc4c32cdb4.png)

There are two things to note:

1. The cost of additional infrastructure is *lower* due to the use of a "real" load, instead of taking the converter's peak load and [multiplying it](https://github.com/quintel/etsource/blob/234f86f9fd7fcabdbd2f7d59d0576c2c5486059b/nodes/households/households_space_heater_electricity.converter.ad#L19-L20) by a constant. The actual "peak load" of the explicitly modelled technologies [is not *hugely* different](https://gist.github.com/antw/1bf5386099f19bbfd7380da760a21369), so I think the blame for the different costs is the `simult_*` constants.

2. There is a large rise in electricity demand due to 100% of households having electric heaters. 70% of houses are old and poorly insulated, so the demand curve becomes very spikey. I think this makes sense, but it is quite a significant departure from the previous model with many more blackout hours (1249 on production, 2616 with the dynamic curve). Fully insulating all homes has [a dramatic effect on peak load and costs](https://cloud.githubusercontent.com/assets/4383/26110577/a87f20f4-3a4a-11e7-867b-057232af4def.png).

If this looks good to you, please merge at your convenience. If not, let me know if there are any other charts or data I can get for you.
