### PR TITLE
Add all relevant converter to an application group

### DIFF
--- a/nodes/agriculture/agriculture_burner_crude_oil.converter.ad
+++ b/nodes/agriculture/agriculture_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.788659793814433
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_burner_network_gas.converter.ad
+++ b/nodes/agriculture/agriculture_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_burner_wood_pellets.converter.ad
+++ b/nodes/agriculture/agriculture_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.760824742268041
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_final_demand_steam_hot_water.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_steam_hot_water.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, application_group]
 - free_co2_factor = 0.0
 
 ~ demand = EB("agriculture/forestry", heat)

--- a/nodes/agriculture/agriculture_geothermal.converter.ad
+++ b/nodes/agriculture/agriculture_geothermal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - input.electricity = 0.0416666666666667
 - input.geothermal = 0.958333333333333
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - input.ambient_heat = 0.956521739130435
 - input.electricity = 0.0434782608695652
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_useful_demand_electricity.demand.ad
+++ b/nodes/agriculture/agriculture_useful_demand_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = useful consumption
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_appliances_coal.converter.ad
+++ b/nodes/buildings/buildings_appliances_coal.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_appliances_crude_oil.converter.ad
+++ b/nodes/buildings/buildings_appliances_crude_oil.converter.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = application
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_appliances_electricity.converter.ad
+++ b/nodes/buildings/buildings_appliances_electricity.converter.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = application
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_appliances_network_gas.converter.ad
+++ b/nodes/buildings/buildings_appliances_network_gas.converter.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = application
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_appliances_wood_pellets.converter.ad
+++ b/nodes/buildings/buildings_appliances_wood_pellets.converter.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = application
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_cooling_airconditioning_electricity.converter.ad
+++ b/nodes/buildings/buildings_cooling_airconditioning_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.25
 - output.cooling = 1.0
 - output.loss = elastic
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_cooling_collective_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/buildings/buildings_cooling_collective_heatpump_water_water_ts_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.05239602663
 - output.cooling = 1.0
 - output.loss = elastic
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_cooling_heatpump_air_water_network_gas.converter.ad
+++ b/nodes/buildings/buildings_cooling_heatpump_air_water_network_gas.converter.ad
@@ -4,7 +4,7 @@
 - input.network_gas = 0.588235294117647
 - output.cooling = 1.0
 - output.loss = elastic
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_lighting_efficient_fluorescent_electricity.converter.ad
+++ b/nodes/buildings/buildings_lighting_efficient_fluorescent_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.light = 0.2
 - output.loss = elastic
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_lighting_led_electricity.converter.ad
+++ b/nodes/buildings/buildings_lighting_led_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.light = 0.45
 - output.loss = elastic
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_lighting_standard_fluorescent_electricity.converter.ad
+++ b/nodes/buildings/buildings_lighting_standard_fluorescent_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.light = 0.16
 - output.loss = elastic
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_space_heater_coal.converter.ad
+++ b/nodes/buildings/buildings_space_heater_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_collective_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/buildings/buildings_space_heater_collective_heatpump_water_water_ts_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.111111111111111
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_crude_oil.converter.ad
+++ b/nodes/buildings/buildings_space_heater_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.85
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/buildings/buildings_space_heater_district_heating_steam_hot_water.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - output.useable_heat = 1.0
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/buildings/buildings_space_heater_electricity.converter.ad
+++ b/nodes/buildings/buildings_space_heater_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_heatpump_air_water_network_gas.converter.ad
+++ b/nodes/buildings/buildings_space_heater_heatpump_air_water_network_gas.converter.ad
@@ -4,7 +4,7 @@
 - input.network_gas = 0.5
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_network_gas.converter.ad
+++ b/nodes/buildings/buildings_space_heater_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.067
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_solar_thermal.converter.ad
+++ b/nodes/buildings/buildings_space_heater_solar_thermal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.95
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_space_heater_wood_pellets.converter.ad
+++ b/nodes/buildings/buildings_space_heater_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.82
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_cokesoven_consumption_coal_gas.converter.ad
+++ b/nodes/energy/energy_cokesoven_consumption_coal_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = energy sector own use
 - output.loss = elastic
 - output.coupling_carrier = 1.0
-- groups = [final_demand_group, metal]
+- groups = [final_demand_group, metal, application_group]
 - free_co2_factor = 0.0
 
 ~ input.electricity = EFFICIENCY(energy_cokesoven_consumption_coal_gas, input, electricity)

--- a/nodes/energy/energy_export_bio_ethanol.ad
+++ b/nodes/energy/energy_export_bio_ethanol.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_bio_oil.ad
+++ b/nodes/energy/energy_export_bio_oil.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_biodiesel.ad
+++ b/nodes/energy/energy_export_biodiesel.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_biogenic_waste.ad
+++ b/nodes/energy/energy_export_biogenic_waste.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_coal_gas.ad
+++ b/nodes/energy/energy_export_coal_gas.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = export
-- groups = [energy_export, metal, final_demand_group]
+- groups = [energy_export, metal, final_demand_group, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_crude_oil.ad
+++ b/nodes/energy/energy_export_crude_oil.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_diesel.ad
+++ b/nodes/energy/energy_export_diesel.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_electricity.ad
+++ b/nodes/energy/energy_export_electricity.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [cost_other, energy_export]
+- groups = [cost_other, energy_export, application_group]
 - merit_order.type = flex
 - merit_order.group = export
 - availability = 1.0

--- a/nodes/energy/energy_export_gasoline.ad
+++ b/nodes/energy/energy_export_gasoline.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_greengas.ad
+++ b/nodes/energy/energy_export_greengas.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0
 
 ~ demand = 0.0

--- a/nodes/energy/energy_export_heavy_fuel_oil.ad
+++ b/nodes/energy/energy_export_heavy_fuel_oil.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_hydrogen.ad
+++ b/nodes/energy/energy_export_hydrogen.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_kerosene.ad
+++ b/nodes/energy/energy_export_kerosene.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_lignite.ad
+++ b/nodes/energy/energy_export_lignite.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_lpg.ad
+++ b/nodes/energy/energy_export_lpg.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_network_gas.ad
+++ b/nodes/energy/energy_export_network_gas.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_non_biogenic_waste.ad
+++ b/nodes/energy/energy_export_non_biogenic_waste.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - co2_free = 0.0

--- a/nodes/energy/energy_export_oil_products.ad
+++ b/nodes/energy/energy_export_oil_products.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 1.0
 
 ~ demand = 

--- a/nodes/energy/energy_export_torrified_biomass_pellets.ad
+++ b/nodes/energy/energy_export_torrified_biomass_pellets.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = export
-- groups = [energy_export, energy_import_export]
+- groups = [energy_export, energy_import_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_uranium_oxide.ad
+++ b/nodes/energy/energy_export_uranium_oxide.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = export
-- groups = [energy_export]
+- groups = [energy_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_export_wood_pellets.ad
+++ b/nodes/energy/energy_export_wood_pellets.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = export
-- groups = [energy_export, energy_import_export]
+- groups = [energy_export, energy_import_export, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_heat_network_unused_steam_hot_water.ad
+++ b/nodes/energy/energy_heat_network_unused_steam_hot_water.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = unused and dumped heat
-- groups = [final_demand_group]
+- groups = [final_demand_group, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
+++ b/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = energy sector own use
 - output.loss = elastic
-- groups = [final_demand_group, preset_demand]
+- groups = [final_demand_group, preset_demand, application_group]
 - free_co2_factor = 0.0
 
 ~ demand = -EB("own_use_in _electricity,_chp_and_heat_plants", electricity)

--- a/nodes/households/households_appliances_clothes_dryer_electricity.converter.ad
+++ b/nodes/households/households_appliances_clothes_dryer_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_computer_media_electricity.converter.ad
+++ b/nodes/households/households_appliances_computer_media_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_dishwasher_electricity.converter.ad
+++ b/nodes/households/households_appliances_dishwasher_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_fridge_freezer_electricity.converter.ad
+++ b/nodes/households/households_appliances_fridge_freezer_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_other_electricity.converter.ad
+++ b/nodes/households/households_appliances_other_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_television_electricity.converter.ad
+++ b/nodes/households/households_appliances_television_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_vacuum_cleaner_electricity.converter.ad
+++ b/nodes/households/households_appliances_vacuum_cleaner_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_appliances_washing_machine_electricity.converter.ad
+++ b/nodes/households/households_appliances_washing_machine_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 1.0
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_cooker_halogen_electricity.converter.ad
+++ b/nodes/households/households_cooker_halogen_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.6
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_cooker_induction_electricity.converter.ad
+++ b/nodes/households/households_cooker_induction_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.85
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_cooker_network_gas.converter.ad
+++ b/nodes/households/households_cooker_network_gas.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.4
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_cooker_resistive_electricity.converter.ad
+++ b/nodes/households/households_cooker_resistive_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.55
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_cooker_wood_pellets.converter.ad
+++ b/nodes/households/households_cooker_wood_pellets.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.3
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_cooling_airconditioning_electricity.converter.ad
+++ b/nodes/households/households_cooling_airconditioning_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.25
 - output.cooling = 1.0
 - output.loss = elastic
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_cooling_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_cooling_heatpump_air_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.222222222222222
 - output.cooling = 1.0
 - output.loss = elastic
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_cooling_heatpump_ground_water_electricity.converter.ad
+++ b/nodes/households/households_cooling_heatpump_ground_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.05263157895
 - output.cooling = 1.0
 - output.loss = elastic
-- groups = [cost_heat_pumps, heat_production]
+- groups = [cost_heat_pumps, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_lighting_efficient_fluorescent_electricity.converter.ad
+++ b/nodes/households/households_lighting_efficient_fluorescent_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.light = 0.25
 - output.loss = elastic
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_lighting_incandescent_electricity.converter.ad
+++ b/nodes/households/households_lighting_incandescent_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.light = 0.05
 - output.loss = elastic
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_lighting_led_electricity.converter.ad
+++ b/nodes/households/households_lighting_led_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.light = 0.5
 - output.loss = elastic
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/households/households_space_heater_coal.converter.ad
+++ b/nodes/households/households_space_heater_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, demand_driven, heat_production]
+- groups = [cost_traditional_heat, demand_driven, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_combined_network_gas.converter.ad
+++ b/nodes/households/households_space_heater_combined_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.067
-- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses]
+- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_crude_oil.converter.ad
+++ b/nodes/households/households_space_heater_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.85
-- groups = [cost_traditional_heat, demand_driven, heat_production]
+- groups = [cost_traditional_heat, demand_driven, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = [cost_traditional_heat, heat_production, demand_driven, etmoses]
+- groups = [cost_traditional_heat, heat_production, demand_driven, etmoses, application_group]
 - output.useable_heat = 1.0
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/households/households_space_heater_electricity.converter.ad
+++ b/nodes/households/households_space_heater_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, merit_household_space_heating_producers]
+- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_heatpump_air_water_electricity.converter.ad
@@ -5,7 +5,7 @@
 - output.cooling = 0.0
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers]
+- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_heatpump_ground_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_heatpump_ground_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.208333333333333
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers]
+- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -8,7 +8,7 @@
 - output.useable_heat.ambient_heat = 1
 - output.useable_heat.electricity = 1
 - output.useable_heat.network_gas = 1.067
-- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers]
+- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_micro_chp_network_gas.converter.ad
+++ b/nodes/households/households_space_heater_micro_chp_network_gas.converter.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.17
 - output.loss = elastic
 - output.useable_heat = 0.88
-- groups = [cost_chps, demand_driven, electricity_production, heat_production, must_run_electricity_production, dispatchable_production]
+- groups = [cost_chps, demand_driven, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, application_group]
 - merit_order.type = must_run
 - merit_order.group = buildings_chp
 - availability = 0.97

--- a/nodes/households/households_space_heater_network_gas.converter.ad
+++ b/nodes/households/households_space_heater_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses]
+- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_space_heater_wood_pellets.converter.ad
+++ b/nodes/households/households_space_heater_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.82
-- groups = [cost_traditional_heat, demand_driven, heat_production]
+- groups = [cost_traditional_heat, demand_driven, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_coal.converter.ad
+++ b/nodes/households/households_water_heater_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, demand_driven]
+- groups = [cost_traditional_heat, demand_driven, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_combined_network_gas.converter.ad
+++ b/nodes/households/households_water_heater_combined_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses]
+- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_crude_oil.converter.ad
+++ b/nodes/households/households_water_heater_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.85
-- groups = [cost_traditional_heat, demand_driven]
+- groups = [cost_traditional_heat, demand_driven, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_water_heater_district_heating_steam_hot_water.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_traditional_heat, heat_production, demand_driven, etmoses]
+- groups = [cost_traditional_heat, heat_production, demand_driven, etmoses, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_fuel_cell_chp_network_gas.converter.ad
+++ b/nodes/households/households_water_heater_fuel_cell_chp_network_gas.converter.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.6
 - output.loss = elastic
 - output.useable_heat = 0.2
-- groups = [cost_chps, demand_driven, electricity_production, must_run_electricity_production, time_curves, dispatchable_production]
+- groups = [cost_chps, demand_driven, electricity_production, must_run_electricity_production, time_curves, dispatchable_production, application_group]
 - merit_order.type = must_run
 - merit_order.group = buildings_chp
 - availability = 0.97

--- a/nodes/households/households_water_heater_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_water_heater_heatpump_air_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.333333333333333
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_hot_water_producers]
+- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_hot_water_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_heatpump_ground_water_electricity.converter.ad
+++ b/nodes/households/households_water_heater_heatpump_ground_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - input.electricity = 0.333333333333333
 - output.loss = elastic
 - output.useable_heat = 1.0
-- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_hot_water_producers]
+- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_hot_water_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -8,7 +8,7 @@
 - output.useable_heat.ambient_heat = 1
 - output.useable_heat.electricity = 1
 - output.useable_heat.network_gas = 0.9
-- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_hot_water_producers]
+- groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_hot_water_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_micro_chp_network_gas.converter.ad
+++ b/nodes/households/households_water_heater_micro_chp_network_gas.converter.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.17
 - output.loss = elastic
 - output.useable_heat = 0.88
-- groups = [cost_chps, demand_driven, electricity_production, heat_production, must_run_electricity_production, dispatchable_production]
+- groups = [cost_chps, demand_driven, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, application_group]
 - merit_order.type = must_run
 - merit_order.group = buildings_chp
 - availability = 0.97

--- a/nodes/households/households_water_heater_network_gas.converter.ad
+++ b/nodes/households/households_water_heater_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.67
-- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses]
+- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_resistive_electricity.converter.ad
+++ b/nodes/households/households_water_heater_resistive_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.95
-- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, merit_household_hot_water_producers]
+- groups = [cost_traditional_heat, demand_driven, heat_production, etmoses, merit_household_hot_water_producers, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_water_heater_wood_pellets.converter.ad
+++ b/nodes/households/households_water_heater_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.82
-- groups = [cost_traditional_heat, demand_driven]
+- groups = [cost_traditional_heat, demand_driven, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_aluminium_carbothermalreduction_electricity.converter.ad
+++ b/nodes/industry/industry_aluminium_carbothermalreduction_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.0277315585135885
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 - input.useable_heat = 0.101497504159734

--- a/nodes/industry/industry_aluminium_electrolysis_bat_electricity.converter.ad
+++ b/nodes/industry/industry_aluminium_electrolysis_bat_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.017164435290079
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 - input.useable_heat = 0.0502917953999313

--- a/nodes/industry/industry_aluminium_electrolysis_current_electricity.converter.ad
+++ b/nodes/industry/industry_aluminium_electrolysis_current_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.0162972620599739
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 - input.useable_heat = 0.0596479791395046

--- a/nodes/industry/industry_aluminium_smeltoven_electricity.converter.ad
+++ b/nodes/industry/industry_aluminium_smeltoven_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.124688279301746
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 - input.useable_heat = 0.456359102244389

--- a/nodes/industry/industry_chemicals_fertilizers_burner_coal.converter.ad
+++ b/nodes/industry/industry_chemicals_fertilizers_burner_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_fertilizers_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_chemicals_fertilizers_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.83
-- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_fertilizers_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_chemicals_fertilizers_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_fertilizers_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_chemicals_fertilizers_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, fertilizers_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_burner_coal.converter.ad
+++ b/nodes/industry/industry_chemicals_other_burner_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_chemicals_other_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.83
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_chemicals_other_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_chemicals_other_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_heater_electricity.converter.ad
+++ b/nodes/industry/industry_chemicals_other_heater_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.995
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 0.99
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_heatpump_water_water_electricity.converter.ad
+++ b/nodes/industry/industry_chemicals_other_heatpump_water_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - input.ambient_heat = 0.7368
 - input.electricity = 0.26316
 - output.useable_heat = 1
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 1.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_other_steam_recompression_electricity.converter.ad
+++ b/nodes/industry/industry_chemicals_other_steam_recompression_electricity.converter.ad
@@ -3,7 +3,7 @@
 - input.ambient_heat = 0.907407407
 - input.electricity = 0.092592593
 - output.useable_heat = 1
-- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, other_chemical_industry, application_group]
 - availability = 1.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_refineries_burner_coal.converter.ad
+++ b/nodes/industry/industry_chemicals_refineries_burner_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_refineries_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_chemicals_refineries_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.83
-- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_refineries_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_chemicals_refineries_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_chemicals_refineries_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_chemicals_refineries_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry]
+- groups = [cost_traditional_heat, heat_production, chemical_industry, refineries_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_final_demand_for_chemical_other_steam_hot_water.ad
+++ b/nodes/industry/industry_final_demand_for_chemical_other_steam_hot_water.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [chemical_industry, other_chemical_industry]
+- groups = [chemical_industry, other_chemical_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_final_demand_for_chemical_refineries_steam_hot_water.ad
+++ b/nodes/industry/industry_final_demand_for_chemical_refineries_steam_hot_water.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [chemical_industry, refineries_industry]
+- groups = [chemical_industry, refineries_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_final_demand_for_other_food_steam_hot_water.ad
+++ b/nodes/industry/industry_final_demand_for_other_food_steam_hot_water.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [other_industry]
+- groups = [other_industry, application_group]
 - free_co2_factor = 0.0
 - output.useable_heat = 1.0

--- a/nodes/industry/industry_final_demand_for_other_paper_steam_hot_water.ad
+++ b/nodes/industry/industry_final_demand_for_other_paper_steam_hot_water.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [other_industry]
+- groups = [other_industry, application_group]
 - free_co2_factor = 0.0
 - output.useable_heat = 1.0

--- a/nodes/industry/industry_other_food_burner_coal.converter.ad
+++ b/nodes/industry/industry_other_food_burner_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, food_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, food_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_food_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_other_food_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.83
-- groups = [cost_traditional_heat, heat_production, food_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, food_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_food_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_other_food_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production, food_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, food_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_food_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_other_food_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, food_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, food_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_food_heater_electricity.converter.ad
+++ b/nodes/industry/industry_other_food_heater_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.995
-- groups = [cost_traditional_heat, heat_production, food_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, food_industry, other_industry, application_group]
 - availability = 0.99
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_metals_process_electricity.converter.ad
+++ b/nodes/industry/industry_other_metals_process_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.5
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_other_metals_process_heat_useable_heat.converter.ad
+++ b/nodes/industry/industry_other_metals_process_heat_useable_heat.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.5
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_other_paper_burner_coal.converter.ad
+++ b/nodes/industry/industry_other_paper_burner_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_paper_burner_crude_oil.converter.ad
+++ b/nodes/industry/industry_other_paper_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.83
-- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_paper_burner_network_gas.converter.ad
+++ b/nodes/industry/industry_other_paper_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_paper_burner_wood_pellets.converter.ad
+++ b/nodes/industry/industry_other_paper_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_other_paper_heater_electricity.converter.ad
+++ b/nodes/industry/industry_other_paper_heater_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.995
-- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry]
+- groups = [cost_traditional_heat, heat_production, paper_industry, other_industry, application_group]
 - availability = 0.99
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/industry/industry_steel_blastfurnace_bat_consumption_useable_heat.converter.ad
+++ b/nodes/industry/industry_steel_blastfurnace_bat_consumption_useable_heat.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = preferred technologies
 - output.loss = elastic
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 ~ input.coupling_carrier = EFFICIENCY(industry_steel_blastfurnace_bat_consumption_useable_heat, input, coupling_carrier)

--- a/nodes/industry/industry_steel_blastfurnace_current_consumption_useable_heat.converter.ad
+++ b/nodes/industry/industry_steel_blastfurnace_current_consumption_useable_heat.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = preferred technologies
 - output.loss = elastic
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 ~ input.coupling_carrier = EFFICIENCY(industry_steel_blastfurnace_current_consumption_useable_heat, input, coupling_carrier)

--- a/nodes/industry/industry_steel_electricfurnace_electricity.converter.ad
+++ b/nodes/industry/industry_steel_electricfurnace_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = preferred technologies
 - output.loss = elastic
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 - output.not_defined = 0.411

--- a/nodes/industry/industry_steel_hisarna_consumption_useable_heat.converter.ad
+++ b/nodes/industry/industry_steel_hisarna_consumption_useable_heat.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = preferred technologies
 - output.loss = elastic
 - output.not_defined = 0.0984095719727931
-- groups = [metal_industry]
+- groups = [metal_industry, application_group]
 - free_co2_factor = 0.0
 
 - input.coupling_carrier = 1.5256023862533

--- a/nodes/industry/industry_useful_demand_for_chemical_fertilizers_coal_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_fertilizers_coal_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_fertilizers_crude_oil_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_fertilizers_crude_oil_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_fertilizers_network_gas_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_fertilizers_network_gas_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry]
+- groups = [non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_fertilizers_wood_pellets_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_fertilizers_wood_pellets_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, fertilizers_industry, chemical_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, fertilizers_industry, chemical_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_other_coal_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_other_coal_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_other_crude_oil_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_other_crude_oil_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_other_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_other_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, useful_demand_electric, chemical_industry, other_chemical_industry]
+- groups = [preset_demand, useful_demand, useful_demand_electric, chemical_industry, other_chemical_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_chemical_other_network_gas_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_other_network_gas_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_other_wood_pellets_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_other_wood_pellets_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, other_chemical_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_refineries_coal_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_refineries_coal_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, refineries_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, refineries_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_refineries_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_refineries_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, useful_demand_electric, chemical_industry, refineries_industry]
+- groups = [preset_demand, useful_demand, useful_demand_electric, chemical_industry, refineries_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_chemical_refineries_network_gas_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_refineries_network_gas_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, refineries_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, refineries_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_chemical_refineries_wood_pellets_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_chemical_refineries_wood_pellets_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, refineries_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, refineries_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_other_construction_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_construction_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_construction_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_construction_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_construction_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_construction_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_construction_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_construction_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_construction_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_construction_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_construction_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_construction_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_food_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_food_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_ict_electricity.ad
+++ b/nodes/industry/industry_useful_demand_for_other_ict_electricity.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [useful_demand, preset_demand, other_industry, ict_industry]
+- groups = [useful_demand, preset_demand, other_industry, ict_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_machinery_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_machinery_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_machinery_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_machinery_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_machinery_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_machinery_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_machinery_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_machinery_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_machinery_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_machinery_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_machinery_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_machinery_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_minerals_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_minerals_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_minerals_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_minerals_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_minerals_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_minerals_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_minerals_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_minerals_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_minerals_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_minerals_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_minerals_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_minerals_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_mining_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_mining_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_mining_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_mining_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_mining_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_mining_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_mining_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_mining_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_mining_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_mining_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_mining_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_mining_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_coal_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_coal_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_crude_oil_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_crude_oil_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_network_gas_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_network_gas_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_non_specified_wood_pellets_non_energetic.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_non_specified_wood_pellets_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, other_industry, application_group]
 - free_co2_factor = 1.0

--- a/nodes/industry/industry_useful_demand_for_other_paper_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_paper_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_textile_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_textile_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_textile_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_textile_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_textile_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_textile_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_textile_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_textile_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_textile_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_textile_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_textile_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_textile_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_transport_equipment_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_transport_equipment_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_transport_equipment_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_transport_equipment_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_transport_equipment_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_transport_equipment_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_transport_equipment_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_transport_equipment_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_transport_equipment_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_transport_equipment_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_transport_equipment_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_transport_equipment_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_wood_products_coal.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_wood_products_coal.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_wood_products_crude_oil.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_wood_products_crude_oil.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_wood_products_electricity.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_wood_products_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_wood_products_network_gas.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_wood_products_network_gas.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_wood_products_useable_heat.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_wood_products_useable_heat.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_useful_demand_for_other_wood_products_wood_pellets.demand.ad
+++ b/nodes/industry/industry_useful_demand_for_other_wood_products_wood_pellets.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, other_industry]
+- groups = [preset_demand, useful_demand, other_industry, application_group]
 - free_co2_factor = 0.0

--- a/nodes/other/other_burner_coal.converter.ad
+++ b/nodes/other/other_burner_coal.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.8
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/other/other_burner_crude_oil.converter.ad
+++ b/nodes/other/other_burner_crude_oil.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.788659793814433
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/other/other_burner_network_gas.converter.ad
+++ b/nodes/other/other_burner_network_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/other/other_burner_wood_pellets.converter.ad
+++ b/nodes/other/other_burner_wood_pellets.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.useable_heat = 0.760824742268041
-- groups = [cost_traditional_heat, heat_production]
+- groups = [cost_traditional_heat, heat_production, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/other/other_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/other/other_heater_district_heating_steam_hot_water.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/other/other_useful_demand_crude_oil_non_energetic.demand.ad
+++ b/nodes/other/other_useful_demand_crude_oil_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, application_group]
 - free_co2_factor = 1.0

--- a/nodes/other/other_useful_demand_electricity.demand.ad
+++ b/nodes/other/other_useful_demand_electricity.demand.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = application
-- groups = [preset_demand, useful_demand, useful_demand_electric]
+- groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_car_using_compressed_natural_gas.converter.ad
+++ b/nodes/transport/transport_car_using_compressed_natural_gas.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.476190476190476
 - output.loss = elastic
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 15.0

--- a/nodes/transport/transport_car_using_diesel_mix.converter.ad
+++ b/nodes/transport/transport_car_using_diesel_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.526315789473684
 - output.loss = elastic
-- groups = [cost_other, inheritable_nou]
+- groups = [cost_other, inheritable_nou, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0

--- a/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/nodes/transport/transport_car_using_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.car_kms = 1.53846153846154
 - output.loss = elastic
-- groups = [cost_other, merit_ev_demand, inheritable_nou]
+- groups = [cost_other, merit_ev_demand, inheritable_nou, application_group]
 - merit_order.group = electric_vehicle
 - merit_order.target = transport_car_flexibility_p2p_electricity
 - merit_order.type = flex

--- a/nodes/transport/transport_car_using_gasoline_mix.converter.ad
+++ b/nodes/transport/transport_car_using_gasoline_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.476190476190476
 - output.loss = elastic
-- groups = [cost_other, inheritable_nou]
+- groups = [cost_other, inheritable_nou, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0

--- a/nodes/transport/transport_car_using_hydrogen.converter.ad
+++ b/nodes/transport/transport_car_using_hydrogen.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.car_kms = 1.02040816326531
 - output.loss = elastic
-- groups = [cost_other, inheritable_nou]
+- groups = [cost_other, inheritable_nou, application_group]
 - free_co2_factor = 0.0
 - full_load_hours = 0.0
 - takes_part_in_ets = 0.0

--- a/nodes/transport/transport_car_using_lpg.converter.ad
+++ b/nodes/transport/transport_car_using_lpg.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.car_kms = 0.5
 - output.loss = elastic
-- groups = [cost_other, inheritable_nou]
+- groups = [cost_other, inheritable_nou, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0

--- a/nodes/transport/transport_plane_using_bio_ethanol.converter.ad
+++ b/nodes/transport/transport_plane_using_bio_ethanol.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_plane_using_gasoline.converter.ad
+++ b/nodes/transport/transport_plane_using_gasoline.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_plane_using_kerosene.converter.ad
+++ b/nodes/transport/transport_plane_using_kerosene.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = technologies
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_ship_using_diesel_mix.converter.ad
+++ b/nodes/transport/transport_ship_using_diesel_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.shipping_kms = 0.00166389351081531
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0

--- a/nodes/transport/transport_ship_using_lng_mix.converter.ad
+++ b/nodes/transport/transport_ship_using_lng_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.shipping_kms = 0.001663893510815
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0

--- a/nodes/transport/transport_train_using_coal.converter.ad
+++ b/nodes/transport/transport_train_using_coal.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 0.3
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_train_using_diesel.converter.ad
+++ b/nodes/transport/transport_train_using_diesel.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 0.3
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_train_using_electricity.converter.ad
+++ b/nodes/transport/transport_train_using_electricity.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.not_defined = 0.9
-- groups = []
+- groups = [application_group]
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_truck_using_compressed_natural_gas.converter.ad
+++ b/nodes/transport/transport_truck_using_compressed_natural_gas.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.truck_kms = 0.106382978723404
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 12.0

--- a/nodes/transport/transport_truck_using_diesel_mix.converter.ad
+++ b/nodes/transport/transport_truck_using_diesel_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.truck_kms = 0.106382978723404
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 12.0

--- a/nodes/transport/transport_truck_using_electricity.converter.ad
+++ b/nodes/transport/transport_truck_using_electricity.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.truck_kms = 0.191570881226054
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/transport/transport_truck_using_gasoline_mix.converter.ad
+++ b/nodes/transport/transport_truck_using_gasoline_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.truck_kms = 0.0965228526398739
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 11.0

--- a/nodes/transport/transport_truck_using_hydrogen.converter.ad
+++ b/nodes/transport/transport_truck_using_hydrogen.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = technologies
 - output.truck_kms = 0.147058824
 - output.loss = elastic
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - free_co2_factor = 0.0
 - full_load_hours = 0.0
 - takes_part_in_ets = 0.0

--- a/nodes/transport/transport_truck_using_lng_mix.converter.ad
+++ b/nodes/transport/transport_truck_using_lng_mix.converter.ad
@@ -2,6 +2,6 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.truck_kms = 0.118203309692671
-- groups = [cost_other]
+- groups = [cost_other, application_group]
 - free_co2_factor = 0.0
 - technical_lifetime = 12.0

--- a/nodes/transport/transport_useful_demand_crude_oil_non_energetic.demand.ad
+++ b/nodes/transport/transport_useful_demand_crude_oil_non_energetic.demand.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = useful consumption
-- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic]
+- groups = [preset_demand, non_energetic_use, useful_demand, useful_demand_non_energetic, application_group]
 - free_co2_factor = 1.0


### PR DESCRIPTION
This group contains all technologies and applications in the ETM and is solely intended to be used to show the primary and final demands of these technologies and applications. The application group contains more detail that the useful demand and final demand groups.

I checked that the total primary demand of all converters in the application group is equal to the total primary demand as displayed in the primary demand mekko (which is based on the final demand and energy export groups). The results are almost identical (difference `~0.1%`). I will take some time next week debugging this.