### PR TITLE
Fixed query for P2H in industry

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_converted_to_heat_industry.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_163_use_of_excess_electricity/electricity_converted_to_heat_industry.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = V(industry_flexibility_p2h_electricity, "useable_heat__output_conversion * demand") / BILLIONS
+- query = Q(industry_flexibility_p2h_electricity_demand)


### PR DESCRIPTION
The output element series that have been changed:
```
INSERT INTO `output_element_series` (`id`, `output_element_id`, `label`, `color`, `order_by`, `group`, `created_at`, `updated_at`, `show_at_first`, `is_target_line`, `target_line_position`, `gquery`, `is_1990`)
VALUES
	(2328, 163, 'electricity_converted_to_gas_industry', '#B3CF7B', 5, '', '2016-09-02 14:19:18', '2016-09-02 14:19:18', 0, 0, '', 'electricity_converted_to_gas_industry', NULL),
	(2463, 163, 'electricity_converted_to_heat_industry', '#8B0000', 9, '', '2017-08-03 16:06:02', '2017-08-03 16:11:57', 0, 0, '', 'electricity_converted_to_heat_industry', 0);

```