### PR TITLE
whitelisted input shares for industry steel blastfurnace burner coal gas

### DIFF
--- a/nodes/industry/industry_steel_blastfurnace_burner_coal_gas.converter.ad
+++ b/nodes/industry/industry_steel_blastfurnace_burner_coal_gas.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [cost_traditional_heat, heat_production, metal_industry]
-- graph_methods = [output]
+- graph_methods = [output, input]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0


### PR DESCRIPTION
Fixes: https://github.com/quintel/etlocal/issues/73 (allows steel sector to be set to 0 in local datasets)