### PR TITLE
Updating biofootprint dummy values with more realistic values

### DIFF
--- a/carriers/palm.ad
+++ b/carriers/palm.ad
@@ -3,6 +3,7 @@
 - cost_per_mj = 0.015188765350149352
 - mj_per_kg = 46.0
 - potential_co2_conversion_per_mj = 0.112
+- typical_production_per_km2 = 15506658.0
 - co2_conversion_per_mj = 0.0
 - kg_per_liter = 0.524
 - graphviz_color = saddlebrown

--- a/carriers/rapeseed.ad
+++ b/carriers/rapeseed.ad
@@ -4,6 +4,7 @@
 - mj_per_kg = 46.0
 - co2_conversion_per_mj = 0.0
 - potential_co2_conversion_per_mj = 0.112
+- typical_production_per_km2 = 5269465.2944731945
 - co2_conversion_per_mj = 0.0
 - kg_per_liter = 0.524
 - graphviz_color = saddlebrown

--- a/carriers/sugar_beets.ad
+++ b/carriers/sugar_beets.ad
@@ -4,6 +4,6 @@
 - mj_per_kg = 46.0
 - co2_conversion_per_mj = 0.0
 - potential_co2_conversion_per_mj = 0.112
-- typical_production_per_km2 = 7716904.800000001
+- typical_production_per_km2 = 10500000.0
 - kg_per_liter = 0.524
 - graphviz_color = saddlebrown

--- a/carriers/sugar_cane.ad
+++ b/carriers/sugar_cane.ad
@@ -4,6 +4,6 @@
 - mj_per_kg = 46.0
 - co2_conversion_per_mj = 0.0
 - potential_co2_conversion_per_mj = 0.112
-- typical_production_per_km2 = 7716904.800000001
+- typical_production_per_km2 = 10500000.0
 - kg_per_liter = 0.524
 - graphviz_color = saddlebrown

--- a/carriers/wheat.ad
+++ b/carriers/wheat.ad
@@ -4,5 +4,5 @@
 - mj_per_kg = 5.43444
 - co2_conversion_per_mj = 0.0
 - potential_co2_conversion_per_mj = 0.112
-- typical_production_per_km2 = 7716904.800000001
+- typical_production_per_km2 = 10500000.0
 - graphviz_color = saddlebrown


### PR DESCRIPTION
Replacing biofootprint dummy values in biofeedstock carriers with more realistic values. The more realistic originate from the old biofootprint values in the biofuel-carriers:

https://github.com/quintel/etsource/commit/daa8b07e8c652706e1708f34d250289e5d686222#diff-2a21b9d5bbcf9ea48b1d0a9711276136

Closing https://github.com/quintel/etsource/issues/1902