### PR TITLE
Add input dac and share-groups

### DIFF
--- a/inputs/flexibility/bunkers/flexibility_p2l_direct_air_capture.ad
+++ b/inputs/flexibility/bunkers/flexibility_p2l_direct_air_capture.ad
@@ -1,0 +1,14 @@
+- query =
+    UPDATE(
+      LINK(bunkers_p2l_direct_air_capture, bunkers_p2l_mixer_co),
+      share,
+      DIVIDE(USER_INPUT(), 100)
+    )
+- priority = 0
+- share_group = carbon_source_p2l
+- max_value = 100.0
+- min_value = 0.0
+- start_value_gql = present:V(bunkers_p2l_direct_air_capture,share_of_bunkers_p2l_mixer_co) * 100
+- step_value = 0.1
+- unit = %
+- update_period = future

--- a/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO.ad
+++ b/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO.ad
@@ -5,6 +5,7 @@
       DIVIDE(USER_INPUT(), 100)
     )
 - priority = 0
+- share_group = carbon_source_p2l
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(bunkers_p2l_point_source_CO,share_of_bunkers_p2l_mixer_co) * 100

--- a/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO2.ad
+++ b/inputs/flexibility/bunkers/flexibility_p2l_point_source_CO2.ad
@@ -5,6 +5,7 @@
       DIVIDE(USER_INPUT(), 100)
     )
 - priority = 0
+- share_group = carbon_source_p2l
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(bunkers_p2l_point_source_CO2,share_of_bunkers_p2l_mixer_co) * 100


### PR DESCRIPTION
- reverted the removal of the share group in the carbon sliders
- reverted the removal of the DAC input statement

