### PR TITLE
Remove final_demand group from edge that does not need to have this group

### DIFF
--- a/edges/bunkers/bunkers_locally_available_kerosene_after_p2l-bunkers_plane_using_kerosene@kerosene.ad
+++ b/edges/bunkers/bunkers_locally_available_kerosene_after_p2l-bunkers_plane_using_kerosene@kerosene.ad
@@ -1,3 +1,2 @@
 - type = share
 - reversed = false
-- groups = [final_demand]


### PR DESCRIPTION
Fixing https://github.com/quintel/etmodel/issues/2685 

