### PR TITLE
Import export waterfall

### DIFF
--- a/gqueries/output_elements/output_series/waterfall_47_present_energy_imports/gas_value_in_present_energy_imports.gql
+++ b/gqueries/output_elements/output_series/waterfall_47_present_energy_imports/gas_value_in_present_energy_imports.gql
@@ -1,6 +1,6 @@
 - unit = PJ
 - query =
       present:DIVIDE(
-    V(G(energy_import),"output_of_natural_gas + output_of_network_gas + output_of_lng").sum - 
-    V(G(energy_export),"input_of_natural_gas + input_of_network_gas + input_of_lng ").sum
+    V(G(energy_import),"output_of_natural_gas + output_of_network_gas").sum - 
+    V(G(energy_export),"input_of_natural_gas + input_of_network_gas").sum
       ,BILLIONS)

--- a/gqueries/output_elements/output_series/waterfall_76_future_energy_imports/gas_in_future_energy_imports.gql
+++ b/gqueries/output_elements/output_series/waterfall_76_future_energy_imports/gas_in_future_energy_imports.gql
@@ -2,6 +2,6 @@
 - query =
     future:
     DIVIDE(
-        V(G(energy_import),"output_of_natural_gas + output_of_lng").sum - 
-        V(G(energy_export),"input_of_natural_gas + input_of_lng ").sum
+        V(G(energy_import),"output_of_natural_gas").sum - 
+        V(G(energy_export),"input_of_natural_gas").sum
     ,BILLIONS)

--- a/gqueries/output_elements/output_series/waterfall_76_future_energy_imports/gas_in_future_energy_imports.gql
+++ b/gqueries/output_elements/output_series/waterfall_76_future_energy_imports/gas_in_future_energy_imports.gql
@@ -2,6 +2,6 @@
 - query =
     future:
     DIVIDE(
-        V(G(energy_import),"output_of_natural_gas").sum - 
-        V(G(energy_export),"input_of_natural_gas").sum
+        V(G(energy_import),"output_of_natural_gas + output_of_network_gas").sum -
+        V(G(energy_export),"input_of_natural_gas + input_of_network_gas").sum
     ,BILLIONS)


### PR DESCRIPTION
As described in issue #1266, I removed LNG from the import/export waterfall. This was done because there already was a separate LNG column, causing LNG to be double counted. I also added network gas to the calculation of future imports and exports, to make present and future match. That shouldn't have an impact on outcome. 