### PR TITLE
Increased and simplified  max of P2H industry sliders

### DIFF
--- a/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_other_useable_heat,demand),(50.0 * 8760 * MJ_PER_MWH)),V(industry_chemicals_other_flexibility_p2h_network_gas_electricity, heat_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_other_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_refineries_useable_heat,demand),(50.0 * 8760 * MJ_PER_MWH)),V(industry_chemicals_refineries_flexibility_p2h_network_gas_electricity, heat_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_refineries_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_food_useable_heat,demand),(50.0 * 8760 * MJ_PER_MWH)),V(industry_other_food_flexibility_p2h_network_gas_electricity, heat_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_food_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_paper_useable_heat,demand),(50.0 * 8760 * MJ_PER_MWH)),V(industry_other_paper_flexibility_p2h_network_gas_electricity, heat_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_paper_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0


### PR DESCRIPTION
Closes https://github.com/quintel/etmodel/issues/3164

+ found out that the `heat_output_capacity` of P2H (50.0) was used twice in the calculation, so removed it.
