### PR TITLE
Insulation costs added as explicit category to cost chart

### DIFF
--- a/gqueries/general/costs/costs_of_insulation.gql
+++ b/gqueries/general/costs/costs_of_insulation.gql
@@ -3,15 +3,16 @@
 - query =
     DIVIDE(
       SUM(
-      Q(costs_of_insulation_corner_houses),
-      Q(costs_of_insulation_detached_houses),
-      Q(costs_of_insulation_semi_detached_houses),
-      Q(costs_of_insulation_terraced_houses),
-      Q(costs_of_insulation_apartments)
+        Q(costs_of_insulation_corner_houses),
+        Q(costs_of_insulation_detached_houses),
+        Q(costs_of_insulation_semi_detached_houses),
+        Q(costs_of_insulation_terraced_houses),
+        Q(costs_of_insulation_apartments)
       ),
       V(households_space_heating_savings_from_insulation,technical_lifetime)
-      )
-    + DIVIDE(
+    )
+    +
+    DIVIDE(
       Q(costs_of_insulation_buildings),
       V(buildings_heating_savings_from_insulation_useable_heat, technical_lifetime)
     )

--- a/gqueries/general/costs/costs_of_produced_heat.gql
+++ b/gqueries/general/costs/costs_of_produced_heat.gql
@@ -1,5 +1,5 @@
-# Total costs of traditional heat and heat pumps.
-# Also insulation costs and imported heat costs are included.
+# Total yearly costs of traditional heat and heat pumps.
+# Also imported heat costs are included.
 # A correction has been implemented for the double counting of technologies
 # in cooling and heating of households
 # (see https://github.com/quintel/etsource/issues/225)
@@ -11,7 +11,6 @@
         G(cost_heat_pumps),
         total_costs_per(:converter)
       ),
-      Q(costs_of_insulation),
       Q(costs_of_imported_heat),
       Q(dashboard_total_cost_correction),
       Q(hydrogen_heat_correction)

--- a/gqueries/general/costs/total_costs.gql
+++ b/gqueries/general/costs/total_costs.gql
@@ -1,8 +1,9 @@
-# Sums up the costs. Only for the Netherlands the netwerk costs are included.
+# Sums up the costs. Only for the Netherlands the network costs are included.
 
 - query =
     SUM(
-        Q(costs_of_produced_heat_plus_insulation),
+        Q(costs_of_produced_heat),
+        Q(costs_of_insulation),
         Q(costs_of_used_electricity),
         Q(costs_of_used_hydrogen),
         Q(costs_of_transport_fuels),

--- a/gqueries/output_elements/dashboard/dashboard_total_cost_correction.gql
+++ b/gqueries/output_elements/dashboard/dashboard_total_cost_correction.gql
@@ -1,6 +1,6 @@
 # Correction for the fact that heating and cooling technologies are counted double.
 # First all double technologies are subtracted to remove them from the
-# 'costs_of_produced_heat_plus_insulation' query which looks like this:
+# 'costs_of_produced_heat' query which looks like this:
 #
 #- query =
 #   SUM(
@@ -9,7 +9,6 @@
 #       G(cost_heat_pumps),
 #       total_costs_per(:converter)
 #     ),
-#     Q(costs_of_insulation),
 #     Q(costs_of_imported_heat),
 #     Q(dashboard_total_cost_correction),
 #     Q(hydrogen_heat_correction)

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/heat_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/heat_in_breakdown_of_total_costs.gql
@@ -1,2 +1,2 @@
-- query = Q(costs_of_produced_heat_plus_insulation)
+- query = Q(costs_of_produced_heat)
 - unit = euro

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/insulation_in_breakdown_of_total_costs.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_48_breakdown_total_costs/insulation_in_breakdown_of_total_costs.gql
@@ -1,0 +1,2 @@
+- query = Q(costs_of_insulation)
+- unit = euro


### PR DESCRIPTION
Fixes https://github.com/quintel/etmodel/issues/3025
- split old query `costs_of_produced_heat_plus_insulation` into `costs_of_produced_heat` and `costs_of_insulation`
- updated `total_costs` query
- add new query for insulation to total costs chart
- updated minor things in other costs queries

Tested it locally and worked fine :) 
![Screen Shot 2019-06-13 at 14 25 15](https://user-images.githubusercontent.com/32833996/59432220-19b89600-8de7-11e9-8f69-74691489146c.png)
