### PR TITLE
Cost charts

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/flexibility_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/flexibility_in_breakdown_of_total_costs_per_household.gql
@@ -1,6 +1,6 @@
 - query =
     DIVIDE(
-      Q(electricity_in_breakdown_of_total_costs),
+      Q(flexibility_in_breakdown_of_total_costs),
       AREA(number_of_residences)
     )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/fuels_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/fuels_in_breakdown_of_total_costs_per_household.gql
@@ -1,2 +1,6 @@
-- query = DIVIDE(SUM(Q(costs_of_transport_fuels),Q(total_costs_of_energy_sector)),AREA(number_of_residences))
+- query =
+    DIVIDE(
+      Q(fuels_in_breakdown_of_total_costs),
+      AREA(number_of_residences)
+    )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/heat_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/heat_in_breakdown_of_total_costs_per_household.gql
@@ -1,2 +1,6 @@
-- query = DIVIDE(Q(costs_of_produced_heat_plus_insulation),AREA(number_of_residences))
+- query =
+    DIVIDE(
+      Q(heat_in_breakdown_of_total_costs),
+      AREA(number_of_residences)
+    )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/hydrogen_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/hydrogen_in_breakdown_of_total_costs_per_household.gql
@@ -1,6 +1,6 @@
 - query =
     DIVIDE(
-      Q(electricity_in_breakdown_of_total_costs),
+      Q(hydrogen_in_breakdown_of_total_costs),
       AREA(number_of_residences)
     )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/network_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/network_in_breakdown_of_total_costs_per_household.gql
@@ -1,6 +1,6 @@
 - query =
     DIVIDE(
-        Q(network_total_costs),
-        AREA(number_of_residences)
+      Q(network_in_breakdown_of_total_costs),
+      AREA(number_of_residences)
     )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/non_energetic_fuels_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/non_energetic_fuels_in_breakdown_of_total_costs_per_household.gql
@@ -1,2 +1,6 @@
-- query = DIVIDE(Q(costs_of_non_energetic_demand),AREA(number_of_residences))
+- query =
+    DIVIDE(
+      Q(non_energetic_fuels_in_breakdown_of_total_costs),
+      AREA(number_of_residences)
+    )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/vehicles_in_breakdown_of_total_costs_per_household.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_113_breakdown_total_costs_per_household/vehicles_in_breakdown_of_total_costs_per_household.gql
@@ -1,6 +1,6 @@
 - query =
     DIVIDE(
-        Q(costs_of_transport_vehicles),
-        AREA(number_of_residences)
+      Q(vehicles_in_breakdown_of_total_costs),
+      AREA(number_of_residences)
     )
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/electricity_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/electricity_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(Q(costs_of_used_electricity),BILLIONS)
-- unit = bln_euro
+- query = Q(costs_of_used_electricity)
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/flexibility_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/flexibility_in_breakdown_of_total_costs.gql
@@ -1,6 +1,2 @@
-- query =
-    DIVIDE(
-        Q(costs_of_flexibility),
-        BILLIONS
-    )
-- unit = bln_euro
+- query = Q(costs_of_flexibility)
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/fuels_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/fuels_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(SUM(Q(costs_of_transport_fuels),Q(total_costs_of_energy_sector)),BILLIONS)
-- unit = bln_euro
+- query = SUM(Q(costs_of_transport_fuels),Q(total_costs_of_energy_sector))
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/heat_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/heat_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(Q(costs_of_produced_heat_plus_insulation),BILLIONS)
-- unit = bln_euro
+- query = Q(costs_of_produced_heat_plus_insulation)
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/hydrogen_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/hydrogen_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(Q(costs_of_used_hydrogen),BILLIONS)
-- unit = bln_euro
+- query = Q(costs_of_used_hydrogen)
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/network_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/network_in_breakdown_of_total_costs.gql
@@ -1,6 +1,2 @@
-- query =
-    DIVIDE(
-        Q(total_costs_of_network_calculation),
-        BILLIONS
-    )
-- unit = bln_euro
+- query = Q(total_costs_of_network_calculation)
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/non_energetic_fuels_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/non_energetic_fuels_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(Q(costs_of_non_energetic_demand),BILLIONS)
-- unit = bln_euro
+- query = Q(costs_of_non_energetic_demand)
+- unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/vehicles_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/vehicles_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(Q(costs_of_transport_vehicles),BILLIONS)
-- unit = bln_euro
+- query = Q(costs_of_transport_vehicles)
+- unit = euro


### PR DESCRIPTION
- Added h2 and flexibility series to costs per household chart
- Fixed mistake in network costs per household
- Simplified costs per household queries by referring directly to total costs queries
- Simplified total costs queries by removing division by BILLIONS and changing unit to euro instead of bln_euro