### PR TITLE
New p2p series for chart 5 "Sources of electricity in households"

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_5_source_of_electricity_in_households/households_batteries_p2p_in_source_of_electricity_in_households.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_5_source_of_electricity_in_households/households_batteries_p2p_in_source_of_electricity_in_households.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = DIVIDE(SUM(V(households_flexibility_p2p_electricity,output_of_electricity)),BILLIONS)


### PR DESCRIPTION
Fixes quintel/etmodel#2825

This chart is still not perfect (see quintel/etmodel#2841), but it's getting closer ;) Fixed because of tomorrows workshop in Antwerp.

![Screen Shot 2019-04-09 at 16 00 56](https://user-images.githubusercontent.com/32833996/55806584-d5f09a00-5ae0-11e9-8fab-f57f2d85382d.png)
