### PR TITLE
CO2 emissions

### DIFF
--- a/carriers/diesel.ad
+++ b/carriers/diesel.ad
@@ -2,6 +2,6 @@
 - infinite = false
 - cost_per_mj = 0.015214672943066214
 - mj_per_kg = 43.1
-- co2_conversion_per_mj = 0.0732
+- co2_conversion_per_mj = 0.0743
 - kg_per_liter = 0.832
 - graphviz_color = saddlebrown

--- a/carriers/gasoline.ad
+++ b/carriers/gasoline.ad
@@ -2,6 +2,6 @@
 - infinite = false
 - cost_per_mj = 0.016130064628386773
 - mj_per_kg = 43.2
-- co2_conversion_per_mj = 0.0733
+- co2_conversion_per_mj = 0.072
 - kg_per_liter = 0.745
 - graphviz_color = saddlebrown

--- a/carriers/heavy_fuel_oil.ad
+++ b/carriers/heavy_fuel_oil.ad
@@ -2,6 +2,6 @@
 - infinite = false
 - cost_per_mj = 0.014813827160493825
 - mj_per_kg = 40.5
-- co2_conversion_per_mj = 0.0806
+- co2_conversion_per_mj = 0.0774
 - kg_per_liter = 0.97
 - graphviz_color = saddlebrown

--- a/carriers/kerosene.ad
+++ b/carriers/kerosene.ad
@@ -2,6 +2,6 @@
 - infinite = false
 - cost_per_mj = 0.010081803098066371
 - mj_per_kg = 43.15
-- co2_conversion_per_mj = 0.073
+- co2_conversion_per_mj = 0.0715
 - kg_per_liter = 0.804
 - graphviz_color = saddlebrown

--- a/carriers/lpg.ad
+++ b/carriers/lpg.ad
@@ -2,6 +2,6 @@
 - infinite = false
 - cost_per_mj = 0.015188765350149352
 - mj_per_kg = 46.0
-- co2_conversion_per_mj = 0.0657
+- co2_conversion_per_mj = 0.0667
 - kg_per_liter = 0.524
 - graphviz_color = saddlebrown

--- a/datasets/nl/fce/coal.yml
+++ b/datasets/nl/fce/coal.yml
@@ -6,7 +6,7 @@
   :co2_transportation_per_mj: 0.00033996
   :co2_conversion_per_mj: 0.088163
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.153
+  :start_value: 0.0
 :east_asia:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00485538
@@ -14,7 +14,7 @@
   :co2_transportation_per_mj: 0.00037335
   :co2_conversion_per_mj: 0.0983293
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.124
+  :start_value: 0.0
 :eastern_europe:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0107564
@@ -22,7 +22,7 @@
   :co2_transportation_per_mj: 0.00127921
   :co2_conversion_per_mj: 0.103616
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.088
+  :start_value: 0.0
 :north_america:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00365593
@@ -30,7 +30,7 @@
   :co2_transportation_per_mj: 0.00021007
   :co2_conversion_per_mj: 0.0874464
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.169
+  :start_value: 0.0
 :russia:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0119648
@@ -46,7 +46,7 @@
   :co2_transportation_per_mj: 0.00026328
   :co2_conversion_per_mj: 0.0901655
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.263
+  :start_value: 0.0
 :south_america:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.00051643
@@ -54,4 +54,12 @@
   :co2_transportation_per_mj: 0.00028475
   :co2_conversion_per_mj: 0.0954937
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.203
+  :start_value: 0.0
+:custom:
+  :co2_exploration_per_mj: 0.0
+  :co2_extraction_per_mj: 0.0
+  :co2_treatment_per_mj: 0.0
+  :co2_transportation_per_mj: 0.0
+  :co2_conversion_per_mj: 0.0945
+  :co2_waste_treatment_per_mj: 0.0
+  :start_value: 1.0

--- a/datasets/nl/fce/lng.yml
+++ b/datasets/nl/fce/lng.yml
@@ -14,7 +14,7 @@
   :co2_transportation_per_mj: 0.00142292934019654
   :co2_conversion_per_mj: 0.0554959589339704
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.415094339622641
+  :start_value: 0.0
 :qatar:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
@@ -22,7 +22,7 @@
   :co2_transportation_per_mj: 0.0034
   :co2_conversion_per_mj: 0.0556666439496815
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.584905660377358
+  :start_value: 0.0
 :trinidad:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
@@ -31,3 +31,11 @@
   :co2_conversion_per_mj: 0.0555647714096
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 0.0
+:custom:
+  :co2_exploration_per_mj: 0.0
+  :co2_extraction_per_mj: 0.0
+  :co2_treatment_per_mj: 0.0
+  :co2_transportation_per_mj: 0.0
+  :co2_conversion_per_mj: 0.0565
+  :co2_waste_treatment_per_mj: 0.0
+  :start_value: 1.0

--- a/datasets/nl/fce/natural_gas.yml
+++ b/datasets/nl/fce/natural_gas.yml
@@ -14,7 +14,7 @@
   :co2_transportation_per_mj: 0.00011197
   :co2_conversion_per_mj: 0.0552117
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.9
+  :start_value: 0.0
 :norway:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
@@ -22,7 +22,7 @@
   :co2_transportation_per_mj: 0.00112427
   :co2_conversion_per_mj: 0.0566487
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.05
+  :start_value: 0.00
 :russia:
   :co2_exploration_per_mj: 0.0
   :co2_extraction_per_mj: 0.0
@@ -30,4 +30,12 @@
   :co2_transportation_per_mj: 0.00988619
   :co2_conversion_per_mj: 0.0551203
   :co2_waste_treatment_per_mj: 0.0
-  :start_value: 0.05
+  :start_value: 0.00
+:custom:
+  :co2_exploration_per_mj: 0.0
+  :co2_extraction_per_mj: 0.0
+  :co2_treatment_per_mj: 0.0
+  :co2_transportation_per_mj: 0.0
+  :co2_conversion_per_mj: 0.0565
+  :co2_waste_treatment_per_mj: 0.0
+  :start_value: 1.0

--- a/datasets/nl/fce/non_biogenic_waste.yml
+++ b/datasets/nl/fce/non_biogenic_waste.yml
@@ -1,9 +1,9 @@
 ---
-:crude_oil:
+:custom:
   :co2_exploration_per_mj: 0.0
-  :co2_extraction_per_mj: 0.00483
+  :co2_extraction_per_mj: 0.0
   :co2_treatment_per_mj: 0.0
-  :co2_transportation_per_mj: 0.00088
-  :co2_conversion_per_mj: 0.0733
+  :co2_transportation_per_mj: 0.0
+  :co2_conversion_per_mj: 0.1052
   :co2_waste_treatment_per_mj: 0.0
   :start_value: 1.0

--- a/gqueries/general/co2/co2_emissions_of_final_demand_excluding_imported_electricity.gql
+++ b/gqueries/general/co2/co2_emissions_of_final_demand_excluding_imported_electricity.gql
@@ -3,6 +3,10 @@
 # assigned no CO2 emission as primary carrier. This is standard, because CO2
 # emissions are not standard calculated for import yet!
 
-- query = V(G(final_demand_group),primary_co2_emission).sum
+- query =
+    SUM(
+      V(G(co2_emissions_primary),primary_co2_emission),
+      V(G(co2_emissions_refinery_products), "demand * weighted_carrier_co2_per_mj")
+      )
 - unit = kg
 - deprecated_key = co2_emission_excl_electricity_import

--- a/gqueries/general/co2/primary_co2_emission_of_buildings.gql
+++ b/gqueries/general/co2/primary_co2_emission_of_buildings.gql
@@ -1,5 +1,10 @@
-# How much Mt CO2 is emitted yearly by the buildings sector 
+# How much Mt CO2 is emitted yearly by the buildings sector
 # Used in education module about the future home, heat and insulation
 
-- query = V( INTERSECTION(G(final_demand_group), SECTOR(buildings)), primary_co2_emission).sum / BILLIONS
+- query =
+    SUM(
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(buildings)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(buildings)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
 - unit = mt

--- a/gqueries/general/co2/primary_co2_emission_of_households.gql
+++ b/gqueries/general/co2/primary_co2_emission_of_households.gql
@@ -1,5 +1,10 @@
-# How much Mt CO2 is emitted yearly by the household sector 
+# How much Mt CO2 is emitted yearly by the household sector
 # Used in education module about the future home, heat and insulation
 
-- query = V( INTERSECTION(G(final_demand_group), SECTOR(households)), primary_co2_emission).sum / BILLIONS
+- query =
+    SUM(
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(households)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(households)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
 - unit = mt

--- a/gqueries/general/co2/primary_co2_emission_of_transport.gql
+++ b/gqueries/general/co2/primary_co2_emission_of_transport.gql
@@ -1,5 +1,10 @@
 # How much Mt CO2 is emitted yearly by the transport sector
 # Used in transportation education module
 
-- query = V( INTERSECTION(G(final_demand_group), SECTOR(transport)), primary_co2_emission).sum / BILLIONS
+- query =
+    SUM(
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(transport)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(transport)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
 - unit = mt

--- a/gqueries/general/co2/primary_co2_of_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_agriculture.gql
@@ -1,7 +1,9 @@
 # CO2 of agriculture sector
 
-- unit = kg
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)), primary_co2_emission)
-    ) / BILLIONS
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(agriculture)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(agriculture)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
+- unit = mt

--- a/gqueries/general/co2/primary_co2_of_ambient_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_agriculture.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_buildings.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_bunkers.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_energy.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_households.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_industry.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_other.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_ambient_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_ambient_in_transport.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "ambient_heat_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "ambient_cold_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_agriculture.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_buildings.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")        
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_bunkers.gql
@@ -3,9 +3,9 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_kerosene? }}, "bio_kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_kerosene? }}, "bio_kerosene_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_energy.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_households.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_industry.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_other.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_biomass_products_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_biomass_products_in_transport.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")          
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.biodiesel? }}, "biodiesel_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_ethanol? }}, "bio_ethanol_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.wood_pellets? }}, "wood_pellets_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.bio_lng? }}, "bio_lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_buildings.gql
@@ -1,7 +1,9 @@
 # CO2 of buildings sector
 
-- unit = kg
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)), primary_co2_emission)
-    ) / BILLIONS
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(buildings)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(buildings)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
+- unit = mt

--- a/gqueries/general/co2/primary_co2_of_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_bunkers.gql
@@ -4,9 +4,11 @@
 - unit = kg
 - query =
     SUM(
-      SUM(
-        V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)), primary_co2_emission)
-      ) / BILLIONS,
+    SUM(
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(bunkers)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(bunkers)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS,
       MIN(
         Q(point_source_co_used),
         Q(point_source_co_available)
@@ -15,4 +17,4 @@
         Q(point_source_co2_used),
         Q(point_source_co2_available)
       ) * INPUT_VALUE(flexibility_p2l_co2_reduction_industry) / 100.0
-    ) 
+    )

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives.gql
@@ -3,8 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(G(final_demand_group),primary_demand_of_coal).sum * V(CARRIER(coal), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_coal_gas).sum * V(CARRIER(coal_gas), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_cokes).sum * V(CARRIER(cokes), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_lignite).sum * V(CARRIER(lignite), co2_per_mj)
+      V(G(co2_emissions_primary),primary_demand_of_coal).sum * V(CARRIER(coal), co2_per_mj),
+      V(G(co2_emissions_primary),primary_demand_of_coal_gas).sum * V(CARRIER(coal_gas), co2_per_mj),
+      V(G(co2_emissions_primary),primary_demand_of_cokes).sum * V(CARRIER(cokes), co2_per_mj),
+      V(G(co2_emissions_primary),primary_demand_of_lignite).sum * V(CARRIER(lignite), co2_per_mj)
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_agriculture.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_buildings.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_bunkers.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_energy.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_households.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_industry.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_other.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_coal_and_derivatives_in_transport.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "coal_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal_gas? }}, "coal_gas_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_agriculture.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_buildings.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_bunkers.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_energy.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_households.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_industry.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_other.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_electricity_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_electricity_in_transport.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.electricity? }}, "electricity_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_energy.gql
@@ -1,7 +1,9 @@
 # CO2 of energy sector
 
-- unit = kg
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)), primary_co2_emission)
-    ) / BILLIONS
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(energy)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(energy)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
+- unit = mt

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_agriculture.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_buildings.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_bunkers.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_energy.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_households.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_industry.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_other.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_geothermal_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_geothermal_in_transport.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "geothermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_agriculture.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_buildings.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_bunkers.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_energy.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_households.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_industry.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_other.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_heat_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_heat_in_transport.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.steam_hot_water? }}, "steam_hot_water_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.useable_heat? }}, "useable_heat_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_households.gql
+++ b/gqueries/general/co2/primary_co2_of_households.gql
@@ -1,7 +1,9 @@
 # CO2 of households sector
 
-- unit = kg
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)), primary_co2_emission)
-    ) / BILLIONS
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(households)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(households)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
+- unit = mt

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_agriculture.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_buildings.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_bunkers.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_energy.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_households.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_industry.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_other.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_hydrogen_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_hydrogen_in_transport.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.hydrogen? }}, "hydrogen_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_imported_electricity.gql
+++ b/gqueries/general/co2/primary_co2_of_imported_electricity.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(G(final_demand_group),primary_demand_of_imported_electricity).sum * V(CARRIER(imported_electricity), co2_per_mj)
+      V(G(co2_emissions_primary),primary_demand_of_imported_electricity).sum * V(CARRIER(imported_electricity), co2_per_mj)
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_imported_hydrogen.gql
+++ b/gqueries/general/co2/primary_co2_of_imported_hydrogen.gql
@@ -3,5 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(G(final_demand_group),primary_demand_of_imported_hydrogen).sum * V(CARRIER(imported_hydrogen), co2_per_mj)
+      V(G(co2_emissions_primary),primary_demand_of_imported_hydrogen).sum * V(CARRIER(imported_hydrogen), co2_per_mj)
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_industry.gql
@@ -4,9 +4,11 @@
 - unit = kg
 - query =
     SUM(
-      SUM(
-        V(INTERSECTION(G(final_demand_group),SECTOR(industry)), primary_co2_emission)
-      ) / BILLIONS,
+    SUM(
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(industry)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(industry)), "demand * weighted_carrier_co2_per_mj")
+      )
+       / BILLIONS,
       NEG(
         MIN(
           Q(point_source_co_used),

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(G(final_demand_group),primary_demand_of_natural_gas).sum * V(CARRIER(natural_gas), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_lng).sum * V(CARRIER(lng), co2_per_mj)
+      V(G(co2_emissions_primary),primary_demand_of_natural_gas).sum * V(CARRIER(natural_gas), co2_per_mj),
+      V(G(co2_emissions_primary),primary_demand_of_lng).sum * V(CARRIER(lng), co2_per_mj)
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_agriculture.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_buildings.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_bunkers.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_energy.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")         
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_households.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_industry.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_other.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")       
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_natural_gas_and_derivatives_in_transport.gql
@@ -3,7 +3,7 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.compressed_network_gas? }}, "compressed_network_gas_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.compressed_network_gas? }}, "compressed_network_gas_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.lng? }}, "lng_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives.gql
@@ -3,10 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(G(final_demand_group),primary_demand_of_crude_oil).sum * V(CARRIER(crude_oil), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_gasoline).sum * V(CARRIER(gasoline), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_diesel).sum * V(CARRIER(diesel), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_kerosene).sum * V(CARRIER(kerosene), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_lpg).sum * V(CARRIER(lpg), co2_per_mj),
-      V(G(final_demand_group),primary_demand_of_heavy_fuel_oil).sum * V(CARRIER(heavy_fuel_oil), co2_per_mj)
+      V(G(co2_emissions_primary),primary_demand_of_crude_oil).sum * V(CARRIER(crude_oil), co2_per_mj),
+      V(G(co2_emissions_refinery_products),"demand * weighted_carrier_co2_per_mj")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_agriculture.gql
@@ -3,10 +3,9 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(agriculture)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS
+

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_buildings.gql
@@ -3,10 +3,9 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(buildings)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS
+

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_bunkers.gql
@@ -3,10 +3,9 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(bunkers)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS
+

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_curtailment.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_curtailment.gql
@@ -3,10 +3,5 @@
 - unit = tonne
 - query =
     SUM(
-      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")
+      V(V(energy_flexibility_curtailment_electricity).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_energy.gql
@@ -3,10 +3,9 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(energy)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS
+

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_export.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_export.gql
@@ -2,19 +2,6 @@
 
 - unit = tonne
 - query =
-        crude_oil = G(energy_export).select { |node| node.query.input_of_crude_oil > 0 };
-        gasoline = G(energy_export).select { |node| node.query.input_of_gasoline > 0 };
-        diesel = G(energy_export).select { |node| node.query.input_of_diesel > 0 };
-        lpg = G(energy_export).select { |node| node.query.input_of_lpg > 0 };
-        kerosene = G(energy_export).select { |node| node.query.input_of_kerosene > 0 };
-        heavy_fuel_oil = G(energy_export).select { |node| node.query.input_of_heavy_fuel_oil > 0 };
-
-        SUM(
-            V(crude_oil, "crude_oil_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)"),
-            V(gasoline, "gasoline_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)"),
-            V(diesel, "diesel_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)"),
-            V(lpg, "lpg_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)"),
-            V(kerosene, "kerosene_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)"),
-            V(heavy_fuel_oil, "heavy_fuel_oil_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)")
-        ) / THOUSANDS
-    
+    SUM(
+        V(G(energy_export).select { |node| node.query.input_of_crude_oil > 0 }, "crude_oil_input_conversion * primary_co2_emission * (1.0 - demand / primary_demand)")
+    ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_households.gql
@@ -3,10 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(households)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_industry.gql
@@ -3,10 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(industry)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_other.gql
@@ -3,10 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(other)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_oil_and_derivatives_in_transport.gql
@@ -3,10 +3,8 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.gasoline? }}, "gasoline_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.diesel? }}, "diesel_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.lpg? }}, "lpg_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.kerosene? }}, "kerosene_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.heavy_fuel_oil? }}, "heavy_fuel_oil_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "crude_oil_input_conversion * primary_co2_emission"),
+      SUM(
+        V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(transport)), "demand * weighted_carrier_co2_per_mj")
+      )
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_other.gql
+++ b/gqueries/general/co2/primary_co2_of_other.gql
@@ -1,7 +1,9 @@
 # CO2 of other sector
 
-- unit = kg
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)), primary_co2_emission)
-    ) / BILLIONS
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(other)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(other)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
+- unit = mt

--- a/gqueries/general/co2/primary_co2_of_solar_in_agriculture.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_agriculture.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(agriculture)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_buildings.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_buildings.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(buildings)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_bunkers.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_bunkers.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(bunkers)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_energy.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_energy.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(energy)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_households.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_households.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(households)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_industry.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_industry.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(industry)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_other.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_other.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(other)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_solar_in_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_solar_in_transport.gql
@@ -3,6 +3,6 @@
 - unit = tonne
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")      
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_radiation? }}, "solar_radiation_input_conversion * primary_co2_emission"),
+      V(INTERSECTION(G(co2_emissions_primary),SECTOR(transport)).select {|node| node.input_slots.detect { |slot| slot.carrier.solar_thermal? }}, "solar_thermal_input_conversion * primary_co2_emission")
     ) / THOUSANDS

--- a/gqueries/general/co2/primary_co2_of_transport.gql
+++ b/gqueries/general/co2/primary_co2_of_transport.gql
@@ -1,7 +1,9 @@
 # CO2 of transport sector
 
-- unit = kg
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),SECTOR(transport)), primary_co2_emission)
-    ) / BILLIONS
+      V( INTERSECTION(G(co2_emissions_primary), SECTOR(transport)), primary_co2_emission),
+      V( INTERSECTION(G(co2_emissions_refinery_products), SECTOR(transport)), "demand * weighted_carrier_co2_per_mj")
+    )
+       / BILLIONS
+- unit = mt

--- a/nodes/agriculture/agriculture_final_demand_crude_oil.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_crude_oil.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/agriculture/agriculture_final_demand_electricity.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_electricity.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_electricity]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_electricity]
 - graph_methods = [demand]
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/agriculture/agriculture_final_demand_hydrogen.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_hydrogen.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - hydrogen.profile = agriculture
 - hydrogen.type = consumer

--- a/nodes/agriculture/agriculture_final_demand_network_gas.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_network_gas.final_demand.ad
@@ -1,9 +1,9 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand =
-    EB("agriculture/forestry", natural_gas) + 
+    EB("agriculture/forestry", natural_gas) +
     EB("agriculture/forestry", biogases)

--- a/nodes/agriculture/agriculture_final_demand_steam_hot_water.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_steam_hot_water.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, application_group]
+- groups = [final_demand_group, co2_emissions_primary, application_group]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/agriculture/agriculture_final_demand_wood_pellets.final_demand.ad
+++ b/nodes/agriculture/agriculture_final_demand_wood_pellets.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/buildings/buildings_final_demand_coal.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_coal.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/buildings/buildings_final_demand_crude_oil.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_crude_oil.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/buildings/buildings_final_demand_electricity.ad
+++ b/nodes/buildings/buildings_final_demand_electricity.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_electricity]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_electricity]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/buildings/buildings_final_demand_network_gas.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_network_gas.final_demand.ad
@@ -1,9 +1,9 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand =
-    EB(commercial_and_public_services, natural_gas) + 
+    EB(commercial_and_public_services, natural_gas) +
     EB(commercial_and_public_services, biogases)

--- a/nodes/buildings/buildings_final_demand_solar_thermal.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_solar_thermal.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/buildings/buildings_final_demand_steam_hot_water.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_steam_hot_water.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/buildings/buildings_final_demand_wood_pellets.final_demand.ad
+++ b/nodes/buildings/buildings_final_demand_wood_pellets.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/bunkers/bunkers_final_demand_bio_kerosene.ad
+++ b/nodes/bunkers/bunkers_final_demand_bio_kerosene.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0

--- a/nodes/bunkers/bunkers_final_demand_electricity.ad
+++ b/nodes/bunkers/bunkers_final_demand_electricity.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0
 - merit_order.group = flat
 - merit_order.type = consumer

--- a/nodes/bunkers/bunkers_final_demand_heavy_fuel_oil.ad
+++ b/nodes/bunkers/bunkers_final_demand_heavy_fuel_oil.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0

--- a/nodes/bunkers/bunkers_final_demand_heavy_fuel_oil.ad
+++ b/nodes/bunkers/bunkers_final_demand_heavy_fuel_oil.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, co2_emissions_primary]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - free_co2_factor = 0.0

--- a/nodes/bunkers/bunkers_final_demand_kerosene.ad
+++ b/nodes/bunkers/bunkers_final_demand_kerosene.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0

--- a/nodes/bunkers/bunkers_final_demand_kerosene.ad
+++ b/nodes/bunkers/bunkers_final_demand_kerosene.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, co2_emissions_primary]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - free_co2_factor = 0.0

--- a/nodes/bunkers/bunkers_final_demand_lng.ad
+++ b/nodes/bunkers/bunkers_final_demand_lng.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0

--- a/nodes/bunkers/bunkers_final_demand_network_gas.ad
+++ b/nodes/bunkers/bunkers_final_demand_network_gas.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_cokesoven_consumption_coal_gas.converter.ad
+++ b/nodes/energy/energy_cokesoven_consumption_coal_gas.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = energy sector own use
 - output.coupling_carrier = 1.0
 - output.loss = elastic
-- groups = [final_demand_group, metal, application_group, mv_net_demand]
+- groups = [final_demand_group, co2_emissions_primary, metal, application_group, mv_net_demand]
 - merit_order.group = flat
 - merit_order.type = consumer
 - merit_order.level = hv

--- a/nodes/energy/energy_heat_network_unused_steam_hot_water.ad
+++ b/nodes/energy/energy_heat_network_unused_steam_hot_water.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = unused and dumped heat
-- groups = [final_demand_group, application_group]
+- groups = [final_demand_group, co2_emissions_primary, application_group]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
+++ b/nodes/energy/energy_power_sector_own_use_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - energy_balance_group = energy sector own use
 - output.loss = elastic
-- groups = [final_demand_group, preset_demand, application_group]
+- groups = [final_demand_group, co2_emissions_primary, preset_demand, application_group]
 - merit_order.group = flat
 - merit_order.type = consumer
 - merit_order.level = hv

--- a/nodes/households/households_final_demand_coal.final_demand.ad
+++ b/nodes/households/households_final_demand_coal.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/households/households_final_demand_crude_oil.final_demand.ad
+++ b/nodes/households/households_final_demand_crude_oil.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/households/households_final_demand_electricity.final_demand.ad
+++ b/nodes/households/households_final_demand_electricity.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_electricity]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_electricity]
 - graph_methods = [demand]
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/households/households_final_demand_hydrogen.final_demand.ad
+++ b/nodes/households/households_final_demand_hydrogen.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_hydrogen]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_hydrogen]
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/households/households_final_demand_network_gas.final_demand.ad
+++ b/nodes/households/households_final_demand_network_gas.final_demand.ad
@@ -1,9 +1,9 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand =
-    EB("residential", natural_gas) + 
+    EB("residential", natural_gas) +
     EB("residential", biogases)

--- a/nodes/households/households_final_demand_solar_thermal.final_demand.ad
+++ b/nodes/households/households_final_demand_solar_thermal.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/households/households_final_demand_steam_hot_water.final_demand.ad
+++ b/nodes/households/households_final_demand_steam_hot_water.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/households/households_final_demand_wood_pellets.final_demand.ad
+++ b/nodes/households/households_final_demand_wood_pellets.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/industry/industry_final_demand_coal.final_demand.ad
+++ b/nodes/industry/industry_final_demand_coal.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/industry/industry_final_demand_coal_gas.ad
+++ b/nodes/industry/industry_final_demand_coal_gas.ad
@@ -1,4 +1,4 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, metal_industry]
+- groups = [final_demand_group, co2_emissions_primary, metal_industry]
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_final_demand_coal_non_energetic.final_demand.ad
+++ b/nodes/industry/industry_final_demand_coal_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use]
+- groups = [final_demand_group, co2_emissions_primary, non_energetic_use]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 

--- a/nodes/industry/industry_final_demand_crude_oil.final_demand.ad
+++ b/nodes/industry/industry_final_demand_crude_oil.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/industry/industry_final_demand_electricity.final_demand.ad
+++ b/nodes/industry/industry_final_demand_electricity.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_electricity]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_electricity]
 - graph_methods = [demand]
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_final_demand_for_other_ict_electricity.ad
+++ b/nodes/industry/industry_final_demand_for_other_ict_electricity.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, final_demand_electricity, other_industry, ict_industry]
+- groups = [final_demand_group, co2_emissions_primary, final_demand_electricity, other_industry, ict_industry]
 - free_co2_factor = 0.0
 - merit_order.group = industry_other
 - merit_order.type = consumer

--- a/nodes/industry/industry_final_demand_hydrogen.final_demand.ad
+++ b/nodes/industry/industry_final_demand_hydrogen.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - hydrogen.profile = industry_heat
 - hydrogen.type = consumer
 - free_co2_factor = 0.0

--- a/nodes/industry/industry_final_demand_network_gas.final_demand.ad
+++ b/nodes/industry/industry_final_demand_network_gas.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/industry/industry_final_demand_network_gas_non_energetic.final_demand.ad
+++ b/nodes/industry/industry_final_demand_network_gas_non_energetic.final_demand.ad
@@ -5,5 +5,5 @@
 - free_co2_factor = 1.0
 
 ~ demand =
-    EB("non-energy use industry/transformation/energy", natural_gas) + 
+    EB("non-energy use industry/transformation/energy", natural_gas) +
     EB("non-energy use industry/transformation/energy", biogases)

--- a/nodes/industry/industry_final_demand_steam_hot_water.final_demand.ad
+++ b/nodes/industry/industry_final_demand_steam_hot_water.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/industry/industry_final_demand_wood_pellets.final_demand.ad
+++ b/nodes/industry/industry_final_demand_wood_pellets.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/industry/industry_own_use_coal.converter.ad
+++ b/nodes/industry/industry_own_use_coal.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - energy_balance_group = energy sector own use
 - output.loss = elastic
-- groups = [preset_demand, final_demand_group]
+- groups = [preset_demand, final_demand_group, co2_emissions_primary]
 - free_co2_factor = 0.0

--- a/nodes/other/other_final_demand_coal.final_demand.ad
+++ b/nodes/other/other_final_demand_coal.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/other/other_final_demand_crude_oil.final_demand.ad
+++ b/nodes/other/other_final_demand_crude_oil.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/other/other_final_demand_electricity.final_demand.ad
+++ b/nodes/other/other_final_demand_electricity.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_electricity]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_electricity]
 - graph_methods = [demand]
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/other/other_final_demand_network_gas.final_demand.ad
+++ b/nodes/other/other_final_demand_network_gas.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/other/other_final_demand_steam_hot_water.final_demand.ad
+++ b/nodes/other/other_final_demand_steam_hot_water.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/other/other_final_demand_wood_pellets.final_demand.ad
+++ b/nodes/other/other_final_demand_wood_pellets.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_bio_ethanol.final_demand.ad
+++ b/nodes/transport/transport_final_demand_bio_ethanol.final_demand.ad
@@ -1,10 +1,10 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand =
-    EB("transport", biogasoline) - 
-    EB("non-specified (transport)", biogasoline) - 
+    EB("transport", biogasoline) -
+    EB("non-specified (transport)", biogasoline) -
     EB("pipeline transport", biogasoline)

--- a/nodes/transport/transport_final_demand_bio_lng.final_demand.ad
+++ b/nodes/transport/transport_final_demand_bio_lng.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_biodiesel.final_demand.ad
+++ b/nodes/transport/transport_final_demand_biodiesel.final_demand.ad
@@ -1,16 +1,16 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand =
-    EB("transport", biodiesels) - 
-    EB("non-specified (transport)", biodiesels) - 
-    EB("pipeline transport", biodiesels) + 
+    EB("transport", biodiesels) -
+    EB("non-specified (transport)", biodiesels) -
+    EB("pipeline transport", biodiesels) +
     EB("transport", other_liquid_biofuels) -
-    EB("non-specified (transport)", biodiesels) - 
-    EB("pipeline transport", biodiesels) + 
+    EB("non-specified (transport)", biodiesels) -
+    EB("pipeline transport", biodiesels) +
     EB("transport", "non-specified primary biofuels and waste") -
-    EB("non-specified (transport)", biodiesels) - 
+    EB("non-specified (transport)", biodiesels) -
     EB("pipeline transport", biodiesels)

--- a/nodes/transport/transport_final_demand_coal.final_demand.ad
+++ b/nodes/transport/transport_final_demand_coal.final_demand.ad
@@ -1,40 +1,40 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand =
     EB("transport", "hard_coal_(if_no_detail)") -
-    EB("non-specified (transport)", "hard_coal_(if_no_detail)") - 
-    EB("pipeline transport", "hard_coal_(if_no_detail)") + 
+    EB("non-specified (transport)", "hard_coal_(if_no_detail)") -
+    EB("pipeline transport", "hard_coal_(if_no_detail)") +
     EB("transport", "brown_coal_(if_no_detail)") -
-    EB("non-specified (transport)", "brown_coal_(if_no_detail)") - 
-    EB("pipeline transport", "brown_coal_(if_no_detail)") + 
+    EB("non-specified (transport)", "brown_coal_(if_no_detail)") -
+    EB("pipeline transport", "brown_coal_(if_no_detail)") +
     EB("transport", anthracite) -
-    EB("non-specified (transport)", anthracite) - 
-    EB("pipeline transport", anthracite) + 
+    EB("non-specified (transport)", anthracite) -
+    EB("pipeline transport", anthracite) +
     EB("transport", coking_coal) -
-    EB("non-specified (transport)", coking_coal) - 
-    EB("pipeline transport", coking_coal) + 
+    EB("non-specified (transport)", coking_coal) -
+    EB("pipeline transport", coking_coal) +
     EB("transport", other_bituminous_coal) -
-    EB("non-specified (transport)", other_bituminous_coal) - 
-    EB("pipeline transport", other_bituminous_coal) + 
+    EB("non-specified (transport)", other_bituminous_coal) -
+    EB("pipeline transport", other_bituminous_coal) +
     EB("transport", sub_bituminous_coal) -
-    EB("non-specified (transport)", sub_bituminous_coal) - 
-    EB("pipeline transport", sub_bituminous_coal) + 
+    EB("non-specified (transport)", sub_bituminous_coal) -
+    EB("pipeline transport", sub_bituminous_coal) +
     EB("transport", lignite) -
-    EB("non-specified (transport)", lignite) - 
-    EB("pipeline transport", lignite) + 
+    EB("non-specified (transport)", lignite) -
+    EB("pipeline transport", lignite) +
     EB("transport", patent_fuel) -
-    EB("non-specified (transport)", patent_fuel) - 
-    EB("pipeline transport", patent_fuel) + 
+    EB("non-specified (transport)", patent_fuel) -
+    EB("pipeline transport", patent_fuel) +
     EB("transport", coke_oven_coke) -
-    EB("non-specified (transport)", coke_oven_coke) - 
-    EB("pipeline transport", coke_oven_coke) + 
+    EB("non-specified (transport)", coke_oven_coke) -
+    EB("pipeline transport", coke_oven_coke) +
     EB("transport", gas_coke) -
-    EB("non-specified (transport)", lignite) - 
-    EB("pipeline transport", lignite) + 
+    EB("non-specified (transport)", lignite) -
+    EB("pipeline transport", lignite) +
     EB("transport", coal_tar) -
     EB("non-specified (transport)", coal_tar) -
     EB("pipeline transport", coal_tar) +

--- a/nodes/transport/transport_final_demand_compressed_network_gas.final_demand.ad
+++ b/nodes/transport/transport_final_demand_compressed_network_gas.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_diesel.final_demand.ad
+++ b/nodes/transport/transport_final_demand_diesel.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_diesel.final_demand.ad
+++ b/nodes/transport/transport_final_demand_diesel.final_demand.ad
@@ -5,6 +5,6 @@
 - free_co2_factor = 0.0
 
 ~ demand =
-    EB("transport", "gas/diesel_oil") - 
-    EB("non-specified (transport)", "gas/diesel_oil") - 
+    EB("transport", "gas/diesel_oil") -
+    EB("non-specified (transport)", "gas/diesel_oil") -
     EB("pipeline transport", "gas/diesel_oil")

--- a/nodes/transport/transport_final_demand_electricity.final_demand.ad
+++ b/nodes/transport/transport_final_demand_electricity.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [cost_other, final_demand_group, final_demand_electricity]
+- groups = [cost_other, final_demand_group, co2_emissions_primary, final_demand_electricity]
 - graph_methods = [demand]
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/nodes/transport/transport_final_demand_gasoline.final_demand.ad
+++ b/nodes/transport/transport_final_demand_gasoline.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_gasoline.final_demand.ad
+++ b/nodes/transport/transport_final_demand_gasoline.final_demand.ad
@@ -6,11 +6,11 @@
 
 ~ demand =
     EB("transport", motor_gasoline) -
-    EB("non-specified (transport)", motor_gasoline) - 
+    EB("non-specified (transport)", motor_gasoline) -
     EB("pipeline transport", motor_gasoline) +
     EB("transport", aviation_gasoline) -
-    EB("non-specified (transport)", aviation_gasoline) - 
+    EB("non-specified (transport)", aviation_gasoline) -
     EB("pipeline transport", motor_gasoline) +
     EB("transport", gasoline_type_jet_fuel) -
-    EB("non-specified (transport)", motor_gasoline) - 
+    EB("non-specified (transport)", motor_gasoline) -
     EB("pipeline transport", motor_gasoline)

--- a/nodes/transport/transport_final_demand_heavy_fuel_oil.final_demand.ad
+++ b/nodes/transport/transport_final_demand_heavy_fuel_oil.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_heavy_fuel_oil.final_demand.ad
+++ b/nodes/transport/transport_final_demand_heavy_fuel_oil.final_demand.ad
@@ -6,5 +6,5 @@
 
 ~ demand =
     EB("transport", fuel_oil) -
-    EB("non-specified (transport)", fuel_oil) - 
+    EB("non-specified (transport)", fuel_oil) -
     EB("pipeline transport", fuel_oil)

--- a/nodes/transport/transport_final_demand_hydrogen.final_demand.ad
+++ b/nodes/transport/transport_final_demand_hydrogen.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - hydrogen.profile = electric_vehicle_profile_3
 - hydrogen.type = consumer
 - graph_methods = [demand]

--- a/nodes/transport/transport_final_demand_kerosene.final_demand.ad
+++ b/nodes/transport/transport_final_demand_kerosene.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_kerosene.final_demand.ad
+++ b/nodes/transport/transport_final_demand_kerosene.final_demand.ad
@@ -6,8 +6,8 @@
 
 ~ demand =
     EB("transport", kerosene_type_jet_fuel) -
-    EB("non-specified (transport)", kerosene_type_jet_fuel) - 
+    EB("non-specified (transport)", kerosene_type_jet_fuel) -
     EB("pipeline transport", kerosene_type_jet_fuel) +
     EB("transport", other_kerosene) -
-    EB("non-specified (transport)", other_kerosene) - 
+    EB("non-specified (transport)", other_kerosene) -
     EB("pipeline transport", other_kerosene)

--- a/nodes/transport/transport_final_demand_lng.final_demand.ad
+++ b/nodes/transport/transport_final_demand_lng.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 

--- a/nodes/transport/transport_final_demand_lpg.final_demand.ad
+++ b/nodes/transport/transport_final_demand_lpg.final_demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group]
+- groups = [final_demand_group, co2_emissions_refinery_products]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 


### PR DESCRIPTION
This PR includes two things:
- Update of CO2 emissions factors, some are specific to NL2015, some are general
- Fix of Refinery double counting problem (see below)

**Refinery double counting**
CO2 of final demand of Refineries (electricity, heat etc. used to make refinery products) is currently (partially) double-counted:
- It is included in final demand of industry
- It is included in the primary demand of refinery products (diesel, gasoline, lpg etc.). E.g. primary demand of gasoline in transport includes final demand of Refineries
Because of this, around 30% of final demand of Refineries is double-counted in NL2015, since 30% of Refinery products is used domestically.

**Fix**
Two new groups have been introduced: ``co2_emissions_primary`` and ``co2_emissions_refinery_products``. The former has been added to all 'regular' final demand nodes (nodes that don't use refinery products). For these nodes, CO2 emissions are calculated using the regular ``primary_co2_emission`` method. The final demand nodes using refinery products have been added to the ``co2_emissions_refinery_products`` group. For these nodes CO2 emissions are not based on primary demand but are 'on the spot' emissions (based on the emissions factors of refinery products). This is calculated by multiplying the demand of these nodes with their ``weighted_carrier_co2_per_mj``.

Nodes included in ``co2_emissions_refinery_products`` are:
- Transport final demand diesel, gasoline, lpg, kerosene and HFO
- Bunkers final demand kerosene and HFO

**Debts**
The node ``energy_power_engine_diesel`` uses diesel, a refinery product. This means that the primary demand of electricity includes a part of the final demand of the Refinery sector. Since the latter is already included in the CO2 calculation, this leads to double-counting. However, as @AlexanderWirtz pointed out this effect is small as diesel engines aren't used much. We have 3 options here:
- Document issue and leave it for now
- Investigate whether ``energy_power_engine_diesel`` can make use of imported diesel only
- Investigate whether ``energy_power_engine_diesel`` can be removed/merged in the crude oil burner
