### PR TITLE
Set P2H sustainability to 1.0

### DIFF
--- a/nodes/energy/energy_flexibility_p2g_electricity.ad
+++ b/nodes/energy/energy_flexibility_p2g_electricity.ad
@@ -40,5 +40,6 @@
 - hours_place_nl = 0.0
 - hours_maint_nl = 0.0
 - hours_remov_nl = 0.0
+- sustainability_share = 1.0
 
 ~ demand = 0.0


### PR DESCRIPTION
P2G is supplied mostly by must-run renewables such as solar and wind energy. Setting its sustainability_share to 1.0 ensures that the resulting hydrogen is considered renewable/sustainable.

Closes quintel/etmodel#2403

## Comparison:

* 9000 offshore turbines
* 100% hydrogen cars

### P2G off

![p2g-off](https://cloud.githubusercontent.com/assets/4383/26408954/14b12194-4097-11e7-9f6b-d53a40012389.png)

### P2G for transport maxed, before this change

![p2g-on-old](https://cloud.githubusercontent.com/assets/4383/26408974/2402708a-4097-11e7-906a-174f82f03a1d.png)

### P2G for transport maxed, after this change

![p2g-on-new](https://cloud.githubusercontent.com/assets/4383/26408979/2e0438d4-4097-11e7-96ff-544aa810ede8.png)
