### PR TITLE
Fix incorrect nodes used for hot water in local datasets

### DIFF
--- a/initializer_inputs/households/households_hot_water/households_water_heater_coal_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_coal_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_coal),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_coal_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_combined_network_gas_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_combined_network_gas_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_combined_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_combined_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_crude_oil_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_crude_oil_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_crude_oil),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_crude_oil_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_district_heating_steam_hot_water),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_district_heating_steam_hot_water_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_fuel_cell_chp_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_fuel_cell_chp_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_ground_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_ground_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_hybrid_heatpump_air_water_electricity_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_hybrid_heatpump_air_water_electricity_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_hybrid_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_hybrid_heatpump_air_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_micro_chp_network_gas_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_micro_chp_network_gas_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_micro_chp_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_micro_chp_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_resistive_electricity_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_resistive_electricity_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_resistive_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_resistive_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/initializer_inputs/households/households_hot_water/households_water_heater_wood_pellets_share.ad
+++ b/initializer_inputs/households/households_hot_water/households_water_heater_wood_pellets_share.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_wood_pellets),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_wood_pellets_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_coal_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_coal_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_coal),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_coal_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_coal_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_coal_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_coal),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_coal_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_combined_network_gas_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_combined_network_gas_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_combined_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_combined_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_combined_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_combined_network_gas_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_combined_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_combined_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_crude_oil_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_crude_oil_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_crude_oil),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_crude_oil_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_crude_oil_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_crude_oil_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_crude_oil),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_crude_oil_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_district_heating_steam_hot_water),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_district_heating_steam_hot_water_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_district_heating_steam_hot_water_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_district_heating_steam_hot_water),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_district_heating_steam_hot_water_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_fuel_cell_chp_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_fuel_cell_chp_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_fuel_cell_chp_network_gas_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_fuel_cell_chp_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_fuel_cell_chp_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_air_water_electricity_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_air_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_ground_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_ground_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_heatpump_ground_water_electricity_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_ground_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_heatpump_ground_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_hybrid_heatpump_air_water_electricity_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_hybrid_heatpump_air_water_electricity_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_hybrid_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_hybrid_heatpump_air_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_hybrid_heatpump_air_water_electricity_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_hybrid_heatpump_air_water_electricity_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_hybrid_heatpump_air_water_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_hybrid_heatpump_air_water_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_micro_chp_network_gas_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_micro_chp_network_gas_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_micro_chp_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_micro_chp_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_micro_chp_network_gas_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_micro_chp_network_gas_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_micro_chp_network_gas),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_micro_chp_network_gas_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_resistive_electricity_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_resistive_electricity_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_resistive_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_resistive_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_resistive_electricity_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_resistive_electricity_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_resistive_electricity),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_resistive_electricity_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_wood_pellets_share_both.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_wood_pellets_share_both.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_wood_pellets),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_wood_pellets_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_both

--- a/inputs/adjust_scaling/households/households_hot_water/households_water_heater_wood_pellets_share_present.ad
+++ b/inputs/adjust_scaling/households/households_hot_water/households_water_heater_wood_pellets_share_present.ad
@@ -1,6 +1,6 @@
 - query =
     UPDATE(
-      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_wood_pellets),useable_heat), "links.detect{|l| !l.flexible? }"),
+      V(OUTPUT_SLOTS(LOOKUP(households_water_heater_wood_pellets_aggregator),useable_heat), "links.detect{|l| !l.flexible? }"),
       share, USER_INPUT() / 100.0
     )
 - share_group = hot_water_households_present


### PR DESCRIPTION
Fixes that initializer inputs and "adjust scaling" inputs had not been updated when the new hot water aggregator nodes were added.

I wrote a script to update all the inputs; I'm not sure how these slipped through the net. Sorry, this was my error. 😟

Ref: https://github.com/quintel/etmodel/issues/2501