### PR TITLE
Updated heat production queries to actually compute heat (and cold) production

### DIFF
--- a/gqueries/general/heat/heat_production_from_ambient.gql
+++ b/gqueries/general/heat/heat_production_from_ambient.gql
@@ -3,8 +3,8 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_ambient_heat),
-      V(G(heat_production),input_of_ambient_cold),
-      V(G(heat_production),input_of_wind),
-      V(G(heat_production),input_of_water)
+      V(G(heat_production),"input_of_ambient_heat * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_ambient_cold * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_wind * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_water * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_biomass_products.gql
+++ b/gqueries/general/heat/heat_production_from_biomass_products.gql
@@ -3,16 +3,16 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_greengas),
-      V(G(heat_production),input_of_biodiesel),
-      V(G(heat_production),input_of_bio_ethanol),
-      V(G(heat_production),input_of_bio_lng),
-      V(G(heat_production),input_of_bio_oil),
-      V(G(heat_production),input_of_biogas),
-      V(G(heat_production),input_of_torrified_biomass_pellets),
-      V(G(heat_production),input_of_wood_pellets),
-      V(G(heat_production),input_of_corn),
-      V(G(heat_production),input_of_manure),
-      V(G(heat_production),input_of_wood),
-      V(G(heat_production),input_of_woody_biomass)
+      V(G(heat_production),"input_of_greengas * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_biodiesel * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_bio_ethanol * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_bio_lng * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_bio_oil * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_biogas * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_torrified_biomass_pellets * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_wood_pellets * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_woody_biomass * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_corn * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_manure * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_wood * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_coal_and_derivatives.gql
+++ b/gqueries/general/heat/heat_production_from_coal_and_derivatives.gql
@@ -3,8 +3,8 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_coal),
-      V(G(heat_production),input_of_lignite),
-      V(G(heat_production),input_of_coal_gas),
-      V(G(heat_production),input_of_cokes)
+      V(G(heat_production),"input_of_coal * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_lignite * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_coal_gas * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_cokes * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_electricity.gql
+++ b/gqueries/general/heat/heat_production_from_electricity.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_electricity)
+      V(G(heat_production),"input_of_electricity * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_geothermal.gql
+++ b/gqueries/general/heat/heat_production_from_geothermal.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_geothermal)
+      V(G(heat_production),"input_of_geothermal * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_heat.gql
+++ b/gqueries/general/heat/heat_production_from_heat.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_steam_hot_water),
-      V(G(heat_production),input_of_useable_heat)
+      V(G(heat_production),"input_of_steam_hot_water * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_useable_heat * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_hydrogen.gql
+++ b/gqueries/general/heat/heat_production_from_hydrogen.gql
@@ -1,0 +1,7 @@
+# Use of 'hydrogen' carrier group in 'heat_production'
+
+- unit = PJ
+- query =
+    SUM(
+      V(G(heat_production),"input_of_hydrogen * heat_and_cold_output_conversion")
+    ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_imported_electricity.gql
+++ b/gqueries/general/heat/heat_production_from_imported_electricity.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_imported_electricity)
+      V(G(heat_production),"input_of_imported_electricity * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_losses.gql
+++ b/gqueries/general/heat/heat_production_from_losses.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_loss)
+      V(G(heat_production),"input_of_loss * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives.gql
+++ b/gqueries/general/heat/heat_production_from_natural_gas_and_derivatives.gql
@@ -3,9 +3,9 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_natural_gas),
-      V(G(heat_production),input_of_lng),
-      V(G(heat_production),input_of_network_gas),
-      V(G(heat_production),input_of_gas_power_fuelmix),
-      V(G(heat_production),input_of_compressed_network_gas)
+      V(G(heat_production),"input_of_natural_gas * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_lng * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_network_gas * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_gas_power_fuelmix * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_compressed_network_gas * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_nuclear.gql
+++ b/gqueries/general/heat/heat_production_from_nuclear.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_uranium_oxide)
+      V(G(heat_production),"input_of_uranium_oxide * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_oil_and_derivatives.gql
+++ b/gqueries/general/heat/heat_production_from_oil_and_derivatives.gql
@@ -3,10 +3,10 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_crude_oil),
-      V(G(heat_production),input_of_gasoline),
-      V(G(heat_production),input_of_diesel),
-      V(G(heat_production),input_of_lpg),
-      V(G(heat_production),input_of_kerosene),
-      V(G(heat_production),input_of_heavy_fuel_oil)
+      V(G(heat_production),"input_of_crude_oil * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_gasoline * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_diesel * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_lpg * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_kerosene * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_heavy_fuel_oil * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_solar.gql
+++ b/gqueries/general/heat/heat_production_from_solar.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_solar_radiation),
-      V(G(heat_production),input_of_solar_thermal)
+      V(G(heat_production),"input_of_solar_radiation * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_solar_thermal * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_useful_demand.gql
+++ b/gqueries/general/heat/heat_production_from_useful_demand.gql
@@ -3,11 +3,11 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_useable_heat),
-      V(G(heat_production),input_of_cooling),
-      V(G(heat_production),input_of_car_kms),
-      V(G(heat_production),input_of_truck_kms),
-      V(G(heat_production),input_of_light),
-      V(G(heat_production),input_of_not_defined),
-      V(G(heat_production),input_of_savings)
+      V(G(heat_production),"input_of_useable_heat * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_cooling * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_car_kms * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_truck_kms * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_light * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_not_defined * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_savings * heat_and_cold_output_conversion")
     ) / BILLIONS

--- a/gqueries/general/heat/heat_production_from_waste.gql
+++ b/gqueries/general/heat/heat_production_from_waste.gql
@@ -3,7 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-      V(G(heat_production),input_of_waste_mix),
-      V(G(heat_production),input_of_non_biogenic_waste),
-      V(G(heat_production),input_of_biogenic_waste)
+      V(G(heat_production),"input_of_waste_mix * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_non_biogenic_waste * heat_and_cold_output_conversion"),
+      V(G(heat_production),"input_of_biogenic_waste * heat_and_cold_output_conversion")
     ) / BILLIONS


### PR DESCRIPTION
Chart 42 (heat and cold production) first showed the carrier inputs for heat production, not the amount of heat/cold produced by each carrier. For CHPs, this meant that all energy going into the CHP showed up in the chart. This fix ensures that the graph shows the (actual) heat and cold produced by the carriers (i.e. by multipling inputs by heat_and_cold_output_conversion).