### PR TITLE
Fix FLH input statements for wind turbines and solar PV parcs

### DIFF
--- a/inputs/full_load_hours/flh_of_energy_hydrogen_wind_turbine_offshore.ad
+++ b/inputs/full_load_hours/flh_of_energy_hydrogen_wind_turbine_offshore.ad
@@ -1,4 +1,20 @@
-- query = UPDATE(V(energy_hydrogen_wind_turbine_offshore), full_load_hours, USER_INPUT())
+# The query starts by fetching the original number of units (nou): we want the new FLH
+# to increase the preset demand, so we have to set this value after updating FLH
+# to prevent ETEngine from calculating a new (lower) NoU.
+#
+# See https://github.com/quintel/etmodel/issues/2906
+- query =
+    original_nou = V(energy_hydrogen_wind_turbine_offshore, number_of_units);
+
+    EACH(
+      UPDATE(V(energy_hydrogen_wind_turbine_offshore), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_hydrogen_wind_turbine_offshore), number_of_units, original_nou),
+      UPDATE(
+        V(energy_hydrogen_wind_turbine_offshore),
+        preset_demand_by_electricity_production,
+        V(energy_hydrogen_wind_turbine_offshore, production_based_on_number_of_units)
+      )
+    )
 - priority = 1
 - max_value = 6500.0
 - min_value_gql = present:V(energy_hydrogen_wind_turbine_offshore, full_load_hours)

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal.ad
@@ -1,4 +1,20 @@
-- query = UPDATE(V(energy_power_wind_turbine_coastal), full_load_hours, USER_INPUT())
+# The query starts by fetching the original number of units (nou): we want the new FLH
+# to increase the preset demand, so we have to set this value after updating FLH
+# to prevent ETEngine from calculating a new (lower) NoU.
+#
+# See https://github.com/quintel/etmodel/issues/2906
+- query =
+    original_nou = V(energy_power_wind_turbine_coastal, number_of_units);
+
+    EACH(
+      UPDATE(V(energy_power_wind_turbine_coastal), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_power_wind_turbine_coastal), number_of_units, original_nou),
+      UPDATE(
+        V(energy_power_wind_turbine_coastal),
+        preset_demand_by_electricity_production,
+        V(energy_power_wind_turbine_coastal, production_based_on_number_of_units)
+      )
+    )
 - priority = 1
 - max_value = 4500.0
 - min_value_gql = present:V(energy_power_wind_turbine_coastal, full_load_hours)

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland.ad
@@ -1,4 +1,20 @@
-- query = UPDATE(V(energy_power_wind_turbine_inland), full_load_hours, USER_INPUT())
+# The query starts by fetching the original number of units (nou): we want the new FLH
+# to increase the preset demand, so we have to set this value after updating FLH
+# to prevent ETEngine from calculating a new (lower) NoU.
+#
+# See https://github.com/quintel/etmodel/issues/2906
+- query =
+    original_nou = V(energy_power_wind_turbine_inland, number_of_units);
+
+    EACH(
+      UPDATE(V(energy_power_wind_turbine_inland), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_power_wind_turbine_inland), number_of_units, original_nou),
+      UPDATE(
+        V(energy_power_wind_turbine_inland),
+        preset_demand_by_electricity_production,
+        V(energy_power_wind_turbine_inland, production_based_on_number_of_units)
+      )
+    )
 - priority = 1
 - max_value = 3500.0
 - min_value_gql = present:V(energy_power_wind_turbine_inland, full_load_hours)

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore.ad
@@ -1,4 +1,20 @@
-- query = UPDATE(V(energy_power_wind_turbine_offshore), full_load_hours, USER_INPUT())
+# The query starts by fetching the original number of units (nou): we want the new FLH
+# to increase the preset demand, so we have to set this value after updating FLH
+# to prevent ETEngine from calculating a new (lower) NoU.
+#
+# See https://github.com/quintel/etmodel/issues/2906
+- query =
+    original_nou = V(energy_power_wind_turbine_offshore, number_of_units);
+
+    EACH(
+      UPDATE(V(energy_power_wind_turbine_offshore), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_power_wind_turbine_offshore), number_of_units, original_nou),
+      UPDATE(
+        V(energy_power_wind_turbine_offshore),
+        preset_demand_by_electricity_production,
+        V(energy_power_wind_turbine_offshore, production_based_on_number_of_units)
+      )
+    )
 - priority = 1
 - max_value = 6500.0
 - min_value_gql = present:V(energy_power_wind_turbine_offshore, full_load_hours)

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
@@ -1,4 +1,11 @@
+# The query starts by fetching the original number of units (nou): we want the new FLH
+# to increase the preset demand, so we have to set this value after updating FLH
+# to prevent ETEngine from calculating a new (lower) NoU.
+#
+# See https://github.com/quintel/etmodel/issues/2906
 - query =
+    original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+
     share_2 =
         DIVIDE(
             (USER_INPUT() - QUERY_PRESENT(->{ V(energy_power_solar_pv_solar_radiation, full_load_hours) })),
@@ -10,6 +17,12 @@
         UPDATE(V(energy_hydrogen_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
         UPDATE(V(buildings_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
         UPDATE(V(households_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
+        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, original_nou),
+        UPDATE(
+          V(energy_power_solar_pv_solar_radiation),
+          preset_demand_by_electricity_production,
+          V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
+        ),
         UPDATE(AREA(), solar_pv_profile_1_share, (1 - share_2)),
         UPDATE(AREA(), solar_pv_profile_2_share, share_2)
     )


### PR DESCRIPTION
Fixes https://github.com/quintel/etmodel/issues/2906:

- Update the input statement for `flh_of_energy_hydrogen_wind_turbine_offshore`, `flh_of_energy_power_wind_turbine_coastal` and `flh_of_energy_power_wind_turbine_coastal`: now, the original number of units are stored before updating the FLH sliders in order to calculate and update the new `preset_demand_by_electricity_production` (with `production_based_on_number_of_units`).

- Update the input statement for `flh_of_solar_pv_solar_radiation` in the same way; however, this only fixes the issue for `energy_power_solar_pv_solar_radiation`. The issue remains for `energy_hydrogen_solar_pv_solar_radiation`, `buildings_solar_pv_solar_radiation`, and `households_solar_pv_solar_radiation`.