### PR TITLE
Adding sliders Ptg, Ptl, Pth and Ptp concerning investment costs

### DIFF
--- a/inputs/costs/investment_costs_bunkers_flexibility_p2l_electricity.ad
+++ b/inputs/costs/investment_costs_bunkers_flexibility_p2l_electricity.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(bunkers_flexibility_p2l_electricity), initial_investment, USER_INPUT())
+- priority = 0
+- max_value = 300.0
+- min_value = -100.0
+- start_value = 0.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- update_type = %

--- a/inputs/costs/investment_costs_energy_flexibility_p2g_electricity.ad
+++ b/inputs/costs/investment_costs_energy_flexibility_p2g_electricity.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(energy_flexibility_p2g_electricity), initial_investment, USER_INPUT())
+- priority = 0
+- max_value = 300.0
+- min_value = -100.0
+- start_value = 0.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- update_type = %

--- a/inputs/costs/investment_costs_households_flexibility_p2h_electricity.ad
+++ b/inputs/costs/investment_costs_households_flexibility_p2h_electricity.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(households_flexibility_p2h_electricity), initial_investment, USER_INPUT())
+- priority = 0
+- max_value = 300.0
+- min_value = -100.0
+- start_value = 0.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- update_type = %

--- a/inputs/costs/investment_costs_households_flexibility_p2p_electricity.ad
+++ b/inputs/costs/investment_costs_households_flexibility_p2p_electricity.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(V(households_flexibility_p2p_electricity), initial_investment, USER_INPUT())
+- priority = 0
+- max_value = 300.0
+- min_value = -100.0
+- start_value = 0.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- update_type = %


### PR DESCRIPTION
Adding sliders:
Ptg: Hydrogen for transport and export
Ptl: Kerosine for Bunkers
Pth: electric boiler for households
Ptp: batteries in households (not electric vehicles). 