### PR TITLE
Price of imported electricity query uses curve

### DIFF
--- a/gqueries/input_elements/label/price_of_imported_electricity.gql
+++ b/gqueries/input_elements/label/price_of_imported_electricity.gql
@@ -1,8 +1,4 @@
 # Price of imported electricity in euro per mwh
 
-- query =
-    PRODUCT(
-     V(CARRIER(imported_electricity), cost_per_mj),
-     MJ_PER_MWH
-    )
+- query = AVG(V(CARRIER(imported_electricity), cost_curve))
 - unit = euro


### PR DESCRIPTION
Returns the average price of the cost curve, to be more useful in scenarios where the user has uploaded a custom curve instead of using the carrier constant.

* quintel/documentation#45
* quintel/etengine#1059
* quintel/etmodel#3070