### PR TITLE
Fix green gas/natural gas distinction in Sankey

### DIFF
--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_agriculture_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_agriculture_in_sankey.gql
@@ -4,7 +4,8 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(agriculture),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)
 

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_buildings_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_buildings_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(buildings),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(buildings),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(buildings),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_bunkers_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_bunkers_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(bunkers),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(bunkers),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(bunkers),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_energy_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_energy_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_export_in_sankey.gql
@@ -1,4 +1,10 @@
 # Query for Sankey diagram: connection between coal_and_derivatives and export
 
 - unit = PJ
-- query = DIVIDE(SUM(V(G(energy_export), "input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")),BILLIONS)
+- query =
+    DIVIDE(
+      SUM(
+        V(G(energy_export), "input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+        (V(G(energy_export), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
+        ),
+        BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_feedstock_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_feedstock_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(G(final_demand_group),USE(non_energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(G(final_demand_group),USE(non_energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(G(final_demand_group),USE(non_energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_households_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_households_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(households),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(households),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(households),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_industry_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_industry_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(industry),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(industry),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(industry),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_other_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_other_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(other),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(other),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(other),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_transport_in_sankey.gql
@@ -4,6 +4,7 @@
 - query =
     DIVIDE(
         SUM(
-            V(INTERSECTION(INTERSECTION(SECTOR(transport),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass")
+            V(INTERSECTION(INTERSECTION(SECTOR(transport),G(final_demand_group)),USE(energetic)),"input_of_non_biogenic_waste + input_of_greengas + input_of_biodiesel + input_of_bio_ethanol + input_of_bio_lng + input_of_bio_oil + input_of_biogas + input_of_torrefied_biomass_pellets + input_of_wood_pellets + input_of_corn + input_of_manure + input_of_wood + input_of_biogenic_waste + input_of_woody_biomass"),
+            (V(INTERSECTION(INTERSECTION(SECTOR(transport),G(final_demand_group)),USE(energetic)), input_of(network_gas, compressed_network_gas)) * Q(share_of_greengas_in_gas_network))
         ),
     BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/biomass_products_to_transport_losses_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/biomass_products_to_transport_losses_in_sankey.gql
@@ -17,5 +17,7 @@
           energy_distribution_non_biogenic_waste,
           energy_distribution_biogenic_waste,
           energy_distribution_bio_lng,
-          output_of_loss))
+          output_of_loss),
+          (V(energy_national_gas_network_natural_gas, output_of_loss) * Q(share_of_greengas_in_gas_network))
+          )
           ,BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_agriculture_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_agriculture_in_sankey.gql
@@ -1,5 +1,5 @@
 # Query for Sankey diagram: connection between natural_gas and agriculture
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(agriculture),G(final_demand_group)), USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(agriculture),G(final_demand_group)), USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))
 

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_buildings_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_buildings_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between natural_gas and buildings
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(buildings),G(final_demand_group)), USE(energetic)), "input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(buildings),G(final_demand_group)), USE(energetic)), "input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_central_heat_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_central_heat_prod_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between natural_gas and chps
 
 - unit = PJ
-- query = DIVIDE(SUM(V(Q(central_heat_producing_converters_sankey), primary_demand_of(natural_gas , lng , compressed_network_gas , gas_power_fuelmix , network_gas))),BILLIONS)
+- query = DIVIDE(SUM(V(Q(central_heat_producing_converters_sankey), primary_demand_of(natural_gas , lng , compressed_network_gas , gas_power_fuelmix))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_electricity_prod_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between natural_gas and electricity
 
 - unit = PJ
-- query = DIVIDE(SUM(V(Q(electricity_producing_converters_sankey), primary_demand_of(natural_gas , lng , compressed_network_gas , gas_power_fuelmix , network_gas))),BILLIONS)
+- query = DIVIDE(SUM(V(Q(electricity_producing_converters_sankey), primary_demand_of(natural_gas , lng , compressed_network_gas , gas_power_fuelmix))),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_energy_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_energy_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between natural_gas and energy
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)), USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)), USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_export_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_export_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between coal_and_derivatives and export
 
 - unit = PJ
-- query = DIVIDE(SUM(V(G(energy_export), "input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS)
+- query = DIVIDE(SUM(V(G(energy_export), "input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_feedstock_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_feedstock_in_sankey.gql
@@ -6,4 +6,4 @@
         SUM(
             V(INTERSECTION(G(final_demand_group),USE(non_energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")
         ),
-    BILLIONS)
+    BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_households_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_households_in_sankey.gql
@@ -1,4 +1,4 @@
 # Query for Sankey diagram: connection between natural_gas and households
 
 - unit = PJ
-- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(households),G(final_demand_group)), USE(energetic)), "input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS)
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(households),G(final_demand_group)), USE(energetic)), "input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")),BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_industry_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_industry_in_sankey.gql
@@ -6,4 +6,4 @@
         SUM(
             V(INTERSECTION(INTERSECTION(SECTOR(industry),G(final_demand_group)),USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")
         ),
-    BILLIONS)
+    BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_other_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_other_in_sankey.gql
@@ -6,4 +6,4 @@
         SUM(
             V(INTERSECTION(INTERSECTION(SECTOR(other),G(final_demand_group)),USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")
         ),
-    BILLIONS)
+    BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_transport_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_transport_in_sankey.gql
@@ -6,4 +6,4 @@
         SUM(
             V(INTERSECTION(INTERSECTION(SECTOR(transport),G(final_demand_group)),USE(energetic)),"input_of_natural_gas + input_of_lng + input_of_compressed_network_gas + input_of_gas_power_fuelmix + input_of_network_gas")
         ),
-    BILLIONS)
+    BILLIONS) * (1 - Q(share_of_greengas_in_gas_network))

--- a/gqueries/output_elements/output_series/sankey/natural_gas_to_transport_losses_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/natural_gas_to_transport_losses_in_sankey.gql
@@ -4,10 +4,8 @@
 - query =
     DIVIDE(
       SUM(
-        V(
-          energy_national_gas_network_natural_gas,
-          energy_distribution_lng,
-          energy_compressor_network_gas,
-          output_of_loss))
+        V(energy_regasification_lng, output_of_loss),
+        V(energy_compressor_network_gas, output_of_loss),
+        (V(energy_national_gas_network_natural_gas, output_of_loss) * (1 - Q(share_of_greengas_in_gas_network))))
           ,BILLIONS)
 


### PR DESCRIPTION
Fixes: https://github.com/quintel/etmodel/issues/3062

Sankey now looks as follows:

_100% natural gas in gas network_
![etmodel test - Energy Transition Model - Your free, independent, comprehensive, fact-based scenario builder  2019-06-24 11-52-02](https://user-images.githubusercontent.com/32056448/60010083-53a35b00-9677-11e9-815b-9ef3eb58a963.png)

_100% green gas in gas network_
![etmodel test - Energy Transition Model - Your free, independent, comprehensive, fact-based scenario builder  2019-06-24 11-52-19](https://user-images.githubusercontent.com/32056448/60010096-5900a580-9677-11e9-92ea-c2d10ebda884.png)
