### PR TITLE
Remove typical production per km2 from waste fats carrier in order to fix biofootprint calculation

### DIFF
--- a/nodes/energy/energy_production_waste_fats.ad
+++ b/nodes/energy/energy_production_waste_fats.ad
@@ -1,6 +1,6 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [bio_footprint_calculation, bio_resources_demand, mining_and_extraction]
+- groups = [bio_resources_demand, mining_and_extraction]
 - free_co2_factor = 0.0
 
 ~ max_demand = PRIMARY_PRODUCTION(energy_production_waste_fats, max_demand)

--- a/nodes/foreign/foreign_energy_production_waste_fats.ad
+++ b/nodes/foreign/foreign_energy_production_waste_fats.ad
@@ -1,5 +1,5 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [foreign, bio_footprint_calculation, bio_resources_demand, mining_and_extraction]
+- groups = [foreign, bio_resources_demand, mining_and_extraction]
 - abroad = true
 - free_co2_factor = 0.0


### PR DESCRIPTION
`Q(bio_footprint)` was returning `NaN` because the `typical_production_per_km2` for waste fats is set to zero and dividing the demand of the `energy_production_waste_fats` node by zero gave `NaN`. 

This PR removes the `energy_production_waste_fats` and `foreign_energy_production_waste_fats` from the `bio_footprint_calculation` group and fixes the issue!