### PR TITLE
Change type of edge between energy_import_greengas and foreign_energy…

### DIFF
--- a/edges/foreign/foreign_energy_upgrade_biogas-energy_import_greengas@greengas.ad
+++ b/edges/foreign/foreign_energy_upgrade_biogas-energy_import_greengas@greengas.ad
@@ -1,2 +1,2 @@
-- type = constant
+- type = share
 - reversed = false


### PR DESCRIPTION
…_upgrade_biogas to share


The edge between `energy_import_greengas` and `foreign_energy_upgrade_biogas` was of type `constant` instead of `share`. This caused the energy balance to be incorrect (incoming energy was not equal to outgoing energy) for this edge, which again resulted in an incorrect biofootprint calculation for greengas. Updating the edge type to `share` seems to have fixed the corresponding issue (https://github.com/quintel/etmodel/issues/2978). 