### PR TITLE
Update queries to fix ETFlex

### DIFF
--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_heating_technology_in_use.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_heating_technology_in_use.gql
@@ -1,5 +1,5 @@
 - query =
-    IF(INPUT_VALUE(households_heater_hybrid_heatpump_air_water_electricity_share) > 10,
+    IF(INPUT_VALUE(households_heater_hybrid_heatpump_air_water_electricity_share) > 50,
       "hybrid_heatpump",
       IF(INPUT_VALUE(households_heater_combined_network_gas_share) > 50,
         "combi_boiler",

--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_heating_technology_in_use.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_heating_technology_in_use.gql
@@ -1,6 +1,6 @@
 - query =
-    IF(INPUT_VALUE(households_heater_district_heating_steam_hot_water_share) > 0,
-      "district_heating",
+    IF(INPUT_VALUE(households_heater_hybrid_heatpump_air_water_electricity_share) > 0,
+      "hybrid_heatpump",
       IF(INPUT_VALUE(households_heater_combined_network_gas_share) > 50,
         "combi_boiler",
         IF(INPUT_VALUE(households_heater_heatpump_ground_water_electricity_share) > 50,

--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_heating_technology_in_use.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_heating_technology_in_use.gql
@@ -1,5 +1,5 @@
 - query =
-    IF(INPUT_VALUE(households_heater_hybrid_heatpump_air_water_electricity_share) > 0,
+    IF(INPUT_VALUE(households_heater_hybrid_heatpump_air_water_electricity_share) > 10,
       "hybrid_heatpump",
       IF(INPUT_VALUE(households_heater_combined_network_gas_share) > 50,
         "combi_boiler",

--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_investment_per_household.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_investment_per_household.gql
@@ -6,10 +6,10 @@
     SUM (
       V(households_space_heater_combined_network_gas,"number_of_units * initial_investment"),
       V(households_space_heater_heatpump_ground_water_electricity,"number_of_units * initial_investment"),
-      V(households_space_heater_district_heating_steam_hot_water, "number_of_units * initial_investment"),
+      V(households_space_heater_hybrid_heatpump_air_water_electricity, "number_of_units * initial_investment"),
       V(households_water_heater_combined_network_gas,"number_of_units * initial_investment"),
       V(households_water_heater_heatpump_ground_water_electricity,"number_of_units * initial_investment"),
-      V(households_water_heater_district_heating_steam_hot_water, "number_of_units * initial_investment"),
+      V(households_water_heater_hybrid_heatpump_air_water_electricity, "number_of_units * initial_investment"),
       V(households_cooling_airconditioning_electricity,"number_of_units * initial_investment"),
       V(households_solar_pv_solar_radiation,"number_of_units * initial_investment"),
       V(households_water_heater_solar_thermal,"initial_investment") * (INPUT_VALUE(households_water_heater_solar_thermal_share) / 50.0) * AREA(number_of_residences),

--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_investment_per_household.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_investment_per_household.gql
@@ -7,12 +7,8 @@
       V(households_space_heater_combined_network_gas,"number_of_units * initial_investment"),
       V(households_space_heater_heatpump_ground_water_electricity,"number_of_units * initial_investment"),
       V(households_space_heater_hybrid_heatpump_air_water_electricity, "number_of_units * initial_investment"),
-      V(households_water_heater_combined_network_gas,"number_of_units * initial_investment"),
-      V(households_water_heater_heatpump_ground_water_electricity,"number_of_units * initial_investment"),
-      V(households_water_heater_hybrid_heatpump_air_water_electricity, "number_of_units * initial_investment"),
       V(households_cooling_airconditioning_electricity,"number_of_units * initial_investment"),
       V(households_solar_pv_solar_radiation,"number_of_units * initial_investment"),
-      V(households_water_heater_solar_thermal,"initial_investment") * (INPUT_VALUE(households_water_heater_solar_thermal_share) / 50.0) * AREA(number_of_residences),
       V(households_water_heater_solar_thermal,"initial_investment") * (INPUT_VALUE(households_water_heater_solar_thermal_share) / 50.0) * AREA(number_of_residences),
       Q(costs_of_insulation_terraced_houses)
     ) / AREA(number_of_residences)

--- a/gqueries/modules/etflex/etflex_level_2/etflex_households_renewability_percentage_heat_per_household.gql
+++ b/gqueries/modules/etflex/etflex_level_2/etflex_households_renewability_percentage_heat_per_household.gql
@@ -5,7 +5,7 @@
       SUM(
         V(households_water_heater_solar_thermal, output_of_useable_heat),
         V(households_space_heater_heatpump_ground_water_electricity, "output_of_useable_heat * sustainability_share"),
-        V(households_space_heater_district_heating_steam_hot_water, "output_of_useable_heat * sustainability_share")
+        V(households_space_heater_hybrid_heatpump_air_water_electricity, "output_of_useable_heat * sustainability_share")
       ),
       V(households_useful_demand_hot_water,
         households_useful_demand_for_space_heating_after_insulation,

--- a/gqueries/modules/etflex/etflex_score_deviations_from_reference_scenario.gql
+++ b/gqueries/modules/etflex/etflex_score_deviations_from_reference_scenario.gql
@@ -5,7 +5,7 @@
 # Reference values:
 #
 # DEMAND
-# * Isolation:          67%
+# * Insulation:          67%
 # * Electric cars:      75%
 # * LED:                90%
 # * Electric trucks:    75%


### PR DESCRIPTION
- Replace district heating by a hybrid heat pump
- Remove the `households_water_heater_...` queries from the investment query (since these do not exist anymore)