### PR TITLE
Fixed final demand queries for household heat and hot water

### DIFF
--- a/gqueries/general/converter_groups/heating_converters_in_households.gql
+++ b/gqueries/general/converter_groups/heating_converters_in_households.gql
@@ -1,7 +1,7 @@
 - query =
-    V(
-      CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),
-      V(households_water_heater_solar_thermal)
+    EXCLUDE(
+      CHILDREN(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater))),
+      V(households_space_heater_deficit)
     )
 - unit = converters
 - deprecated_key = households_heating_converters

--- a/gqueries/general/converter_groups/hot_water_converters_in_households.gql
+++ b/gqueries/general/converter_groups/hot_water_converters_in_households.gql
@@ -1,6 +1,6 @@
 - query =
-    V(
-    	CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),
-    	V(households_water_heater_solar_thermal)
+    EXCLUDE(
+      CHILDREN(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h))),
+      V(households_water_heater_deficit)
     )
 - unit = converters

--- a/gqueries/general/energy_use/energy_used_for_heating_in_households.gql
+++ b/gqueries/general/energy_use/energy_used_for_heating_in_households.gql
@@ -2,6 +2,7 @@
 - query =
     SUM(
       V(Q(heating_converters_in_households),demand),
+      V(LINK(households_water_heater_solar_thermal,households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater),demand),
       NEG(Q(gas_allocated_to_electricity_production_in_households_heating))
     )
 - deprecated_key = households_heating_final_demand_total

--- a/gqueries/general/energy_use/energy_used_for_hot_water_in_households.gql
+++ b/gqueries/general/energy_use/energy_used_for_hot_water_in_households.gql
@@ -4,6 +4,7 @@
 - query =
     SUM(
       V(Q(hot_water_converters_in_households),demand),
+      V(LINK(households_water_heater_solar_thermal,households_useful_demand_for_hot_water_for_houses_with_solar_heater),demand),
       NEG(Q(gas_allocated_to_electricity_production_in_households_hot_water))
     )
 - deprecated_key = total_input_for_hot_water

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/ambient_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/ambient_used_for_heating_in_households.gql
@@ -3,6 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_ambient_heat),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_ambient_cold)
+      V(Q(heating_converters_in_households), input_of_ambient_heat)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/biomass_products_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/biomass_products_used_for_heating_in_households.gql
@@ -3,8 +3,8 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_biodiesel),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_bio_ethanol),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_wood_pellets),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_bio_lng)
+      V(Q(heating_converters_in_households), input_of_biodiesel),
+      V(Q(heating_converters_in_households), input_of_bio_ethanol),
+      V(Q(heating_converters_in_households), input_of_wood_pellets),
+      V(Q(heating_converters_in_households), input_of_bio_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/coal_and_derivatives_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/coal_and_derivatives_used_for_heating_in_households.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_coal),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_coal_gas)      
+      V(Q(heating_converters_in_households), input_of_coal),
+      V(Q(heating_converters_in_households), input_of_coal_gas),
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/electricity_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/electricity_used_for_heating_in_households.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_electricity)
+      V(Q(heating_converters_in_households), input_of_electricity)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/geothermal_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/geothermal_used_for_heating_in_households.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_geothermal)      
+      V(Q(heating_converters_in_households), input_of_geothermal)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/heat_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/heat_used_for_heating_in_households.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_steam_hot_water),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_useable_heat)      
+      V(Q(heating_converters_in_households), input_of_steam_hot_water),
+      V(Q(heating_converters_in_households), input_of_useable_heat)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/natural_gas_and_derivatives_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/natural_gas_and_derivatives_used_for_heating_in_households.gql
@@ -3,6 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_network_gas),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_lng)      
+      V(Q(heating_converters_in_households), input_of_network_gas),
+      V(Q(heating_converters_in_households), input_of_lng)
     ) / BILLIONS
+

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/oil_and_derivatives_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/oil_and_derivatives_used_for_heating_in_households.gql
@@ -3,10 +3,10 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_crude_oil),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_gasoline),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_diesel),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_lpg),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_kerosene),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_heavy_fuel_oil)      
+      V(Q(heating_converters_in_households), input_of_crude_oil),
+      V(Q(heating_converters_in_households), input_of_gasoline),
+      V(Q(heating_converters_in_households), input_of_diesel),
+      V(Q(heating_converters_in_households), input_of_lpg),
+      V(Q(heating_converters_in_households), input_of_kerosene),
+      V(Q(heating_converters_in_households), input_of_heavy_fuel_oil)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/solar_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/solar_used_for_heating_in_households.gql
@@ -3,7 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_solar_radiation),
-      V(CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater)),input_of_solar_thermal),
+      V(Q(heating_converters_in_households), input_of_solar_radiation),
+      V(Q(heating_converters_in_households), input_of_solar_thermal),
       V(LINK(households_water_heater_solar_thermal,households_useful_demand_for_space_heating_after_insulation_for_houses_with_solar_heater),demand)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/ambient_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/ambient_used_for_hot_water_in_households.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_ambient_heat),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_ambient_cold)      
+      V(Q(hot_water_converters_in_households), input_of_ambient_heat),
+      V(Q(hot_water_converters_in_households), input_of_ambient_cold)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/biomass_products_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/biomass_products_used_for_hot_water_in_households.gql
@@ -3,8 +3,9 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_biodiesel),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_bio_ethanol),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_wood_pellets),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_bio_lng)      
+      V(Q(hot_water_converters_in_households), input_of_biodiesel),
+      V(Q(hot_water_converters_in_households), input_of_bio_ethanol),
+      V(Q(hot_water_converters_in_households), input_of_wood_pellets),
+      V(Q(hot_water_converters_in_households), input_of_bio_lng)
     ) / BILLIONS
+

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/coal_and_derivatives_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/coal_and_derivatives_used_for_hot_water_in_households.gql
@@ -3,6 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_coal),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_coal_gas)      
+      V(Q(hot_water_converters_in_households), input_of_coal),
+      V(Q(hot_water_converters_in_households), input_of_coal_gas)
     ) / BILLIONS
+

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/electricity_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/electricity_used_for_hot_water_in_households.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_electricity)      
+      V(Q(hot_water_converters_in_households), input_of_electricity)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/geothermal_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/geothermal_used_for_hot_water_in_households.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_geothermal)      
+      V(Q(hot_water_converters_in_households), input_of_geothermal)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/heat_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/heat_used_for_hot_water_in_households.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_steam_hot_water),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_useable_heat)      
+      V(Q(hot_water_converters_in_households), input_of_steam_hot_water),
+      V(Q(hot_water_converters_in_households), input_of_useable_heat)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/natural_gas_and_derivatives_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/natural_gas_and_derivatives_used_for_hot_water_in_households.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_network_gas),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_lng)      
+      V(Q(hot_water_converters_in_households), input_of_network_gas),
+      V(Q(hot_water_converters_in_households), input_of_lng)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/oil_and_derivatives_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/oil_and_derivatives_used_for_hot_water_in_households.gql
@@ -3,10 +3,10 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_crude_oil),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_gasoline),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_diesel),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_lpg),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_kerosene),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_heavy_fuel_oil)      
+      V(Q(hot_water_converters_in_households), input_of_crude_oil),
+      V(Q(hot_water_converters_in_households), input_of_gasoline),
+      V(Q(hot_water_converters_in_households), input_of_diesel),
+      V(Q(hot_water_converters_in_households), input_of_lpg),
+      V(Q(hot_water_converters_in_households), input_of_kerosene),
+      V(Q(hot_water_converters_in_households), input_of_heavy_fuel_oil)
     ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/solar_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/solar_used_for_hot_water_in_households.gql
@@ -3,7 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_solar_radiation),
-      V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)),input_of_solar_thermal),
-      V(LINK(households_water_heater_solar_thermal,households_useful_demand_for_hot_water_for_houses_with_solar_heater),demand)      
+      V(Q(hot_water_converters_in_households), input_of_solar_radiation),
+      V(Q(hot_water_converters_in_households), input_of_solar_thermal),
+      V(LINK(households_water_heater_solar_thermal,households_useful_demand_for_hot_water_for_houses_with_solar_heater),demand)
     ) / BILLIONS


### PR DESCRIPTION
Updates the final demand queries used in the "Final energy demand for heating in residences" and "Final energy demand for hot water in residences" charts.

I changed the `*_converters_in_households` converter groups, removed the deficit node (so that its heat is never accidentally considered to be part of the demand), and then changed all of the chart queries to reference the group instead of hard-coding the node name(s).

Note that there is a bug with ambient heat and ambient cold being wrongly reported as zero (visible in the charts below). This is not related to the gqueries, and I'm already looking into it.

<img width="613" alt="screen shot 2017-08-24 at 10 57 43" src="https://user-images.githubusercontent.com/4383/29661174-25b74ff6-88bb-11e7-84ba-5248973cce1a.png">

<img width="609" alt="screen shot 2017-08-24 at 10 57 52" src="https://user-images.githubusercontent.com/4383/29661178-295222a8-88bb-11e7-9013-9d037ae0ff1e.png">

