### PR TITLE
Bump ruby-zip gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
     ruby-graphviz (1.2.3)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
@@ -95,4 +95,4 @@ DEPENDENCIES
   rubel!
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
Fixes potential security threat (according to github).