### PR TITLE
Fix CO2 biomass chart (#188); international transport was added twice

### DIFF
--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/co2_emissions_of_final_demand_excluding_imported_electricity_in_co2_emissions.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/co2_emissions_of_final_demand_excluding_imported_electricity_in_co2_emissions.gql
@@ -7,6 +7,6 @@
 - unit = PJ
 - query =
     SUM(
-        V(G(final_demand_group),primary_co2_emission).sum,
+        V(G(final_demand_group),primary_co2_emission).sum / BILLIONS,
         NEG(Q(primary_co2_of_bunkers))
-    ) / BILLIONS
+    )

--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/co2_emissions_of_final_demand_excluding_imported_electricity_in_co2_emissions.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/co2_emissions_of_final_demand_excluding_imported_electricity_in_co2_emissions.gql
@@ -1,6 +1,12 @@
 # Take note: The imported electricity is not included in
 # co2_emissions_of_final_demand_excluding_imported_electricity because it is
-# assigned no CO2 emission as primary carrier.
+# assigned no CO2 emission as primary carrier
+# Also international transport is not included in this chart, since it is separately shown
+# with the query: primary_co2_of_bunkers
 
 - unit = PJ
-- query = V(G(final_demand_group),primary_co2_emission).sum / BILLIONS
+- query =
+    SUM(
+        V(G(final_demand_group),primary_co2_emission).sum,
+        NEG(V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)), primary_co2_emission).sum)
+    ) / BILLIONS

--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/co2_emissions_of_final_demand_excluding_imported_electricity_in_co2_emissions.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/co2_emissions_of_final_demand_excluding_imported_electricity_in_co2_emissions.gql
@@ -8,5 +8,5 @@
 - query =
     SUM(
         V(G(final_demand_group),primary_co2_emission).sum,
-        NEG(V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)), primary_co2_emission).sum)
+        NEG(Q(primary_co2_of_bunkers))
     ) / BILLIONS


### PR DESCRIPTION
Subtracted international transport emissions from the total co2 emissions in chart #188

This was the issue:
<img width="1181" alt="pastedgraphic-8" src="https://user-images.githubusercontent.com/32833996/37598470-93ed4baa-2b82-11e8-9526-e7f1332a867a.png">

<img width="1134" alt="pastedgraphic-10" src="https://user-images.githubusercontent.com/32833996/37598477-98c72f06-2b82-11e8-802d-b400dc39065b.png">
