### PR TITLE
Remove scaling information from Brabant presets (production)

### DIFF
--- a/presets/quintel/west_en_midden_brabant_res_basis.ad
+++ b/presets/quintel/west_en_midden_brabant_res_basis.ad
@@ -393,9 +393,3 @@
 - user_values.transport_useful_demand_passenger_kms = 1.5
 - user_values.transport_vehicle_combustion_engine_efficiency = 2.0
 - user_values.transport_vehicle_using_electricity_efficiency = 0.3
-- scaling.area_attribute = number_of_residences
-- scaling.base_value = 7587964.0
-- scaling.has_agriculture =
-- scaling.has_energy =
-- scaling.has_industry =
-- scaling.value = 511017.0

--- a/presets/quintel/west_en_midden_brabant_res_variatie.ad
+++ b/presets/quintel/west_en_midden_brabant_res_variatie.ad
@@ -399,9 +399,3 @@
 - user_values.transport_useful_demand_passenger_kms = 1.5
 - user_values.transport_vehicle_combustion_engine_efficiency = 2.0
 - user_values.transport_vehicle_using_electricity_efficiency = 0.3
-- scaling.area_attribute = number_of_residences
-- scaling.base_value = 7587964.0
-- scaling.has_agriculture =
-- scaling.has_energy =
-- scaling.has_industry =
-- scaling.value = 511017.0


### PR DESCRIPTION
"scaling" attributes are incorrectly added by ETEngine's "export as preset" feature when exporting a local dataset.