### PR TITLE
Ignore initializer method when the value is blank

### DIFF
--- a/tasks/csv_import_datasets.rb
+++ b/tasks/csv_import_datasets.rb
@@ -43,7 +43,7 @@ namespace :import do
 
   def set_graph_values(dataset, graph_values)
     graph_values.each_pair do |key, val|
-      next unless key
+      next if key.blank? || val.blank?
 
       element_key, _, method = key.rpartition('-')
 


### PR DESCRIPTION
Fix for CSV dataset import. Blank value should be ignored.