### PR TITLE
Update car converters to inherit number of units from parent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 group :development, :test do
-  gem 'atlas',    ref: '6eb0ad5', github: 'quintel/atlas'
+  gem 'atlas',    ref: 'cec2d64', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 group :development, :test do
-  gem 'atlas',    ref: 'cec2d64', github: 'quintel/atlas'
+  gem 'atlas',    ref: '1ab0482', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: 6eb0ad5f9a721ee31c4afa36b97a357d3d42ae9d
-  ref: 6eb0ad5
+  revision: cec2d6452ed6b5d3ea7386d3450561c9e33b1109
+  ref: cec2d64
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)
@@ -47,7 +47,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.4)
     equalizer (0.0.11)
-    i18n (0.8.1)
+    i18n (0.8.4)
     ice_nine (0.11.2)
     minitest (5.10.2)
     rake (10.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: cec2d6452ed6b5d3ea7386d3450561c9e33b1109
-  ref: cec2d64
+  revision: 1ab0482f69b026b64f02ea9b7afa81dd3b878300
+  ref: 1ab0482
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)

--- a/datasets/barendrecht/barendrecht.derived.ad
+++ b/datasets/barendrecht/barendrecht.derived.ad
@@ -82,9 +82,9 @@
 - base_dataset = nl
 - scaling.area_attribute = number_of_residences
 - scaling.base_value = 7449298
-- scaling.has_agriculture = 
-- scaling.has_energy = 
-- scaling.has_industry = 
+- scaling.has_agriculture =
+- scaling.has_energy =
+- scaling.has_industry =
 - scaling.value = 18615
 - init.agriculture_useful_demand_electricity = 0.0
 - init.agriculture_useful_demand_useable_heat = 0.0
@@ -178,6 +178,7 @@
 - init.number_of_agriculture_chp_engine_biogas = 0.0
 - init.number_of_agriculture_chp_engine_network_gas = 0.0
 - init.number_of_agriculture_chp_supercritical_wood_pellets = 0.0
+- init.number_of_cars = 22225.0
 - init.number_of_energy_chp_combined_cycle_network_gas = 0.0
 - init.number_of_energy_chp_supercritical_waste_mix = 0.0
 - init.number_of_energy_chp_ultra_supercritical_coal = 0.0

--- a/datasets/barendrecht/graph.yml
+++ b/datasets/barendrecht/graph.yml
@@ -5480,6 +5480,7 @@
       :loss:
         :type: :elastic
   :transport_useful_demand_car_kms:
+    :number_of_units: 19780.271375235625
     :in:
       :car_kms: {}
     :out:

--- a/datasets/de_Biezen/de_Biezen.derived.ad
+++ b/datasets/de_Biezen/de_Biezen.derived.ad
@@ -191,6 +191,7 @@
 
 # TRANSPORT
 - init.transport_useful_demand_car_kms = 26592404.871
+- init.number_of_cars = 1765.0
 - init.transport_useful_demand_planes = 0
 - init.transport_useful_demand_ship_kms = 0
 - init.transport_useful_demand_trains = 0

--- a/datasets/de_Biezen/graph.yml
+++ b/datasets/de_Biezen/graph.yml
@@ -5480,6 +5480,7 @@
       :loss:
         :type: :elastic
   :transport_useful_demand_car_kms:
+    :number_of_units: 1413.2560262725428
     :in:
       :car_kms: {}
     :out:

--- a/datasets/drenthe/drenthe.derived.ad
+++ b/datasets/drenthe/drenthe.derived.ad
@@ -290,3 +290,4 @@
 - init.number_of_industry_chp_turbine_gas_power_fuelmix = 0
 - init.households_solar_pv_solar_radiation_market_penetration = 4.09743266290988
 - init.buildings_solar_pv_solar_radiation_market_penetration = 0.530023683886235ß
+- init.number_of_cars = 253051

--- a/datasets/drenthe/graph.yml
+++ b/datasets/drenthe/graph.yml
@@ -5480,6 +5480,7 @@
       :loss:
         :type: :elastic
   :transport_useful_demand_car_kms:
+    :number_of_units: 225166.75073624388
     :in:
       :car_kms: {}
     :out:

--- a/datasets/groningen/graph.yml
+++ b/datasets/groningen/graph.yml
@@ -5480,6 +5480,7 @@
       :loss:
         :type: :elastic
   :transport_useful_demand_car_kms:
+    :number_of_units: 307691.33928391646
     :in:
       :car_kms: {}
     :out:

--- a/datasets/groningen/groningen.derived.ad
+++ b/datasets/groningen/groningen.derived.ad
@@ -82,9 +82,9 @@
 - base_dataset = nl
 - scaling.area_attribute = number_of_residences
 - scaling.base_value = 7449298
-- scaling.has_agriculture = 
-- scaling.has_energy = 
-- scaling.has_industry = 
+- scaling.has_agriculture =
+- scaling.has_energy =
+- scaling.has_industry =
 - scaling.value = 289565
 - init.agriculture_useful_demand_electricity = 0.0
 - init.agriculture_useful_demand_useable_heat = 0.0
@@ -191,6 +191,7 @@
 - init.co_firing_coal_share = 0.0
 - init.other_useful_demand_non_energetic = 0.0
 - init.transport_useful_demand_car_kms = 3916001550.0499997
+- init.number_of_cars = 259915.0
 - init.transport_useful_demand_planes = 0.0
 - init.transport_useful_demand_trains = 0.0
 - init.transport_useful_demand_truck_kms = 547000000.0

--- a/datasets/noorderplantsoen/graph.yml
+++ b/datasets/noorderplantsoen/graph.yml
@@ -5480,6 +5480,7 @@
       :loss:
         :type: :elastic
   :transport_useful_demand_car_kms:
+    :number_of_units: 2296.2753930638833
     :in:
       :car_kms: {}
     :out:

--- a/datasets/noorderplantsoen/noorderplantsoen.derived.ad
+++ b/datasets/noorderplantsoen/noorderplantsoen.derived.ad
@@ -221,6 +221,7 @@
 - init.number_of_industry_chp_turbine_gas_power_fuelmix = 0
 
 # TRANSPORT
+- init.number_of_cars = 930.0
 - init.transport_useful_demand_car_kms = 8876542.882
 - init.transport_useful_demand_planes = 0
 - init.transport_useful_demand_ship_kms = 0

--- a/datasets/paddepoel_noord/graph.yml
+++ b/datasets/paddepoel_noord/graph.yml
@@ -5480,6 +5480,7 @@
       :loss:
         :type: :elastic
   :transport_useful_demand_car_kms:
+    :number_of_units: 409.10042865784135
     :in:
       :car_kms: {}
     :out:

--- a/datasets/paddepoel_noord/paddepoel_noord.derived.ad
+++ b/datasets/paddepoel_noord/paddepoel_noord.derived.ad
@@ -189,6 +189,7 @@
 
 
 # TRANSPORT
+- init.number_of_cars = 154.0
 - init.transport_useful_demand_car_kms = 1470126.568
 - init.transport_useful_demand_planes = 0
 - init.transport_useful_demand_ship_kms = 0

--- a/gqueries/general/costs/costs_of_transport_vehicles.gql
+++ b/gqueries/general/costs/costs_of_transport_vehicles.gql
@@ -1,8 +1,8 @@
 # Return total cost of all electric cars
 
 - query =
-    SUM( 
-      V((transport_car_using_electricity), total_costs_per(:plant)) * V(LINK(transport_car_using_electricity, transport_useful_demand_car_kms), share) * QUERY_FUTURE(-> { AREA(number_of_cars) }),
-      V((transport_car_using_hydrogen), total_costs_per(:plant)) * V(LINK(transport_car_using_hydrogen, transport_useful_demand_car_kms), share) * QUERY_FUTURE(-> { AREA(number_of_cars) })
+    SUM(
+      V(transport_car_using_electricity, total_costs_per(:converter)),
+      V(transport_car_using_hydrogen, total_costs_per(:converter))
     )
 - unit = euro

--- a/gqueries/modules/scenario_report/number_of_electric_vehicles_per_year.gql
+++ b/gqueries/modules/scenario_report/number_of_electric_vehicles_per_year.gql
@@ -1,5 +1,5 @@
-- query = 
+- query =
     DIVIDE(
-        QUERY_DELTA( -> {V(transport_car_using_electricity, share_of_transport_useful_demand_car_kms)}) * AREA(number_of_cars),
-        Q(scenario_duration) 
+        QUERY_DELTA(-> { V(transport_car_using_electricity, number_of_units) }),
+        Q(scenario_duration)
     )

--- a/initializer_inputs/number_of/number_of_cars.ad
+++ b/initializer_inputs/number_of/number_of_cars.ad
@@ -1,0 +1,6 @@
+- query =
+    EACH(
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT()),
+      UPDATE(AREA(), number_of_cars, USER_INPUT())
+    )
+- priority = 10

--- a/initializer_inputs/transport/transport_car/transport_useful_demand_car_kms.ad
+++ b/initializer_inputs/transport/transport_car/transport_useful_demand_car_kms.ad
@@ -1,8 +1,6 @@
 - query =
     EACH(
-      UPDATE(V(transport_useful_demand_car_kms), preset_demand, USER_INPUT()),
-      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT()),
-      UPDATE(AREA(), number_of_cars, USER_INPUT())
+      UPDATE(V(transport_useful_demand_car_kms), preset_demand, USER_INPUT())
     )
 - priority = 10
 

--- a/initializer_inputs/transport/transport_car/transport_useful_demand_car_kms.ad
+++ b/initializer_inputs/transport/transport_car/transport_useful_demand_car_kms.ad
@@ -1,13 +1,8 @@
 - query =
     EACH(
       UPDATE(V(transport_useful_demand_car_kms), preset_demand, USER_INPUT()),
-      UPDATE(AREA(), number_of_cars, USER_INPUT()),
-      UPDATE(V(transport_car_using_compressed_natural_gas), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_diesel_mix), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_electricity), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_gasoline_mix), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_hydrogen), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_lpg), number_of_units, USER_INPUT())
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT()),
+      UPDATE(AREA(), number_of_cars, USER_INPUT())
     )
 - priority = 10
 

--- a/inputs/adjust_scaling/number_of/number_of_cars.ad
+++ b/inputs/adjust_scaling/number_of/number_of_cars.ad
@@ -1,3 +1,7 @@
-- query = UPDATE(AREA(), number_of_cars, USER_INPUT())
+- query =
+    EACH(
+      UPDATE(AREA(), number_of_cars, USER_INPUT()),
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT())
+    )
 - priority = 0
 - update_period = future

--- a/inputs/adjust_scaling/number_of/number_of_cars_both.ad
+++ b/inputs/adjust_scaling/number_of/number_of_cars_both.ad
@@ -1,3 +1,7 @@
-- query = UPDATE(AREA(), number_of_cars, USER_INPUT())
+- query =
+    EACH(
+      UPDATE(AREA(), number_of_cars, USER_INPUT()),
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT())
+    )
 - priority = 8
 - update_period = both

--- a/inputs/adjust_scaling/number_of/number_of_cars_present.ad
+++ b/inputs/adjust_scaling/number_of/number_of_cars_present.ad
@@ -1,3 +1,7 @@
-- query = UPDATE(AREA(), number_of_cars, USER_INPUT())
+- query =
+    EACH(
+      UPDATE(AREA(), number_of_cars, USER_INPUT()),
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT())
+    )
 - priority = 2
 - update_period = present

--- a/inputs/adjust_scaling/transport/transport_car/transport_useful_demand_car_kms_both.ad
+++ b/inputs/adjust_scaling/transport/transport_car/transport_useful_demand_car_kms_both.ad
@@ -1,13 +1,8 @@
-- query = 
+- query =
     EACH(
       UPDATE(V(transport_useful_demand_car_kms), preset_demand, USER_INPUT()),
-      UPDATE(AREA(), number_of_cars, USER_INPUT()),
-      UPDATE(V(transport_car_using_compressed_natural_gas), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_diesel_mix), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_electricity), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_gasoline_mix), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_hydrogen), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_lpg), number_of_units, USER_INPUT())
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT()),
+      UPDATE(AREA(), number_of_cars, USER_INPUT())
     )
 - priority = 10
 - max_value = 5.0

--- a/inputs/demand/transport/transport_car/transport_useful_demand_car_kms.ad
+++ b/inputs/demand/transport/transport_car/transport_useful_demand_car_kms.ad
@@ -1,13 +1,8 @@
 - query = 
     EACH(
       UPDATE(V(transport_useful_demand_car_kms), preset_demand, USER_INPUT()),
-      UPDATE(AREA(), number_of_cars, USER_INPUT()),
-      UPDATE(V(transport_car_using_compressed_natural_gas), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_diesel_mix), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_electricity), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_gasoline_mix), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_hydrogen), number_of_units, USER_INPUT()),
-      UPDATE(V(transport_car_using_lpg), number_of_units, USER_INPUT())
+      UPDATE(V(transport_useful_demand_car_kms), number_of_units, USER_INPUT()),
+      UPDATE(AREA(), number_of_cars, USER_INPUT())
     )
 - priority = 1
 - max_value = 5.0

--- a/nodes/transport/transport_car_using_diesel_mix.converter.ad
+++ b/nodes/transport/transport_car_using_diesel_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.526315789473684
 - output.loss = elastic
-- groups = [cost_other]
+- groups = [cost_other, inheritable_nou]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0

--- a/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/nodes/transport/transport_car_using_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.car_kms = 1.53846153846154
 - output.loss = elastic
-- groups = [cost_other, merit_ev_demand]
+- groups = [cost_other, merit_ev_demand, inheritable_nou]
 - merit_order.demand_profile = 
 - merit_order.demand_source = 
 - merit_order.group = electric_vehicle
@@ -37,6 +37,3 @@
 - technical_lifetime = 13.0
 - wacc = 0.0
 - reserved_fraction = 1.0
-- number_of_units = 11216.216216216
-# hard-coded number_of_units is a temporary fix of etmodel/2025
-# will be be replaced by a dynamic value in etsource/#1038

--- a/nodes/transport/transport_car_using_gasoline_mix.converter.ad
+++ b/nodes/transport/transport_car_using_gasoline_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.476190476190476
 - output.loss = elastic
-- groups = [cost_other]
+- groups = [cost_other, inheritable_nou]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0

--- a/nodes/transport/transport_car_using_hydrogen.converter.ad
+++ b/nodes/transport/transport_car_using_hydrogen.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.car_kms = 1.02040816326531
 - output.loss = elastic
-- groups = [cost_other]
+- groups = [cost_other, inheritable_nou]
 - free_co2_factor = 0.0
 - full_load_hours = 0.0
 - takes_part_in_ets = 0.0

--- a/nodes/transport/transport_car_using_lpg.converter.ad
+++ b/nodes/transport/transport_car_using_lpg.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.5
 - output.loss = elastic
-- groups = [cost_other]
+- groups = [cost_other, inheritable_nou]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0

--- a/nodes/transport/transport_useful_demand_car_kms.demand.ad
+++ b/nodes/transport/transport_useful_demand_car_kms.demand.ad
@@ -3,3 +3,4 @@
 - output.loss = elastic
 - groups = [preset_demand, useful_demand, useful_demand_transport]
 - free_co2_factor = 0.0
+~ number_of_units = AREA(number_of_cars)

--- a/spec/node_groups_spec.rb
+++ b/spec/node_groups_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe ':inheritable_nou nodes' do
+  graph = Atlas::GraphBuilder.build
+
+  Atlas::Node.all.each do |node|
+    next unless node.groups.include?(:inheritable_nou)
+
+    describe node.key do
+      let(:gnode) { graph.node(node.key) }
+
+      it 'must have exactly one output link' do
+        expect(gnode.edges(:out).length).to eq(1)
+      end
+
+      it 'must have a parent with a number_of_units attribute' do
+        parent_node = gnode.out.first
+
+        if parent_node
+          model   = parent_node.get(:model)
+          literal = model.number_of_units
+          query   = model.queries[:number_of_units]
+
+          expect(literal || query).to be
+        else
+          pending 'Failure due to no parent node'
+        end
+      end
+    end # describe node.key
+  end # each node
+end


### PR DESCRIPTION
This is part of quintel/etmodel#2360 and changes ETSource so that the individual car nodes (transport car using gasoline, transport car using electricity, etc) have a correct `number_of_units` attribute. This attribute will be recomputed if you increase the demand of "car kms" or change the share of car technologies.

This is achieved by:

1. Setting a `number_of_units` attribute on "transport_useful_demand_for_car_kms",
2. Assigning the individual car nodes to the `inheritable_nou` group which will trigger the behaviour in ETEngine (only once quintel/etengine#926 is merged).

It is possible that we could decouple *demand* for cars from *number* of cars by changing some queries; this would permit us to add a separate slider for the number of vehicles.

### Caveats:

1. The number of units of cars [is read from the area/dataset `number_of_cars` attribute](https://github.com/quintel/etsource/blob/cars-nou/nodes/transport/transport_useful_demand_car_kms.demand.ad#L6). This is not ideal since it means we now have two places where the number of cars is available in ETEngine (the area data and the `number_of_units` attribute on "transport_useful_demand_for_car_kms".
  
   Queries have been adjusted to update both attributes, but ideally we might remove the area attribute and use a CSV to store the value for cars and trucks.

2. You may not set the number of units for the individual car types; you must set the total number of cars by changing `number_of_units` on the "transport_useful_demand_for_car_kms" node and adjust the shares of each technology as desired. ETEngine will then work out the number of units for each technology.

3. I have not tested the behaviour in local datasets and therefore cannot *yet* answer [these questions](https://github.com/quintel/etmodel/issues/2360#issuecomment-306500961). This testing is next on my list and I will update this issue once completed.

### Examples:

Here are a couple of example of how this change affects the number of units attribute on the various car nodes both before this change ("old number of units") and after ("new number of units").

#### NL, 2050, default settings:

| Node | Old number of units | New number of units |
| :---: | ---: | --: |
| `transport_useful_demand_car_kms` | 0 | 7,916 K	|
| `transport_car_using_compressed_natural_gas` | 0 | 0 |
| `transport_car_using_diesel_mix` | 0 | 2,147 K |
| `transport_car_using_electricity` | 11 K | 11 K |
| `transport_car_using_gasoline_mix` | 0 | 5,345 K |
| `transport_car_using_hydrogen` | 0 | 0 |
| `transport_car_using_lpg` | 0 | 406 K |

#### NL, 2050, Demand increased by 2% per year

| Node | Old number of units | New number of units |
| :---: | ---: | --: |
| `transport_useful_demand_car_kms` | 0 | 16,469 K	|
| `transport_car_using_compressed_natural_gas` | 0 | 0 |
| `transport_car_using_diesel_mix` | 0 | 4,468 K |
| `transport_car_using_electricity` | 23 K | 23 K |
| `transport_car_using_gasoline_mix` | 0 | 11,120 K |
| `transport_car_using_hydrogen` | 0 | 0 |
| `transport_car_using_lpg` | 0 | 845 K |

#### NL, 2050, EV share = 100%

| Node | Old number of units | New number of units |
| :---: | ---: | --: |
| `transport_useful_demand_car_kms` | 0 | 7,916 K	|
| `transport_car_using_compressed_natural_gas` | 0 | 0 |
| `transport_car_using_diesel_mix` | 0 | 0 |
| `transport_car_using_electricity` | **11 K (!!!)** | 7,916 K |
| `transport_car_using_gasoline_mix` | 0 | 0 |
| `transport_car_using_hydrogen` | 0 | 0 |
| `transport_car_using_lpg` | 0 | 0 |

---

FYI @ChaelKruip @DorinevanderVlies 