### PR TITLE
Make the ETDataset path dynamic

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,1 @@
+ETDATASET_PATH="../etdataset"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 gem 'rake'
 
 group :development, :test do
+  gem 'dotenv'
   gem 'roo'
   gem 'atlas',    ref: 'dce3f01', github: 'quintel/atlas'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.4)
+    dotenv (2.2.0)
     equalizer (0.0.11)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
@@ -86,6 +87,7 @@ PLATFORMS
 
 DEPENDENCIES
   atlas!
+  dotenv
   rake
   refinery!
   roo

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ will have to adjust and extend the energy balance with the use of
 
 Please [contact us][contact] when you have questions.
 
+## Setup
+
+Prerequisites:
+- rbenv
+- ruby
+- bundler
+- rspec
+
+There's no additional setup required for ETSource. There are however optional
+arguments you can set in a `.env` file in the root directory of your local
+ETSource project. See the `.env.default` which options are available.
+
 ## "Active" Documents
 
 Files with an ".ad" extension are editable through the [Atlas console][console]

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'dotenv/load'
+
 def encrypt_balance(directory)
   if File.exists?('.password')
     password = File.read('.password').strip
@@ -47,7 +49,7 @@ namespace :import do
 
     datasets.each do |country, year|
       dest = Pathname.new("datasets/#{ country }")
-      csvs = Pathname.glob("../etdataset/data/#{ country }/#{ year }/*/output/*.csv")
+      csvs = Pathname.glob("#{ ENV['ETDATASET_PATH'] }/data/#{ country }/#{ year }/*/output/*.csv")
 
       puts "Importing #{ country }/#{ year } dataset:"
 
@@ -107,7 +109,7 @@ namespace :import do
 
     node      = Atlas::Node.find(ENV['NODE'])
     node_path = "#{node.sector}/#{node.key}.#{node.class.subclass_suffix}"
-    xlsx      = Roo::Spreadsheet.open("../etdataset/nodes_source_analyses/#{node_path}.xlsx")
+    xlsx      = Roo::Spreadsheet.open("#{ ENV['ETDATASET_PATH'] }/nodes_source_analyses/#{node_path}.xlsx")
 
     xlsx.sheet('Dashboard').each(attribute: 'Attribute', value: 'Value') do |key_val|
       next unless key_val[:value].is_a?(Numeric)
@@ -161,7 +163,7 @@ namespace :import do
     Atlas.data_dir = File.expand_path(File.dirname(__FILE__))
 
     carrier = Atlas::Carrier.find(ENV['CARRIER'])
-    xlsx    = Roo::Spreadsheet.open("../etdataset/carriers_source_analyses/#{ENV['CARRIER']}.carrier.xlsx")
+    xlsx    = Roo::Spreadsheet.open("#{ ENV['ETDATASET_PATH'] }/carriers_source_analyses/#{ENV['CARRIER']}.carrier.xlsx")
 
     unless carrier
       raise ArgumentError, "carrier #{ENV['CARRIER']} does not exist!"
@@ -209,7 +211,7 @@ namespace :import do
 
     raise ArgumentError, "CARRIER '#{carrier}' does not exist in '#{dataset}'" unless current_fce
 
-    xlsx        = Roo::Spreadsheet.open("../etdataset/carriers_source_analyses/#{carrier}.carrier.xlsx")
+    xlsx        = Roo::Spreadsheet.open("#{ ENV['ETDATASET_PATH'] }/carriers_source_analyses/#{carrier}.carrier.xlsx")
     yaml_file   = Atlas.data_dir.join("datasets/#{dataset}/fce/#{carrier}.yml")
 
     current_fce = xlsx.sheet("#{ dataset }_fce")
@@ -231,7 +233,7 @@ namespace :import do
 end # :import
 
 desc <<-DESC
-  Import ETDataset CSVs from ../etdataset
+  Import ETDataset CSVs from #{ ENV['ETDATASET_PATH'] }
 
   Defaults to importing all datasets listed in datasets.yml. Providing an optional DATASET environment
   parameter results in importing only one dataset. If an optional YEAR environment parameter is provided,

--- a/helpers/encrypt_balance.rb
+++ b/helpers/encrypt_balance.rb
@@ -1,0 +1,18 @@
+def encrypt_balance(directory)
+  if File.exists?('.password')
+    password = File.read('.password').strip
+  else
+    puts "File .password not found in root. Cannot encrypt energy balance CSV"
+    exit(1)
+  end
+
+  csv  = directory.join('energy_balance.csv')
+  dest = directory.join('energy_balance.gpg')
+
+  if csv.file?
+    dest = csv.dirname.join('energy_balance.gpg')
+    system("gpg --batch --yes --passphrase '#{ password }' -c --output '#{ dest }' '#{ csv }'")
+    puts "  - Encrypted energy balance"
+  end
+end
+


### PR DESCRIPTION
Because of the minor effort I thought [this](https://github.com/quintel/etsource/pull/1389#issuecomment-339356749) might actually be doable.

Note: everybody does need to do a `mv .env.default .env` + run `bundle install` again whenever they want to make use of the rake tasks.