### PR TITLE
Add wacc to insulation cost queries

### DIFF
--- a/gqueries/general/costs/costs_of_insulation.gql
+++ b/gqueries/general/costs/costs_of_insulation.gql
@@ -5,7 +5,6 @@
       Q(costs_of_insulation_buildings),
       Q(costs_of_insulation_new_residences),
       Q(costs_of_insulation_old_residences)
-    ) / AREA(technical_lifetime_insulation)
-
+    )
 - unit = euro
 - deprecated_key = insulation_costs

--- a/gqueries/general/costs/costs_of_insulation_buildings.gql
+++ b/gqueries/general/costs/costs_of_insulation_buildings.gql
@@ -1,4 +1,4 @@
 - unit = euro
 
 - query =
-    V(buildings_heating_savings_from_insulation_useable_heat, initial_investment)
+    V(buildings_heating_savings_from_insulation_useable_heat, initial_investment) / AREA(technical_lifetime_insulation)+(V(buildings_heating_savings_from_insulation_useable_heat, initial_investment) / 2 * 0.04)

--- a/gqueries/general/costs/costs_of_insulation_new_residences.gql
+++ b/gqueries/general/costs/costs_of_insulation_new_residences.gql
@@ -1,4 +1,4 @@
 - unit = euro
 
 - query =
-    V(households_new_houses_heating_savings_from_insulation, initial_investment)
+    V(households_new_houses_heating_savings_from_insulation, initial_investment) / AREA(technical_lifetime_insulation) + (V(households_new_houses_heating_savings_from_insulation, initial_investment) / 2 * 0.04)

--- a/gqueries/general/costs/costs_of_insulation_old_residences.gql
+++ b/gqueries/general/costs/costs_of_insulation_old_residences.gql
@@ -1,4 +1,4 @@
 - unit = euro
 
 - query =
-    V(households_old_houses_heating_savings_from_insulation, initial_investment)
+    (V(households_old_houses_heating_savings_from_insulation, initial_investment) / AREA(technical_lifetime_insulation)) + (V(households_old_houses_heating_savings_from_insulation, initial_investment) / 2 * 0.04)


### PR DESCRIPTION
Wacc is added to the insulation costs queries.
The value of wacc (0.04) is currently hard-coded. This will be cleaned up this week.
See also https://github.com/quintel/etsource/issues/1347#event-1252892610