### PR TITLE
Update Leeuwarden dataset: increase biogas used in CHPs agriculture

### DIFF
--- a/datasets/GM0080_leeuwarden/graph_values.yml
+++ b/datasets/GM0080_leeuwarden/graph_values.yml
@@ -1,12 +1,12 @@
 ---
 agriculture_chp_engine_biogas:
-  demand: 0.0
+  demand: 97.6
 agriculture_final_demand_wood_pellets:
   demand: 0.0
 agriculture_chp_supercritical_wood_pellets:
   demand: 0.0
 agriculture_final_demand_steam_hot_water:
-  demand: 1.125407053287
+  demand: 35.285407053286995
 agriculture_final_demand_crude_oil:
   demand: 0.0
 agriculture_final_demand_network_gas:
@@ -14,7 +14,7 @@ agriculture_final_demand_network_gas:
 agriculture_chp_engine_network_gas:
   demand: 2.3944830921
 agriculture_final_demand_electricity:
-  demand: 39.60891398133007
+  demand: 42.049619181330065
 agriculture_final_demand_hydrogen:
   demand: 0.0
 buildings_collective_chp_wood_pellets:
@@ -172,7 +172,7 @@ energy_mixer_for_gas_power_fuel:
     :crude_oil: 0.0
     :bio_oil: 0.0
 energy_production_biogas:
-  demand: 0.0
+  demand: 97.6
 energy_power_hv_network_loss:
   demand: 92.6495417564653
 energy_power_nuclear_gen3_uranium_oxide:
@@ -320,7 +320,7 @@ industry_other_metals_burner_network_gas:
 agriculture_final_demand_electricity-agriculture_geothermal@electricity:
   parent_share: 0.0
 agriculture_final_demand_electricity-agriculture_heatpump_water_water_ts_electricity@electricity:
-  parent_share: 0.0007066957639954315
+  parent_share: 0.000665676699861613
 buildings_final_demand_coal-buildings_final_demand_for_space_heating_coal@coal:
   parent_share: 0.0
 buildings_final_demand_electricity-buildings_final_demand_for_appliances_electricity@electricity:


### PR DESCRIPTION
I have updated the biogas used in CHPs in agriculture to match with the 41PJ electricity production through biogas Klimaatmonitor reports for Leeuwarden here: https://klimaatmonitor.databank.nl/dashboard/Dashboard/Hernieuwbare-Energie/Hernieuwbare-elektriciteit--315/?regionlevel=gemeente . 

The only thing is that the total heat and electricity demand for agriculture simultaneously increases while doing that! Heat from 1 to 35 TJ and electricity from 39 TJ to 80 TJ. Shall we leave that?