### PR TITLE
Removing dispatchable_production group from local CHPs

### DIFF
--- a/nodes/agriculture/agriculture_chp_engine_biogas.central_producer.ad
+++ b/nodes/agriculture/agriculture_chp_engine_biogas.central_producer.ad
@@ -4,7 +4,7 @@
 - output.electricity = 0.42
 - output.loss = elastic
 - output.steam_hot_water = 0.35
-- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, dispatchable_production, mv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, mv_net_supply]
 - presentation_group = chps
 - merit_order.group = industry_chp
 - merit_order.level = mv

--- a/nodes/agriculture/agriculture_chp_engine_network_gas.central_producer.ad
+++ b/nodes/agriculture/agriculture_chp_engine_network_gas.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.43
 - output.loss = elastic
 - output.steam_hot_water = 0.47
-- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, dispatchable_production, mv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, mv_net_supply]
 - presentation_group = chps
 - merit_order.group = agriculture_chp
 - merit_order.level = mv

--- a/nodes/agriculture/agriculture_chp_supercritical_wood_pellets.central_producer.ad
+++ b/nodes/agriculture/agriculture_chp_supercritical_wood_pellets.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.2
 - output.loss = elastic
 - output.steam_hot_water = 0.85
-- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, dispatchable_production, mv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, mv_net_supply]
 - presentation_group = chps
 - merit_order.group = agriculture_chp
 - merit_order.level = mv

--- a/nodes/buildings/buildings_chp_engine_biogas.central_producer.ad
+++ b/nodes/buildings/buildings_chp_engine_biogas.central_producer.ad
@@ -4,7 +4,7 @@
 - output.electricity = 0.42
 - output.loss = elastic
 - output.steam_hot_water = 0.35
-- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, dispatchable_production, lv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, lv_net_supply]
 - presentation_group = chps
 - merit_order.group = buildings_chp
 - merit_order.level = lv

--- a/nodes/buildings/buildings_collective_chp_network_gas.central_producer.ad
+++ b/nodes/buildings/buildings_collective_chp_network_gas.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.43
 - output.loss = elastic
 - output.steam_hot_water = 0.47
-- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, lv_net_supply]
+- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, lv_net_supply]
 - presentation_group = chps
 - merit_order.group = buildings_chp
 - merit_order.level = lv

--- a/nodes/buildings/buildings_collective_chp_wood_pellets.central_producer.ad
+++ b/nodes/buildings/buildings_collective_chp_wood_pellets.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.2
 - output.loss = elastic
 - output.steam_hot_water = 0.75
-- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, lv_net_supply]
+- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, lv_net_supply]
 - presentation_group = chps
 - merit_order.group = buildings_chp
 - merit_order.level = lv

--- a/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.27
 - output.loss = elastic
 - output.steam_hot_water = 0.15
-- groups = [preset_demand, central_production, cost_chps, electricity_production, must_run_electricity_production, dispatchable_production, heat_production, hv_net_supply]
+- groups = [preset_demand, central_production, cost_chps, electricity_production, must_run_electricity_production, heat_production, hv_net_supply]
 - presentation_group = chps
 - merit_order.group = industry_chp
 - merit_order.level = hv

--- a/nodes/households/households_collective_chp_biogas.central_producer.ad
+++ b/nodes/households/households_collective_chp_biogas.central_producer.ad
@@ -4,7 +4,7 @@
 - output.electricity = 0.42
 - output.loss = elastic
 - output.steam_hot_water = 0.35
-- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, lv_net_supply]
+- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, lv_net_supply]
 - presentation_group = chps
 - merit_order.group = households_heating
 - merit_order.level = lv

--- a/nodes/households/households_collective_chp_network_gas.central_producer.ad
+++ b/nodes/households/households_collective_chp_network_gas.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.43
 - output.loss = elastic
 - output.steam_hot_water = 0.47
-- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, lv_net_supply]
+- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, lv_net_supply]
 - presentation_group = chps
 - merit_order.group = households_heating
 - merit_order.level = lv

--- a/nodes/households/households_collective_chp_wood_pellets.central_producer.ad
+++ b/nodes/households/households_collective_chp_wood_pellets.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.2
 - output.loss = elastic
 - output.steam_hot_water = 0.75
-- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, dispatchable_production, lv_net_supply]
+- groups = [cost_chps, electricity_production, heat_production, must_run_electricity_production, lv_net_supply]
 - presentation_group = chps
 - merit_order.group = households_heating
 - merit_order.level = lv

--- a/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.central_producer.ad
+++ b/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.42
 - output.loss = elastic
 - output.steam_hot_water = 0.4
-- groups = [cost_chps, electricity_production, must_run_electricity_production, dispatchable_production, heat_production, hv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, hv_net_supply]
 - presentation_group = chps
 - merit_order.group = industry_chp
 - merit_order.level = hv

--- a/nodes/industry/industry_chp_engine_gas_power_fuelmix.central_producer.ad
+++ b/nodes/industry/industry_chp_engine_gas_power_fuelmix.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.42
 - output.loss = elastic
 - output.steam_hot_water = 0.48
-- groups = [cost_chps, electricity_production, must_run_electricity_production, dispatchable_production, heat_production, mv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, mv_net_supply]
 - presentation_group = chps
 - merit_order.group = industry_chp
 - merit_order.level = mv

--- a/nodes/industry/industry_chp_turbine_gas_power_fuelmix.central_producer.ad
+++ b/nodes/industry/industry_chp_turbine_gas_power_fuelmix.central_producer.ad
@@ -3,7 +3,7 @@
 - output.electricity = 0.38
 - output.loss = elastic
 - output.steam_hot_water = 0.42
-- groups = [cost_chps, electricity_production, must_run_electricity_production, dispatchable_production, heat_production, mv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, mv_net_supply]
 - presentation_group = chps
 - merit_order.group = industry_chp
 - merit_order.level = mv

--- a/nodes/industry/industry_chp_ultra_supercritical_coal.central_producer.ad
+++ b/nodes/industry/industry_chp_ultra_supercritical_coal.central_producer.ad
@@ -5,7 +5,7 @@
 - output.electricity = 0.4
 - output.loss = elastic
 - output.steam_hot_water = 0.15
-- groups = [cost_chps, electricity_production, must_run_electricity_production, dispatchable_production, heat_production, hv_net_supply]
+- groups = [cost_chps, electricity_production, must_run_electricity_production, heat_production, hv_net_supply]
 - presentation_group = chps
 - merit_order.group = industry_chp
 - merit_order.level = hv


### PR DESCRIPTION
Closing https://github.com/quintel/etsource/issues/2094 : removed the `dispatchable_production` group from local CHP nodes.

Question: the node [`energy_chp_supercritical_waste_mix.central_producer`](https://github.com/quintel/etsource/blob/master/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad) also contains both groups, should this node also only contain the `must_run_electricity_production` group?