### PR TITLE
Change min and max restrictions of number of residences input

### DIFF
--- a/inputs/demand/households/households_misc/households_number_of_residences.ad
+++ b/inputs/demand/households/households_misc/households_number_of_residences.ad
@@ -36,8 +36,8 @@
   )
 
 - priority = 0
-- max_value_gql = present:AREA(number_of_residences) * 2
-- min_value_gql = present:AREA(number_of_residences) * 0.5
+- max_value_gql = present:AREA(number_of_residences) * 4
+- min_value = 0.0
 - start_value_gql = present:AREA(number_of_residences)
 - step_value = 0.1
 - unit = #


### PR DESCRIPTION
I've changed the minimum and maximum restrictions of the `households_number_of_residences` input, respectively to `0.0` and `4 * original number of residences`. Usually, we do not really impose restrictions on our users. This makes it possible to create unrealistic scenarios (for example, by "destroying" all residences). Furthermore, I wasn't sure if doubling the number of residences would be a sufficient maximum for local regions that have huge (housing) development plans.