### PR TITLE
Fix ETMoses buffer queries

### DIFF
--- a/gqueries/modules/etmoses/etmoses_hot_water_buffer_demand.gql
+++ b/gqueries/modules/etmoses/etmoses_hot_water_buffer_demand.gql
@@ -2,8 +2,13 @@
 # scenario into ETMoses.
 # This query sums the demand of all hot water technologies which are explcitly modelled in ETMoses
 
-- query = 
-    (V(households_useful_demand_for_hot_water_for_houses_with_p2h, demand) +
-    V(INTERSECTION(G(etmoses),CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h))), output_of_useable_heat).sum) / BILLIONS
+- query =
+    SUM(
+      V(households_useful_demand_for_hot_water_for_houses_with_p2h, demand),
+      V(
+        INTERSECTION(G(etmoses),G(merit_household_hot_water_producers)),
+        output_of_useable_heat
+      )
+    ) / BILLIONS
 
 - unit = PJ

--- a/gqueries/modules/etmoses/etmoses_space_heating_buffer_demand.gql
+++ b/gqueries/modules/etmoses/etmoses_space_heating_buffer_demand.gql
@@ -2,9 +2,9 @@
 # importing a scenario into ETMoses.
 
 - query =
-    V(
-      INTERSECTION(G(etmoses),CHILDREN(V(households_useful_demand_for_space_heating_after_insulation_and_solar_heater))), 
+    SUM(V(
+      INTERSECTION(G(etmoses),G(merit_household_space_heating_producers)),
       output_of_useable_heat
-    ).sum / BILLIONS
+    )) / BILLIONS
 
 - unit = PJ


### PR DESCRIPTION
Hot water and space heating nodes are not directly connected to useful demand nodes, and the use of Array#sum (on nil) would raise an error due to no matching nodes.

Replaces `CHILDREN(useful_demand)` by referencing the relevant group names instead, and removes the use of Array#sum in favour of `SUM()`.

Closes quintel/etmoses#1610

---

FYI @DorinevanderVlies 