### PR TITLE
Assign "use" to new household heat nodes

### DIFF
--- a/nodes/households/households_space_heater_coal_aggregator.ad
+++ b/nodes/households/households_space_heater_coal_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_combined_network_gas_aggregator.ad
+++ b/nodes/households/households_space_heater_combined_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_crude_oil_aggregator.ad
+++ b/nodes/households/households_space_heater_crude_oil_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_deficit.ad
+++ b/nodes/households/households_space_heater_deficit.ad
@@ -1,1 +1,4 @@
+- use = energetic
+- groups = []
+
 ~ demand = 0.0

--- a/nodes/households/households_space_heater_district_heating_steam_hot_water_aggregator.ad
+++ b/nodes/households/households_space_heater_district_heating_steam_hot_water_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_electricity_aggregator.ad
+++ b/nodes/households/households_space_heater_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_heatpump_air_water_electricity_aggregator.ad
+++ b/nodes/households/households_space_heater_heatpump_air_water_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_heatpump_ground_water_electricity_aggregator.ad
+++ b/nodes/households/households_space_heater_heatpump_ground_water_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity_aggregator.ad
+++ b/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_micro_chp_network_gas_aggregator.ad
+++ b/nodes/households/households_space_heater_micro_chp_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_network_gas_aggregator.ad
+++ b/nodes/households/households_space_heater_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_space_heater_wood_pellets_aggregator.ad
+++ b/nodes/households/households_space_heater_wood_pellets_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_coal_aggregator.ad
+++ b/nodes/households/households_water_heater_coal_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_combined_network_gas_aggregator.ad
+++ b/nodes/households/households_water_heater_combined_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_crude_oil_aggregator.ad
+++ b/nodes/households/households_water_heater_crude_oil_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_deficit.ad
+++ b/nodes/households/households_water_heater_deficit.ad
@@ -1,1 +1,4 @@
+- use = energetic
+- groups = []
+
 ~ demand = 0.0

--- a/nodes/households/households_water_heater_district_heating_steam_hot_water_aggregator.ad
+++ b/nodes/households/households_water_heater_district_heating_steam_hot_water_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_fuel_cell_chp_network_gas_aggregator.ad
+++ b/nodes/households/households_water_heater_fuel_cell_chp_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_heatpump_air_water_electricity_aggregator.ad
+++ b/nodes/households/households_water_heater_heatpump_air_water_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_heatpump_ground_water_electricity_aggregator.ad
+++ b/nodes/households/households_water_heater_heatpump_ground_water_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity_aggregator.ad
+++ b/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_micro_chp_network_gas_aggregator.ad
+++ b/nodes/households/households_water_heater_micro_chp_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_network_gas_aggregator.ad
+++ b/nodes/households/households_water_heater_network_gas_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_resistive_electricity_aggregator.ad
+++ b/nodes/households/households_water_heater_resistive_electricity_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []

--- a/nodes/households/households_water_heater_wood_pellets_aggregator.ad
+++ b/nodes/households/households_water_heater_wood_pellets_aggregator.ad
@@ -1,1 +1,2 @@
-
+- use = energetic
+- groups = []


### PR DESCRIPTION
Assigns a use of "energetic" to the new household heating nodes. This should fix quintel/etmodel#2452.