### PR TITLE
Remove coal freight train from efficiency input

### DIFF
--- a/inputs/demand/transport/transport_efficiency/transport_trains_efficiency.ad
+++ b/inputs/demand/transport/transport_efficiency/transport_trains_efficiency.ad
@@ -1,7 +1,7 @@
 - query =
     EACH(
     UPDATE(OUTPUT_SLOTS(V(transport_passenger_train_using_diesel_mix,transport_passenger_train_using_electricity,transport_passenger_train_using_coal),passenger_kms), conversion, USER_INPUT()),
-    UPDATE(OUTPUT_SLOTS(V(transport_freight_train_using_diesel_mix,transport_freight_train_using_electricity,transport_freight_train_using_coal),freight_tonne_kms), conversion, USER_INPUT())
+    UPDATE(OUTPUT_SLOTS(V(transport_freight_train_using_diesel_mix,transport_freight_train_using_electricity),freight_tonne_kms), conversion, USER_INPUT())
     )
 - priority = 0
 - max_value = 3.0


### PR DESCRIPTION
Adjusts the `transport_trains_efficiency` input to remove a nonexistent coal freight train converter, which was causing this input to fail.

Airbrake refs: [[1]](https://quintel.airbrake.io/projects/35333/groups/2089917896139495527), [[2]](https://quintel.airbrake.io/projects/35333/groups/2089879752283281218), [[3]](https://quintel.airbrake.io/projects/35333/groups/2089227749026716000), [[4]](https://quintel.airbrake.io/projects/35333/groups/2089492077646733032).