### PR TITLE
Fixed mistake in size input statement for aggregated other sector

### DIFF
--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other.ad
@@ -1,5 +1,5 @@
 - query =
-    UPDATE_WITH_FACTOR(V(Q(aggregated_other_industry_energetic_converters)), preset_demand, USER_INPUT())
+    UPDATE_WITH_FACTOR(V(G(aggregated_other_industry)), preset_demand, USER_INPUT())
 - priority = 0
 - max_value = 300.0
 - min_value = 0.0


### PR DESCRIPTION
Also included non-energetic useful demands in the query, before it only changed the demand of energetic useful demands

Fixing https://github.com/quintel/etmodel/issues/2893