### PR TITLE
Energy sankey fix

### DIFF
--- a/gqueries/output_elements/output_series/sankey/electricity_prod_to_conversion_loss_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/electricity_prod_to_conversion_loss_in_sankey.gql
@@ -1,9 +1,10 @@
 # Query for Sankey diagram: connection between electricity_prod and loss
+# Excluding the losses of sustainable electricity nodes, since their output energy is primary energy
 
 - unit = PJ
 - query =
     DIVIDE(
       SUM(V(
-        Q(electricity_producing_converters_sankey), output_of_loss),
+        EXCLUDE(Q(electricity_producing_converters_sankey),G(primary_energy_demand)), output_of_loss),
         V(energy_flexibility_curtailment_electricity, demand)),
         BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/water_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/water_to_electricity_prod_in_sankey.gql
@@ -1,4 +1,10 @@
 # Query for Sankey diagram: connection between water and electricity
 
 - unit = PJ
-- query = DIVIDE(V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.water? }}, primary_demand_of(electricity)),BILLIONS)
+- query =
+    DIVIDE(
+        SUM(
+            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.water? }}, primary_demand_of(electricity))
+        ),
+        BILLIONS
+    )

--- a/gqueries/output_elements/output_series/sankey/wind_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/wind_to_electricity_prod_in_sankey.gql
@@ -3,8 +3,8 @@
 - unit = PJ
 - query =
     DIVIDE(
-      SUM(
-        V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.wind? }}, primary_demand_of(electricity))
-      ),
-    BILLIONS
+        SUM(
+            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.wind? }}, primary_demand_of(electricity))
+        ),
+        BILLIONS
     )


### PR DESCRIPTION
Two things:
1.  Electricity production -> losses: excluded the losses of the sustainable electricity production nodes, since their output energy is primary energy (as mentioned in https://github.com/quintel/etmodel/issues/2854)
2. Hydropower gquery was not working, but is fixed now