### PR TITLE
Space heating HPs are aliases of the hot water HPs

### DIFF
--- a/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
+++ b/nodes/households/households_space_heater_district_heating_steam_hot_water.converter.ad
@@ -2,6 +2,7 @@
 - energy_balance_group = technologies
 - groups = [cost_traditional_heat, heat_production, demand_driven, etmoses, application_group, aggregator_producer]
 - output.useable_heat = 1.0
+- fever.alias_of = households_water_heater_district_heating_steam_hot_water
 - fever.defer_for = 4
 - fever.group = space_heating
 - fever.type = producer

--- a/nodes/households/households_space_heater_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_heatpump_air_water_electricity.converter.ad
@@ -6,6 +6,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group, aggregator_producer]
+- fever.alias_of = households_water_heater_heatpump_air_water_electricity
 - fever.base_cop = 3.25
 - fever.capacity.electricity = 0.002588997
 - fever.cop_per_degree = 0.0875

--- a/nodes/households/households_space_heater_heatpump_ground_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_heatpump_ground_water_electricity.converter.ad
@@ -5,6 +5,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group, aggregator_producer]
+- fever.alias_of = households_water_heater_heatpump_ground_water_electricity
 - fever.base_cop = 3.25
 - fever.cop_per_degree = 0.0875
 - fever.defer_for = 4

--- a/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -9,6 +9,7 @@
 - output.useable_heat.electricity = 1
 - output.useable_heat.network_gas = 1.067
 - groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group, aggregator_producer]
+- fever.alias_of = households_water_heater_hybrid_heatpump_air_water_electricity
 - fever.base_cop = 3.25
 - fever.capacity.electricity = 0.001294498
 - fever.capacity.network_gas = 0.022

--- a/nodes/households/households_space_heater_micro_chp_network_gas.converter.ad
+++ b/nodes/households/households_space_heater_micro_chp_network_gas.converter.ad
@@ -6,6 +6,7 @@
 - groups = [cost_chps, demand_driven, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, application_group, aggregator_producer]
 - merit_order.group = buildings_chp
 - merit_order.type = must_run
+- fever.alias_of = households_water_heater_micro_chp_network_gas
 - fever.defer_for = 4
 - fever.group = space_heating
 - fever.type = producer


### PR DESCRIPTION
Sets the electric- and hybrid- heat pumps for space heating to be aliases of their hot water equivalents. This ensures that the capacity of the heat pump is not considered twice.

![screen-shot-2017-08-28-at-17 21 45](https://user-images.githubusercontent.com/4383/29783485-78d5eec6-8c18-11e7-903b-a68cf7600815.png)

Currently the following heat producers act this way:

* `households_space_heater_combined_network_gas` → `households_water_heater_combined_network_gas`

* `households_space_heater_heatpump_air_water_electricity` → `households_water_heater_heatpump_air_water_electricity`

* `households_space_heater_heatpump_ground_water_electricity` → `households_water_heater_heatpump_ground_water_electricity`

* `households_space_heater_hybrid_heatpump_air_water_electricity` → `households_water_heater_hybrid_heatpump_air_water_electricity`

@ChaelKruip @DorinevanderVlies Do any others *also* need to behave this way?