### PR TITLE
Fixing errors in sankey gqueries

### DIFF
--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_central_heat_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_central_heat_prod_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between biomass_products and chps
 
 - unit = PJ
-- query = DIVIDE(SUM(V(Q(heat_producing_converters_sankey), primary_demand_of(non_biogenic_waste, greengas , biodiesel , bio_ethanol , bio_lng , bio_oil , biogas , torrefied_biomass_pellets , wood_pellets , corn , manure , wood , biogenic_waste , woody_biomass))),BILLIONS)
+- query = DIVIDE(SUM(V(Q(central_heat_producing_converters_sankey), primary_demand_of(non_biogenic_waste, greengas , biodiesel , bio_ethanol , bio_lng , bio_oil , biogas , torrefied_biomass_pellets , wood_pellets , corn , manure , wood , biogenic_waste , woody_biomass))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/geo_ambient_to_central_heat_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/geo_ambient_to_central_heat_prod_in_sankey.gql
@@ -4,8 +4,8 @@
 - query =
     DIVIDE(
         SUM(
-            V(Q(central_heat_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, primary_demand_of(electricity)),
-            V(Q(central_heat_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, primary_demand_of(electricity)),
-            V(Q(central_heat_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, primary_demand_of(electricity))
+            V(Q(central_heat_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold"),
+            V(Q(central_heat_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold"),
+            V(Q(central_heat_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold")
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/geo_ambient_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/geo_ambient_to_electricity_prod_in_sankey.gql
@@ -4,8 +4,8 @@
 - query =
     DIVIDE(
         SUM(
-            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, primary_demand_of(electricity)),
-            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, primary_demand_of(electricity)),
-            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, primary_demand_of(electricity))
+            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold"),
+            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold"),
+            V(Q(electricity_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold")
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/geo_ambient_to_hydrogen_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/geo_ambient_to_hydrogen_prod_in_sankey.gql
@@ -4,8 +4,8 @@
 - query =
     DIVIDE(
         SUM(
-            V(Q(hydrogen_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, primary_demand_of(electricity)),
-            V(Q(hydrogen_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, primary_demand_of(electricity)),
-            V(Q(hydrogen_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, primary_demand_of(electricity))
+            V(Q(hydrogen_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.geothermal? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold"),
+            V(Q(hydrogen_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_heat? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold"),
+            V(Q(hydrogen_producing_converters_sankey).select {|node| node.input_slots.detect { |slot| slot.carrier.ambient_cold? }}, "input_of_geothermal + input_of_ambient_heat + input_of_ambient_cold")
         ),
     BILLIONS)


### PR DESCRIPTION
@MartLubben found out that central biomass heaters and geothermal heaters are not displayed in the Sankey. I am not sure if this commit fixes those errors. Geothermal energy is not considered as primary energy, so maybe instead of the geothermal energy (which is now shown in the Sankey with this commit), the produced hydrogen/electricity/heat should be shown as input of the 'central heat'-block. Let me know what you think @michieldenhaan !