### PR TITLE
Add missing consumption nodes to the Merit order

### DIFF
--- a/gqueries/general/merit/hv/hv_industry_other_load_curve.gql
+++ b/gqueries/general/merit/hv/hv_industry_other_load_curve.gql
@@ -1,5 +1,6 @@
 - query =
     MERIT_LOAD_CURVES(
+      energy_cokesoven_consumption_coal_gas,
       industry_final_demand_for_other_electricity,
       industry_final_demand_for_other_ict_electricity
     )

--- a/gqueries/general/merit/hv/hv_other_load_curve.gql
+++ b/gqueries/general/merit/hv/hv_other_load_curve.gql
@@ -1,5 +1,6 @@
 - query =
     MERIT_LOAD_CURVES(
       bunkers_final_demand_electricity,
+      energy_power_sector_own_use_electricity,
       other_final_demand_electricity
     )

--- a/nodes/energy/energy_cokesoven_consumption_coal_gas.converter.ad
+++ b/nodes/energy/energy_cokesoven_consumption_coal_gas.converter.ad
@@ -3,6 +3,9 @@
 - output.coupling_carrier = 1.0
 - output.loss = elastic
 - groups = [final_demand_group, metal, application_group, mv_net_demand]
+- merit_order.group = flat
+- merit_order.type = consumer
+- merit_order.level = hv
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/energy/energy_power_hv_network_loss.ad
+++ b/nodes/energy/energy_power_hv_network_loss.ad
@@ -2,8 +2,9 @@
 - energy_balance_group = distribution losses
 - output.loss = elastic
 - groups = []
+- merit_order.group = flat
+- merit_order.type = consumer
+- merit_order.level = hv
 - free_co2_factor = 0.0
 
 ~ demand = -EB(losses, electricity)
-- merit_order.group = flat
-- merit_order.type = consumer

--- a/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
+++ b/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
@@ -2,6 +2,9 @@
 - energy_balance_group = energy sector own use
 - output.loss = elastic
 - groups = [final_demand_group, preset_demand, application_group]
+- merit_order.group = flat
+- merit_order.type = consumer
+- merit_order.level = hv
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 


### PR DESCRIPTION
Adds HV losses and own use, and energy_cokesoven_consumption_coal_gas. With quintel/etengine@ab9bdde7 this accounts for all of the missing demand in a default scenario.

![screen shot 2018-05-16 at 14 23 40](https://user-images.githubusercontent.com/4383/40119629-17639510-5915-11e8-81d8-9f696541ec93.png)
