### PR TITLE
Validate presence and unity of EV profile shares

### DIFF
--- a/datasets/nl2012/nl2012.full.ad
+++ b/datasets/nl2012/nl2012.full.ad
@@ -75,3 +75,6 @@
 - investment_hv_net_high = 0.25
 - investment_hv_net_per_turbine = 1.2
 - number_of_cars = 7858712.0
+- electric_vehicle_profile_1_share = 1.0
+- electric_vehicle_profile_2_share = 0.0
+- electric_vehicle_profile_3_share = 0.0


### PR DESCRIPTION
* Bumps the Atlas version to assert that `electric_vehicle_profile_?_share` attributes are set, and that the three values sum to 1.0
* Adds missing shares for the NL2012 dataset.

Ref quintel/etengine#923