### PR TITLE
Fix queries used to set bunker demands

### DIFF
--- a/inputs/demand/bunkers/bunkers_allocated_percentage_aviation.ad
+++ b/inputs/demand/bunkers/bunkers_allocated_percentage_aviation.ad
@@ -1,4 +1,3 @@
-- query = UPDATE_WITH_FACTOR(V(bunkers_useful_demand_planes), preset_demand, USER_INPUT())
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
@@ -6,11 +5,10 @@
 - step_value = 0.1
 - unit = %
 - update_period = both
-- update_type = %
 
-#- query =
-      UPDATE(
-        V(bunkers_useful_demand_planes),
-        preset_demand,
-        V(bunkers_total_useful_demand_planes, preset_demand) * USER_INPUT()
-      )
+- query =
+    UPDATE(
+      V(bunkers_useful_demand_planes),
+      preset_demand,
+      V(bunkers_total_useful_demand_planes, preset_demand) * (USER_INPUT() / 100)
+    )

--- a/inputs/demand/bunkers/bunkers_allocated_percentage_shipping.ad
+++ b/inputs/demand/bunkers/bunkers_allocated_percentage_shipping.ad
@@ -1,4 +1,3 @@
-- query = UPDATE_WITH_FACTOR(V(bunkers_useful_demand_ships), preset_demand, USER_INPUT())
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
@@ -6,11 +5,10 @@
 - step_value = 0.1
 - unit = %
 - update_period = both
-- update_type = %
 
-#- query =
-      UPDATE(
-        V(bunkers_useful_demand_ships),
-        preset_demand,
-        V(bunkers_total_useful_demand_ships, preset_demand) * USER_INPUT()
-      )
+- query =
+    UPDATE(
+      V(bunkers_useful_demand_ships),
+      preset_demand,
+      V(bunkers_total_useful_demand_ships, preset_demand) * (USER_INPUT() / 100)
+    )


### PR DESCRIPTION
This pull request fixes the two queries use to set the demand of bunkers. I needed to remove `- update_type = %` to get them to work.

While this fixes the assignment of demand, the two input edges to useful_demand_shipping and useful_demand_planes do not currently have a share assigned. This means they both get a share of 100%:

<img width="875" alt="screen shot 2017-11-16 at 09 59 43" src="https://user-images.githubusercontent.com/4383/32885585-d206e5fa-cab5-11e7-8cb9-8716d25d50c6.png">

<img width="864" alt="screen shot 2017-11-16 at 10 09 01" src="https://user-images.githubusercontent.com/4383/32885707-3208c522-cab6-11e7-9dc8-7d35acc7dfc7.png">

Either these edges need to be assigned a share, or if the default state is for one to be 100% and the other 0%, the 0% edges could be changed to `- type = flexible`.