### PR TITLE
`rake import` also imports bicycles_demand.csv

### DIFF
--- a/tasks/etdataset/import_dataset.rb
+++ b/tasks/etdataset/import_dataset.rb
@@ -45,6 +45,8 @@ namespace :import do
           cp_csv(csv, dest.join('shares'))
         when /time_curve$/
           cp_csv(csv, dest.join('time_curves'))
+        when /^bicycles_demand/
+          cp_csv(csv, dest.join('demands/bicycles_demand.csv'))
         when /^metal_demands/
           cp_csv(csv, dest.join('demands/metal_demands.csv'))
         when /^primary_production/


### PR DESCRIPTION
Updates `rake import` to also copy the bicycles_demand.csv file from ETDataset.

Note that the NL2015 dataset has had a "parent_values.csv" manually added to the "demands" directory; running `rake import` will remove this file *even though it is needed by ETLocal*. Therefore if you choose to import the NL2015 dataset, prior to committing your changes you should follow it up with `git checkout datasets/**/parent_values.csv` to restore the parent_values.csv file. This is being tracked separately in #1773.

Closes #1772.