### PR TITLE
Adding child_share-attribute to the carbon capture edges

### DIFF
--- a/edges/bunkers/bunkers_p2l_direct_air_capture-bunkers_p2l_mixer_co@co.ad
+++ b/edges/bunkers/bunkers_p2l_direct_air_capture-bunkers_p2l_mixer_co@co.ad
@@ -1,3 +1,5 @@
 - type = share
 - reversed = false
 - groups = []
+
+~ child_share = 1.0

--- a/edges/bunkers/bunkers_p2l_point_source_CO-bunkers_p2l_mixer_co@co.ad
+++ b/edges/bunkers/bunkers_p2l_point_source_CO-bunkers_p2l_mixer_co@co.ad
@@ -1,3 +1,5 @@
 - type = share
 - reversed = false
 - groups = []
+
+~ child_share = 0.0

--- a/edges/bunkers/bunkers_p2l_point_source_CO2-bunkers_p2l_mixer_co@co.ad
+++ b/edges/bunkers/bunkers_p2l_point_source_CO2-bunkers_p2l_mixer_co@co.ad
@@ -1,3 +1,5 @@
 - type = share
 - reversed = false
 - groups = []
+
+~ child_share = 0.0

--- a/inputs/flexibility/bunkers/flexibility_p2l_direct_air_capture.ad
+++ b/inputs/flexibility/bunkers/flexibility_p2l_direct_air_capture.ad
@@ -8,7 +8,7 @@
 - share_group = carbon_source_p2l
 - max_value = 100.0
 - min_value = 0.0
-- start_value = 100.0
+- start_value_gql = present:V(bunkers_p2l_direct_air_capture,share_of_bunkers_p2l_mixer_co) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future

--- a/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO.ad
+++ b/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO.ad
@@ -8,7 +8,7 @@
 - share_group = carbon_source_p2l
 - max_value = 100.0
 - min_value = 0.0
-- start_value = 0.0
+- start_value_gql = present:V(bunkers_p2l_point_source_CO,share_of_bunkers_p2l_mixer_co) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future

--- a/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO2.ad
+++ b/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO2.ad
@@ -8,7 +8,7 @@
 - share_group = carbon_source_p2l
 - max_value = 100.0
 - min_value = 0.0
-- start_value = 0.0
+- start_value_gql = present:V(bunkers_p2l_point_source_CO2,share_of_bunkers_p2l_mixer_co) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future


### PR DESCRIPTION
I have added `child_share`-attributes to the edges of carbon-capturing. First, I had also updated the input statements that they should update the `child_share` instead of the `share`. But that did not work! So I changed it back to `share` and that worked.