### PR TITLE
Updated slider max for electricity and heat plants

### DIFF
--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_ultra_supercritical_coal), 
-            number_of_units, 
+            V(energy_chp_ultra_supercritical_coal),
+            number_of_units,
             USER_INPUT() / V(energy_chp_ultra_supercritical_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_chp_ultra_supercritical_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_chp_ultra_supercritical_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_chp_ultra_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_chp_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_chp_ultra_supercritical_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_coal, output_of_electricity)*2), V(energy_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_ultra_supercritical_coal,number_of_units),V(energy_chp_ultra_supercritical_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_cofiring_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_ultra_supercritical_cofiring_coal), 
-            number_of_units, 
+            V(energy_chp_ultra_supercritical_cofiring_coal),
+            number_of_units,
             USER_INPUT() / V(energy_chp_ultra_supercritical_cofiring_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_chp_ultra_supercritical_cofiring_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_chp_ultra_supercritical_cofiring_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_chp_ultra_supercritical_cofiring_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_chp_ultra_supercritical_cofiring_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_chp_ultra_supercritical_cofiring_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_cofiring_coal, output_of_electricity)*2), V(energy_chp_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_ultra_supercritical_cofiring_coal,number_of_units),V(energy_chp_ultra_supercritical_cofiring_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_lignite.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_ultra_supercritical_lignite), 
-            number_of_units, 
+            V(energy_chp_ultra_supercritical_lignite),
+            number_of_units,
             USER_INPUT() / V(energy_chp_ultra_supercritical_lignite, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_chp_ultra_supercritical_lignite), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_chp_ultra_supercritical_lignite),
+        	preset_demand_by_electricity_production,
         	V(energy_chp_ultra_supercritical_lignite, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_chp_ultra_supercritical_lignite,maximum_yearly_electricity_production_per_unit)),2,V(energy_chp_ultra_supercritical_lignite, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_lignite, output_of_electricity)*2), V(energy_chp_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_ultra_supercritical_lignite,number_of_units),V(energy_chp_ultra_supercritical_lignite,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_ccs_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_ccs_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_combined_cycle_ccs_coal), 
-            number_of_units, 
+            V(energy_power_combined_cycle_ccs_coal),
+            number_of_units,
             USER_INPUT() / V(energy_power_combined_cycle_ccs_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_combined_cycle_ccs_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_combined_cycle_ccs_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_combined_cycle_ccs_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_combined_cycle_ccs_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_combined_cycle_ccs_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_ccs_coal, output_of_electricity)*2), V(energy_power_combined_cycle_ccs_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_combined_cycle_ccs_coal,number_of_units),V(energy_power_combined_cycle_ccs_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_combined_cycle_coal), 
-            number_of_units, 
+            V(energy_power_combined_cycle_coal),
+            number_of_units,
             USER_INPUT() / V(energy_power_combined_cycle_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_combined_cycle_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_combined_cycle_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_combined_cycle_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_combined_cycle_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_combined_cycle_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_coal, output_of_electricity)*2), V(energy_power_combined_cycle_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_combined_cycle_coal,number_of_units),V(energy_power_combined_cycle_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_supercritical_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_supercritical_coal), 
-            number_of_units, 
+            V(energy_power_supercritical_coal),
+            number_of_units,
             USER_INPUT() / V(energy_power_supercritical_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_supercritical_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_supercritical_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_supercritical_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_supercritical_coal, output_of_electricity)*2), V(energy_power_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_supercritical_coal ,number_of_units),V(energy_power_supercritical_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_ccs_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_ccs_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_ccs_coal), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_ccs_coal),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_ccs_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_ccs_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_ccs_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_ultra_supercritical_ccs_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_ccs_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_ccs_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_ccs_coal, output_of_electricity)*2), V(energy_power_ultra_supercritical_ccs_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_ccs_coal,number_of_units),V(energy_power_ultra_supercritical_ccs_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_coal), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_coal),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_ultra_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_coal, output_of_electricity)*2), V(energy_power_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_coal,number_of_units),V(energy_power_ultra_supercritical_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_cofiring_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_cofiring_coal), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_cofiring_coal),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_cofiring_coal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_cofiring_coal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_cofiring_coal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_ultra_supercritical_cofiring_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_cofiring_coal,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_cofiring_coal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_cofiring_coal, output_of_electricity)*2), V(energy_power_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_cofiring_coal,number_of_units),V(energy_power_ultra_supercritical_cofiring_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_lignite.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_lignite), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_lignite),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_lignite, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_lignite), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_lignite),
+        	preset_demand_by_electricity_production,
         	V(energy_power_ultra_supercritical_lignite, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_lignite,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_lignite, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_lignite, output_of_electricity)*2), V(energy_power_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_lignite,number_of_units),V(energy_power_ultra_supercritical_lignite,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_oxyfuel_ccs_lignite), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_oxyfuel_ccs_lignite),
+        	preset_demand_by_electricity_production,
         	V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite, output_of_electricity)*2), V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,number_of_units),V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_combined_cycle_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_combined_cycle_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_combined_cycle_network_gas), 
-            number_of_units, 
+            V(energy_chp_combined_cycle_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_chp_combined_cycle_network_gas,electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_chp_combined_cycle_network_gas), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_chp_combined_cycle_network_gas),
+        	preset_demand_by_electricity_production,
         	V(energy_chp_combined_cycle_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_chp_combined_cycle_network_gas,maximum_yearly_electricity_production_per_unit)),2,V(energy_chp_combined_cycle_network_gas,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_combined_cycle_network_gas, output_of_electricity)*2), V(energy_chp_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_combined_cycle_network_gas,number_of_units),V(energy_chp_combined_cycle_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_ccs_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_ccs_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_combined_cycle_ccs_network_gas), 
-            number_of_units, 
+            V(energy_power_combined_cycle_ccs_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_power_combined_cycle_ccs_network_gas,electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_combined_cycle_ccs_network_gas), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_combined_cycle_ccs_network_gas),
+        	preset_demand_by_electricity_production,
         	V(energy_power_combined_cycle_ccs_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_combined_cycle_ccs_network_gas,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_combined_cycle_ccs_network_gas,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_ccs_network_gas, output_of_electricity)*2), V(energy_power_combined_cycle_ccs_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_combined_cycle_ccs_network_gas,number_of_units),V(energy_power_combined_cycle_ccs_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_combined_cycle_network_gas), 
-            number_of_units, 
+            V(energy_power_combined_cycle_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_power_combined_cycle_network_gas,electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_combined_cycle_network_gas), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_combined_cycle_network_gas),
+        	preset_demand_by_electricity_production,
         	V(energy_power_combined_cycle_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_combined_cycle_network_gas,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_combined_cycle_network_gas,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_network_gas, output_of_electricity)*2), V(energy_power_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_combined_cycle_network_gas,number_of_units),V(energy_power_combined_cycle_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_engine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_engine_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_engine_network_gas), 
-            number_of_units, 
+            V(energy_power_engine_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_power_engine_network_gas,electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_engine_network_gas), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_engine_network_gas),
+        	preset_demand_by_electricity_production,
         	V(energy_power_engine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_engine_network_gas,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_engine_network_gas,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_engine_network_gas, output_of_electricity)*2), V(energy_power_engine_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_engine_network_gas,number_of_units),V(energy_power_engine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_turbine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_turbine_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_turbine_network_gas), 
-            number_of_units, 
+            V(energy_power_turbine_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_power_turbine_network_gas,electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_turbine_network_gas), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_turbine_network_gas),
+        	preset_demand_by_electricity_production,
         	V(energy_power_turbine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_turbine_network_gas,typical_electricity_production_per_unit)),2,V(energy_power_turbine_network_gas,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_turbine_network_gas, output_of_electricity)*2), V(energy_power_turbine_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_turbine_network_gas,number_of_units),V(energy_power_turbine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_ultra_supercritical_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_ultra_supercritical_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_network_gas), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_network_gas, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_network_gas), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_network_gas),
+        	preset_demand_by_electricity_production,
         	V(energy_power_ultra_supercritical_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_network_gas,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_network_gas,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_network_gas, output_of_electricity)*2), V(energy_power_ultra_supercritical_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_network_gas,number_of_units),V(energy_power_ultra_supercritical_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen2_uranium_oxide.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_nuclear_gen2_uranium_oxide), 
-            number_of_units, 
+            V(energy_power_nuclear_gen2_uranium_oxide),
+            number_of_units,
             USER_INPUT() / V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_nuclear_gen2_uranium_oxide), 
-     		preset_demand_by_electricity_production, 
+        	L(energy_power_nuclear_gen2_uranium_oxide),
+     		preset_demand_by_electricity_production,
       		V(energy_power_nuclear_gen2_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_nuclear_gen3_uranium_oxide,maximum_yearly_electricity_production_per_unit)),V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_capacity),2))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_nuclear_gen2_uranium_oxide, output_of_electricity)*2), V(energy_power_nuclear_gen2_uranium_oxide,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_gen2_uranium_oxide,number_of_units),V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen3_uranium_oxide.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            L(energy_power_nuclear_gen3_uranium_oxide), 
-            number_of_units, 
+            L(energy_power_nuclear_gen3_uranium_oxide),
+            number_of_units,
             USER_INPUT() / V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_nuclear_gen3_uranium_oxide), 
-      		preset_demand_by_electricity_production, 
+        	L(energy_power_nuclear_gen3_uranium_oxide),
+      		preset_demand_by_electricity_production,
       		V(energy_power_nuclear_gen3_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_nuclear_gen3_uranium_oxide,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_nuclear_gen3_uranium_oxide, output_of_electricity)*2), V(energy_power_nuclear_gen3_uranium_oxide,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_gen3_uranium_oxide,number_of_units),V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/oil_plants/capacity_of_energy_power_engine_diesel.ad
+++ b/inputs/supply/electricity/oil_plants/capacity_of_energy_power_engine_diesel.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_engine_diesel), 
-            number_of_units, 
+            V(energy_power_engine_diesel),
+            number_of_units,
             USER_INPUT() / V(energy_power_engine_diesel,electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_engine_diesel), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_engine_diesel),
+        	preset_demand_by_electricity_production,
         	V(energy_power_engine_diesel, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_engine_diesel,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_engine_diesel,electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_engine_diesel, output_of_electricity)*2), V(energy_power_engine_diesel,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_engine_diesel,number_of_units),V(energy_power_engine_diesel,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/oil_plants/capacity_of_energy_power_ultra_supercritical_crude_oil.ad
+++ b/inputs/supply/electricity/oil_plants/capacity_of_energy_power_ultra_supercritical_crude_oil.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_ultra_supercritical_crude_oil), 
-            number_of_units, 
+            V(energy_power_ultra_supercritical_crude_oil),
+            number_of_units,
             USER_INPUT() / V(energy_power_ultra_supercritical_crude_oil, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_ultra_supercritical_crude_oil), 
-      		preset_demand_by_electricity_production, 
+        	L(energy_power_ultra_supercritical_crude_oil),
+      		preset_demand_by_electricity_production,
       		V(energy_power_ultra_supercritical_crude_oil, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_ultra_supercritical_crude_oil,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_ultra_supercritical_crude_oil, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_crude_oil, output_of_electricity)*2), V(energy_power_ultra_supercritical_crude_oil,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_crude_oil,number_of_units),V(energy_power_ultra_supercritical_crude_oil, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -13,7 +13,7 @@
             V(industry_chp_combined_cycle_gas_power_fuelmix, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = future:MAX(1.0,PRODUCT(DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_combined_cycle_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit)),V(industry_chp_combined_cycle_gas_power_fuelmix,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(industry_final_demand_electricity,demand), V(industry_chp_combined_cycle_gas_power_fuelmix, output_of_electricity)*2), V(industry_chp_combined_cycle_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_combined_cycle_gas_power_fuelmix,number_of_units),V(industry_chp_combined_cycle_gas_power_fuelmix,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -5,17 +5,17 @@
 - query =
     EACH(
         UPDATE(
-            V(industry_chp_engine_gas_power_fuelmix), 
-            number_of_units, 
+            V(industry_chp_engine_gas_power_fuelmix),
+            number_of_units,
             USER_INPUT() / V(industry_chp_engine_gas_power_fuelmix,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(industry_chp_engine_gas_power_fuelmix),constant), 
-            share, 
+            OUTPUT_LINKS(V(industry_chp_engine_gas_power_fuelmix),constant),
+            share,
             V(industry_chp_engine_gas_power_fuelmix, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = future:MAX(1.0,PRODUCT(DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_engine_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit))),V(industry_chp_engine_gas_power_fuelmix,heat_output_capacity))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(industry_final_demand_electricity,demand), V(industry_chp_engine_gas_power_fuelmix, output_of_electricity)*2), V(industry_chp_engine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_engine_gas_power_fuelmix,number_of_units),V(industry_chp_engine_gas_power_fuelmix,heat_output_capacity))
 - step_value = 0.1

--- a/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -5,17 +5,17 @@
 - query =
     EACH(
         UPDATE(
-            V(industry_chp_turbine_gas_power_fuelmix), 
-      		number_of_units, 
+            V(industry_chp_turbine_gas_power_fuelmix),
+      		number_of_units,
       		USER_INPUT() / V(industry_chp_turbine_gas_power_fuelmix,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(industry_chp_turbine_gas_power_fuelmix),constant), 
-            share, 
+            OUTPUT_LINKS(V(industry_chp_turbine_gas_power_fuelmix),constant),
+            share,
             V(industry_chp_turbine_gas_power_fuelmix, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = future:MAX(1.0,PRODUCT(DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_turbine_gas_power_fuelmix,maximum_yearly_electricity_production_per_unit)),V(industry_chp_turbine_gas_power_fuelmix,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(industry_final_demand_electricity,demand), V(industry_chp_turbine_gas_power_fuelmix, output_of_electricity)*2), V(industry_chp_turbine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_turbine_gas_power_fuelmix,number_of_units),V(industry_chp_turbine_gas_power_fuelmix,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/heat_networks/heat_netwerk_industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -4,17 +4,17 @@
 - query =
     EACH(
         UPDATE(
-            V(industry_chp_ultra_supercritical_coal), 
-            number_of_units, 
+            V(industry_chp_ultra_supercritical_coal),
+            number_of_units,
             USER_INPUT() / V(industry_chp_ultra_supercritical_coal,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(industry_chp_ultra_supercritical_coal),constant), 
-            share, 
+            OUTPUT_LINKS(V(industry_chp_ultra_supercritical_coal),constant),
+            share,
             V(industry_chp_ultra_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = future:MAX(1.0,PRODUCT(DIVIDE(V(industry_final_demand_electricity,demand),V(industry_chp_ultra_supercritical_coal,maximum_yearly_electricity_production_per_unit)),V(industry_chp_ultra_supercritical_coal,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(industry_final_demand_electricity,demand), V(industry_chp_ultra_supercritical_coal, output_of_electricity)*2), V(industry_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_ultra_supercritical_coal,number_of_units),V(industry_chp_ultra_supercritical_coal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/heat_network_agriculture/capacity_of_agriculture_chp_engine_biogas.ad
+++ b/inputs/supply/heat_networks/heat_network_agriculture/capacity_of_agriculture_chp_engine_biogas.ad
@@ -5,17 +5,17 @@
 - query =
     EACH(
         UPDATE(
-            V(agriculture_chp_engine_biogas), 
-            number_of_units, 
+            V(agriculture_chp_engine_biogas),
+            number_of_units,
             USER_INPUT() / V(agriculture_chp_engine_biogas,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(agriculture_chp_engine_biogas),constant), 
-            share, 
+            OUTPUT_LINKS(V(agriculture_chp_engine_biogas),constant),
+            share,
             V(agriculture_chp_engine_biogas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:PRODUCT(Q(maximum_number_of_agriculture_chp_engine_biogas),V(agriculture_chp_engine_biogas,heat_output_capacity))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(agriculture_final_demand_electricity,demand), V(agriculture_chp_engine_biogas, output_of_electricity)*2), V(agriculture_chp_engine_biogas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(agriculture_chp_engine_biogas,number_of_units),V(agriculture_chp_engine_biogas,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/heat_network_agriculture/capacity_of_agriculture_chp_engine_network_gas.ad
+++ b/inputs/supply/heat_networks/heat_network_agriculture/capacity_of_agriculture_chp_engine_network_gas.ad
@@ -5,17 +5,17 @@
 - query =
     EACH(
         UPDATE(
-            V(agriculture_chp_engine_network_gas), 
-            number_of_units, 
+            V(agriculture_chp_engine_network_gas),
+            number_of_units,
             USER_INPUT() / V(agriculture_chp_engine_network_gas,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(agriculture_chp_engine_network_gas),constant), 
-            share, 
+            OUTPUT_LINKS(V(agriculture_chp_engine_network_gas),constant),
+            share,
             V(agriculture_chp_engine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:PRODUCT(Q(maximum_number_of_chps_in_agriculture),V(agriculture_chp_engine_network_gas,heat_output_capacity))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(agriculture_final_demand_electricity,demand), V(agriculture_chp_engine_network_gas, output_of_electricity)*2), V(agriculture_chp_engine_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(agriculture_chp_engine_network_gas,number_of_units),V(agriculture_chp_engine_network_gas,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/heat_network_agriculture/capacity_of_agriculture_chp_supercritical_wood_pellets.ad
+++ b/inputs/supply/heat_networks/heat_network_agriculture/capacity_of_agriculture_chp_supercritical_wood_pellets.ad
@@ -5,17 +5,17 @@
 - query =
     EACH(
         UPDATE(
-            V(agriculture_chp_supercritical_wood_pellets), 
-            number_of_units, 
+            V(agriculture_chp_supercritical_wood_pellets),
+            number_of_units,
             USER_INPUT() / V(agriculture_chp_supercritical_wood_pellets,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(agriculture_chp_supercritical_wood_pellets),constant), 
-            share, 
+            OUTPUT_LINKS(V(agriculture_chp_supercritical_wood_pellets),constant),
+            share,
             V(agriculture_chp_supercritical_wood_pellets, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:PRODUCT(Q(maximum_number_of_agriculture_chp_supercritical_wood_pellets),V(agriculture_chp_supercritical_wood_pellets,heat_output_capacity))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(V(agriculture_final_demand_electricity,demand), V(agriculture_chp_supercritical_wood_pellets, output_of_electricity)*2), V(agriculture_chp_supercritical_wood_pellets,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(agriculture_chp_supercritical_wood_pellets,number_of_units),V(agriculture_chp_supercritical_wood_pellets,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_coal.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_coal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_coal), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_coal),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_coal,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(energy_heater_for_heat_network_coal),constant), 
-      		share, 
+            OUTPUT_LINKS(V(energy_heater_for_heat_network_coal),constant),
+      		share,
       		V(energy_heater_for_heat_network_coal, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production),output_of_heat_carriers)),V(energy_heater_for_heat_network_coal,typical_heat_production_per_unit)),2.0,V(energy_heater_for_heat_network_coal,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_coal, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_coal,number_of_units),V(energy_heater_for_heat_network_coal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_geothermal.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_geothermal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_geothermal), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_geothermal),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_geothermal,heat_output_capacity)
         ),
         UPDATE(
             OUTPUT_LINKS(V(energy_heater_for_heat_network_geothermal),constant),
-            share, 
+            share,
             V(energy_heater_for_heat_network_geothermal, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production),output_of_heat_carriers)),V(energy_heater_for_heat_network_geothermal,typical_heat_production_per_unit)),2.0,V(energy_heater_for_heat_network_geothermal,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_geothermal, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_geothermal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_geothermal,number_of_units),V(energy_heater_for_heat_network_geothermal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_lignite.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_lignite.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_lignite), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_lignite),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_lignite,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(energy_heater_for_heat_network_lignite),constant), 
-      		share, 
+            OUTPUT_LINKS(V(energy_heater_for_heat_network_lignite),constant),
+      		share,
       		V(energy_heater_for_heat_network_lignite, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production), output_of_heat_carriers)),V(energy_heater_for_heat_network_lignite, typical_heat_production_per_unit)),2.0),V(energy_heater_for_heat_network_lignite,heat_output_capacity))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_lignite, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_lignite, number_of_units),V(energy_heater_for_heat_network_lignite,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_network_gas.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_network_gas.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_network_gas), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_network_gas),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_network_gas,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(energy_heater_for_heat_network_network_gas),constant), 
-      		share, 
+            OUTPUT_LINKS(V(energy_heater_for_heat_network_network_gas),constant),
+      		share,
       		V(energy_heater_for_heat_network_network_gas, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production),output_of_heat_carriers)),V(energy_heater_for_heat_network_network_gas,typical_heat_production_per_unit)),2.0,V(energy_heater_for_heat_network_network_gas,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_network_gas, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_network_gas,number_of_units),V(energy_heater_for_heat_network_network_gas,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_oil.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_oil.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_crude_oil), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_crude_oil),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_crude_oil,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(energy_heater_for_heat_network_crude_oil),constant), 
-		    share, 
+            OUTPUT_LINKS(V(energy_heater_for_heat_network_crude_oil),constant),
+		    share,
       		V(energy_heater_for_heat_network_crude_oil, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production),output_of_heat_carriers)),V(energy_heater_for_heat_network_crude_oil,typical_heat_production_per_unit)),2.0,V(energy_heater_for_heat_network_crude_oil,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_crude_oil, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_crude_oil,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_crude_oil,number_of_units),V(energy_heater_for_heat_network_crude_oil,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_waste_mix.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_waste_mix.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_waste_mix), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_waste_mix),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_waste_mix,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(energy_heater_for_heat_network_waste_mix),constant), 
-			share, 
+            OUTPUT_LINKS(V(energy_heater_for_heat_network_waste_mix),constant),
+			share,
 			V(energy_heater_for_heat_network_waste_mix, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production),output_of_heat_carriers)),V(energy_heater_for_heat_network_waste_mix,typical_heat_production_per_unit)),2.0,V(energy_heater_for_heat_network_waste_mix,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_waste_mix, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_waste_mix,number_of_units),V(energy_heater_for_heat_network_waste_mix,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_wood_pellets.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/capacity_of_energy_heater_for_heat_network_wood_pellets.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_heater_for_heat_network_wood_pellets), 
-            number_of_units, 
+            V(energy_heater_for_heat_network_wood_pellets),
+            number_of_units,
             USER_INPUT() / V(energy_heater_for_heat_network_wood_pellets,heat_output_capacity)
         ),
         UPDATE(
-            OUTPUT_LINKS(V(energy_heater_for_heat_network_wood_pellets),constant), 
-      		share, 
+            OUTPUT_LINKS(V(energy_heater_for_heat_network_wood_pellets),constant),
+      		share,
       		V(energy_heater_for_heat_network_wood_pellets, production_based_on_number_of_heat_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(SUM(V(G(heat_production),output_of_heat_carriers)),V(energy_heater_for_heat_network_wood_pellets,typical_heat_production_per_unit)), 2.0,V(energy_heater_for_heat_network_wood_pellets,heat_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heater_for_heat_network_wood_pellets, output_of_steam_hot_water)*2), V(energy_heater_for_heat_network_wood_pellets,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heater_for_heat_network_wood_pellets,number_of_units),V(energy_heater_for_heat_network_wood_pellets,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/volume_of_imported_heat.ad
+++ b/inputs/supply/heat_networks/large_scale_heat_and_residual_heat/volume_of_imported_heat.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_import_heat), preset_demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:PRODUCT(Q(heat_production_total),2)
+- max_value_gql = present:DIVIDE(Q(heat_production_total), 2)
 - min_value = 0.0
 - start_value_gql = present:DIVIDE(V(energy_import_heat, demand),BILLIONS)
 - step_value = 0.1

--- a/inputs/supply/renewable_electricity/geothermal/capacity_of_energy_power_geothermal.ad
+++ b/inputs/supply/renewable_electricity/geothermal/capacity_of_energy_power_geothermal.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_geothermal), 
-            number_of_units, 
+            V(energy_power_geothermal),
+            number_of_units,
             USER_INPUT() / V(energy_power_geothermal, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_geothermal), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_geothermal),
+        	preset_demand_by_electricity_production,
         	V(energy_power_geothermal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_geothermal,typical_electricity_production_per_unit)),V(energy_power_geothermal, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_geothermal, output_of_electricity)*2), V(energy_power_geothermal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_geothermal,number_of_units),V(energy_power_geothermal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_mountain.ad
+++ b/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_mountain.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_hydro_mountain), 
-        	number_of_units, 
+            V(energy_power_hydro_mountain),
+        	number_of_units,
         	USER_INPUT() / V(energy_power_hydro_mountain,electricity_output_capacity)
         ),
         UPDATE(
-            L(energy_power_hydro_mountain), 
-            preset_demand_by_electricity_production, 
+            L(energy_power_hydro_mountain),
+            preset_demand_by_electricity_production,
             V(energy_power_hydro_mountain, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_hydro_mountain,maximum_yearly_electricity_production_per_unit)),V(energy_power_hydro_river, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_hydro_mountain, output_of_electricity)*2), V(energy_power_hydro_mountain,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_hydro_mountain,number_of_units),V(energy_power_hydro_mountain,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_river.ad
+++ b/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_river.ad
@@ -12,7 +12,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_hydro_river,typical_electricity_production_per_unit)),V(energy_power_hydro_river, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_hydro_river, output_of_electricity)*2), V(energy_power_hydro_river,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_hydro_river,number_of_units),V(energy_power_hydro_river,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_combined_cycle_hydrogen.ad
+++ b/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_combined_cycle_hydrogen.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_combined_cycle_hydrogen), 
-            number_of_units, 
+            V(energy_power_combined_cycle_hydrogen),
+            number_of_units,
             USER_INPUT() / V(energy_power_combined_cycle_hydrogen, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_combined_cycle_hydrogen), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_combined_cycle_hydrogen),
+        	preset_demand_by_electricity_production,
         	V(energy_power_combined_cycle_hydrogen, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_combined_cycle_hydrogen,typical_electricity_production_per_unit)),2,V(energy_power_combined_cycle_hydrogen, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_hydrogen, output_of_electricity)*2), V(energy_power_combined_cycle_hydrogen,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_combined_cycle_hydrogen,number_of_units),V(energy_power_combined_cycle_hydrogen,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_turbine_hydrogen.ad
+++ b/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_turbine_hydrogen.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_turbine_hydrogen), 
-            number_of_units, 
+            V(energy_power_turbine_hydrogen),
+            number_of_units,
             USER_INPUT() / V(energy_power_turbine_hydrogen, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_turbine_hydrogen), 
-      		preset_demand_by_electricity_production, 
+        	L(energy_power_turbine_hydrogen),
+      		preset_demand_by_electricity_production,
       		V(energy_power_turbine_hydrogen, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_turbine_hydrogen,typical_electricity_production_per_unit)),2,V(energy_power_turbine_hydrogen, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_turbine_hydrogen, output_of_electricity)*2), V(energy_power_turbine_hydrogen,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_turbine_hydrogen,number_of_units),V(energy_power_turbine_hydrogen,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_energy_power_solar_csp_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_energy_power_solar_csp_solar_radiation.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_power_solar_csp_solar_radiation), 
-            number_of_units, 
+            V(energy_power_solar_csp_solar_radiation),
+            number_of_units,
             USER_INPUT() / V(energy_power_solar_csp_solar_radiation, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_power_solar_csp_solar_radiation), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_power_solar_csp_solar_radiation),
+        	preset_demand_by_electricity_production,
         	V(energy_power_solar_csp_solar_radiation, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_solar_csp_solar_radiation,typical_electricity_production_per_unit)),V(energy_power_solar_csp_solar_radiation, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_solar_csp_solar_radiation, output_of_electricity)*2), V(energy_power_solar_csp_solar_radiation,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_solar_csp_solar_radiation,number_of_units),V(energy_power_solar_csp_solar_radiation,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_energy_power_solar_pv_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_energy_power_solar_pv_solar_radiation.ad
@@ -11,7 +11,7 @@
             V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(AREA(total_land_area),V(energy_power_solar_pv_solar_radiation,land_use_per_unit)),V(energy_power_solar_pv_solar_radiation, electricity_output_capacity)))
+- max_value_gql = present:PRODUCT(DIVIDE(AREA(total_land_area),V(energy_power_solar_pv_solar_radiation,land_use_per_unit)),V(energy_power_solar_pv_solar_radiation, electricity_output_capacity))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_solar_pv_solar_radiation,number_of_units),V(energy_power_solar_pv_solar_radiation,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
+++ b/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
@@ -1,17 +1,17 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_supercritical_waste_mix), 
-            number_of_units, 
+            V(energy_chp_supercritical_waste_mix),
+            number_of_units,
             USER_INPUT() / V(energy_chp_supercritical_waste_mix, electricity_output_capacity)
         ),
         UPDATE(
-        	L(energy_chp_supercritical_waste_mix), 
-        	preset_demand_by_electricity_production, 
+        	L(energy_chp_supercritical_waste_mix),
+        	preset_demand_by_electricity_production,
         	V(energy_chp_supercritical_waste_mix, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_chp_supercritical_waste_mix,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_supercritical_waste_mix, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_supercritical_waste_mix, output_of_electricity)*2), V(energy_chp_supercritical_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_supercritical_waste_mix,number_of_units),V(energy_chp_supercritical_waste_mix,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_power_supercritical_waste_mix.ad
+++ b/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_power_supercritical_waste_mix.ad
@@ -11,7 +11,7 @@
         	V(energy_power_supercritical_waste_mix, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:MAX(5.0,PRODUCT(DIVIDE(Q(total_electricity_consumed),V(energy_power_supercritical_waste_mix,maximum_yearly_electricity_production_per_unit)),2,V(energy_power_supercritical_waste_mix, electricity_output_capacity)))
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_supercritical_waste_mix, output_of_electricity)*2), V(energy_power_supercritical_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_supercritical_waste_mix,number_of_units),V(energy_power_supercritical_waste_mix,electricity_output_capacity))
 - step_value = 1.0


### PR DESCRIPTION
The slider max for electricity and heat plants now takes into account installed capacity of the plants in the starting year. In this way the slider max can never be too restrictive to display installed capacity in the present. 

- For electricity plants the slider max is now equal to (the installed capacity required to supply) total electricity demand in the present, or twice the installed capacity of the plant in the present (whichever is larger). 

_Example 1: Region X has a yearly electricity demand of 100 PJ in the present and no domestic production. The slider max for all power plant sliders (except sliders with 'land' potential like wind and solar) equals the capacity required to produce 100 PJ_

_Example 2: Region X has a yearly electricity demand of 10 PJ and a supply of 20 PJ because of a 200 MW coal plant in the region. The slider max for all power plant sliders except the coal plant equals the capacity required to produce 10 PJ (like in example 1). For the coal plant the slider max equals the capacity required to produce 40 PJ (twice current installed capacity), ensuring that the slider max is large enough to display current installed capacity and to allow for expansion of the current installed capacity_

- For heat plants the slider max equals half the (installed capacity required to supply) total heat production in the present (both collective heat and individual heat), or twice the installed capacity of the plant in the present  (whichever is bigger). 

Closes https://github.com/quintel/etsource/issues/2085