### PR TITLE
Changed biofootprint calculation nodes and removed whitelisting of bioresource-demand

### DIFF
--- a/nodes/energy/energy_biogas_fermentation_wet_biomass.converter.ad
+++ b/nodes/energy/energy_biogas_fermentation_wet_biomass.converter.ad
@@ -2,7 +2,7 @@
 - energy_balance_group = biomass conversion
 - output.biogas = 0.54
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - presentation_group = biomass
 - availability = 0.98
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_greengas_gasification_dry_biomass.ad
+++ b/nodes/energy/energy_greengas_gasification_dry_biomass.ad
@@ -1,7 +1,7 @@
 - use = undefined
 - output.greengas = 0.602
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]]
 - availability = 0.9
 - presentation_group = biomass
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_greengas_gasification_wet_biomass.ad
+++ b/nodes/energy/energy_greengas_gasification_wet_biomass.ad
@@ -1,7 +1,7 @@
 - use = undefined
 - output.greengas = 0.68
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]]
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_import_biogenic_waste.ad
+++ b/nodes/energy/energy_import_biogenic_waste.ad
@@ -1,4 +1,4 @@
 - use = undefined
 - energy_balance_group = import
-- groups = [energy_import, energy_import_export, primary_energy_demand, bio_resources_demand]
+- groups = [energy_import, energy_import_export, primary_energy_demand, bio_footprint_calculation], bio_resources_demand]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_production_bio_ethanol.ad
+++ b/nodes/energy/energy_production_bio_ethanol.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = growth and production
 - output.bio_ethanol = 0.38
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_production_bio_kerosene.ad
+++ b/nodes/energy/energy_production_bio_kerosene.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = growth and production
 - output.bio_kerosene = 0.6
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_production_bio_lng.ad
+++ b/nodes/energy/energy_production_bio_lng.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = growth and production
 - output.bio_lng = 0.432
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_production_bio_oil.ad
+++ b/nodes/energy/energy_production_bio_oil.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = growth and production
 - output.bio_oil = 0.998
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_production_biodiesel.ad
+++ b/nodes/energy/energy_production_biodiesel.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = growth and production
 - output.biodiesel = 0.985
 - output.loss = elastic
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_production_biogenic_waste.ad
+++ b/nodes/energy/energy_production_biogenic_waste.ad
@@ -1,6 +1,7 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [mining_and_extraction, bio_footprint_calculation, primary_energy_demand, bio_resources_demand]
+- groups = [mining_and_extraction, primary_energy_demand, bio_resources_demand]
+- graph_methods = [max_demand]
 - free_co2_factor = 0.0
 
 ~ max_demand = PRIMARY_PRODUCTION(energy_production_biogenic_waste, max_demand)

--- a/nodes/energy/energy_production_biogenic_waste.ad
+++ b/nodes/energy/energy_production_biogenic_waste.ad
@@ -1,7 +1,6 @@
 - use = undefined
 - energy_balance_group = growth and production
 - groups = [mining_and_extraction, primary_energy_demand, bio_resources_demand]
-- graph_methods = [max_demand]
 - free_co2_factor = 0.0
 
 ~ max_demand = PRIMARY_PRODUCTION(energy_production_biogenic_waste, max_demand)

--- a/nodes/energy/energy_production_dry_biomass.ad
+++ b/nodes/energy/energy_production_dry_biomass.ad
@@ -1,7 +1,7 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [mining_and_extraction, bio_footprint_calculation, bio_resources_demand]
-- graph_methods = [demand, max_demand]
+- groups = [mining_and_extraction, bio_resources_demand]
+- graph_methods = [max_demand]
 - free_co2_factor = 0.0
 
 ~ max_demand = PRIMARY_PRODUCTION(energy_production_dry_biomass, max_demand)

--- a/nodes/energy/energy_production_oily_biomass.ad
+++ b/nodes/energy/energy_production_oily_biomass.ad
@@ -1,7 +1,7 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [mining_and_extraction, bio_footprint_calculation, bio_resources_demand]
-- graph_methods = [demand, max_demand]
+- groups = [mining_and_extraction, bio_resources_demand]
+- graph_methods = [max_demand]
 - free_co2_factor = 0.0
 
 ~ max_demand = PRIMARY_PRODUCTION(energy_production_oily_biomass, max_demand)

--- a/nodes/energy/energy_production_wet_biomass.ad
+++ b/nodes/energy/energy_production_wet_biomass.ad
@@ -1,7 +1,7 @@
 - use = undefined
 - energy_balance_group = growth and production
-- groups = [mining_and_extraction, bio_footprint_calculation, bio_resources_demand]
-- graph_methods = [demand, max_demand]
+- groups = [mining_and_extraction, bio_resources_demand]
+- graph_methods = [max_demand]
 - free_co2_factor = 0.0
 
 ~ max_demand = PRIMARY_PRODUCTION(energy_production_wet_biomass, max_demand)

--- a/nodes/energy/energy_production_wood_pellets.converter.ad
+++ b/nodes/energy/energy_production_wood_pellets.converter.ad
@@ -2,5 +2,5 @@
 - energy_balance_group = biomass conversion
 - output.loss = elastic
 - output.wood_pellets = 0.9
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_torrefaction_wood.converter.ad
+++ b/nodes/energy/energy_torrefaction_wood.converter.ad
@@ -4,5 +4,5 @@
 - output.torrefied_biomass_pellets = 0.86
 - input.network_gas = 0.053
 - input.dry_biomass = 0.947
-- groups = [primary_energy_demand]
+- groups = [primary_energy_demand, bio_footprint_calculation]
 - free_co2_factor = 0.0


### PR DESCRIPTION
- Biofootprint calculation was first located in the bioresource-nodes (wet, dry, oily and biogenic waste), but should be in the same nodes on which the `primary_energy_demand` calculation is based.
- Whitelisting `demand` is removed, since it has no effect. We found out that it is not possible to set the `max_demand` and the `demand` for the same node. The `max_demand` or potential is most important, therefore we choose to remove the present `demand`/production for the bioresource-nodes.


