### PR TITLE
Queries for import in the merit order

### DIFF
--- a/gqueries/output_elements/output_series/table_116_merit_order/energy_interconnector_imported_electricity_merit_order.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/energy_interconnector_imported_electricity_merit_order.gql
@@ -1,0 +1,9 @@
+- query =
+  {
+    capacity:        Q(merit_order_energy_interconnector_imported_electricity_capacity_in_merit_order_table),
+    availability: Q(merit_order_energy_interconnector_imported_electricity_availability_in_merit_order_table),
+    full_load_hours: Q(merit_order_energy_interconnector_imported_electricity_full_load_hours_in_merit_order_table),
+    load_factor:     Q(merit_order_energy_interconnector_imported_electricity_load_factor_in_merit_order_table),
+    operating_costs: Q(merit_order_energy_interconnector_imported_electricity_operating_costs_in_merit_order_table),
+    position:        Q(merit_order_energy_interconnector_imported_electricity_position_in_merit_order_table)
+  }

--- a/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_availability_in_merit_order_table.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_availability_in_merit_order_table.gql
@@ -1,0 +1,5 @@
+# Availability of 'energy_interconnector_imported_electricity' in merit order table
+
+- unit = Percentage
+- query =
+    V(energy_interconnector_imported_electricity, "availability * 100")

--- a/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_capacity_in_merit_order_table.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_capacity_in_merit_order_table.gql
@@ -1,0 +1,5 @@
+# Installed capacity of 'energy_interconnector_imported_electricity' in merit order table
+
+- unit = MW
+- query =
+    V(energy_interconnector_imported_electricity, installed_production_capacity_in_mw_electricity)

--- a/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_full_load_hours_in_merit_order_table.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_full_load_hours_in_merit_order_table.gql
@@ -1,0 +1,9 @@
+# Full load hours of 'energy_interconnector_imported_electricity' in merit order table
+
+- unit = hours
+- query =
+    V(
+      energy_interconnector_imported_electricity,
+      "demand / electricity_output_capacity / MJ_PER_MWH"
+    )
+

--- a/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_operating_costs_in_merit_order_table.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_operating_costs_in_merit_order_table.gql
@@ -1,0 +1,4 @@
+# Operating costs of 'energy_interconnector_imported_electricity' in merit order table
+
+- unit = EUR
+- query = Q(price_of_imported_electricity)

--- a/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_position_in_merit_order_table.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/merit_order_energy_interconnector_imported_electricity_position_in_merit_order_table.gql
@@ -1,0 +1,4 @@
+# position of 'energy_interconnector_imported_electricity' in merit order table
+
+- unit = number
+- query = V(energy_interconnector_imported_electricity , merit_order_position)

--- a/nodes/energy/energy_interconnector_imported_electricity.converter.ad
+++ b/nodes/energy/energy_interconnector_imported_electricity.converter.ad
@@ -9,6 +9,7 @@
 - full_load_hours = 0.0
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
+- number_of_units = 1.0
 
 ~ max_demand = infinity
 ~ electricity_output_capacity = AREA(interconnector_capacity)


### PR DESCRIPTION
Adds queries used to show information about the import interconnector in the MO table and capacity chart.