### PR TITLE
fix queries for "sources of electricity in buildings" chart

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_74_source_of_electricity_in_buildings/centrally_produced_in_source_of_electricity_in_buildings.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_74_source_of_electricity_in_buildings/centrally_produced_in_source_of_electricity_in_buildings.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = DIVIDE(V(buildings_local_production_electricity,electricity_flexible_input_link_value),BILLIONS)
+- query = DIVIDE(V(buildings_local_production_electricity,electricity_flexible_input_link_value),BILLIONS) * V(LINK(buildings_local_production_electricity, buildings_final_demand_electricity), parent_share)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_74_source_of_electricity_in_buildings/chps_in_source_of_electricity_in_buildings.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_74_source_of_electricity_in_buildings/chps_in_source_of_electricity_in_buildings.gql
@@ -8,4 +8,4 @@
           buildings_collective_chp_wood_pellets, output_of_electricity
         )
       ),BILLIONS
-    )
+    ) * V(LINK(buildings_local_production_electricity, buildings_final_demand_electricity), parent_share)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_74_source_of_electricity_in_buildings/solar_panels_in_source_of_electricity_in_buildings.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_74_source_of_electricity_in_buildings/solar_panels_in_source_of_electricity_in_buildings.gql
@@ -1,2 +1,2 @@
 - unit = PJ
-- query = DIVIDE(SUM(V(buildings_solar_pv_solar_radiation,output_of_electricity)),BILLIONS)
+- query = DIVIDE(SUM(V(buildings_solar_pv_solar_radiation,output_of_electricity)),BILLIONS) * V(LINK(buildings_local_production_electricity, buildings_final_demand_electricity), parent_share)


### PR DESCRIPTION
The electricity supply queries included electricity supplied to ICT sector whereas the demand queries only included buildings. Changed supply queries to only show electricity supplied to buildings sector (ex ICT)