### PR TITLE
Update solar PV full load hours for weather years

### DIFF
--- a/datasets/nl/curves/weather/1987/weather_properties.csv
+++ b/datasets/nl/curves/weather/1987/weather_properties.csv
@@ -2,5 +2,5 @@ key,value,unit
 flh_of_energy_power_wind_turbine_coastal,1765,hours
 flh_of_energy_power_wind_turbine_offshore,2905,hours
 flh_of_energy_power_wind_turbine_inland,1765,hours
-flh_of_energy_power_solar_pv_solar_radiation,738,hours
+flh_of_energy_power_solar_pv_solar_radiation,853,hours
 average_difference_in_air_temperature,-2.026849315,degC

--- a/datasets/nl/curves/weather/1997/weather_properties.csv
+++ b/datasets/nl/curves/weather/1997/weather_properties.csv
@@ -2,5 +2,5 @@ key,value,unit
 flh_of_energy_power_wind_turbine_coastal,1759,hours
 flh_of_energy_power_wind_turbine_offshore,3025,hours
 flh_of_energy_power_wind_turbine_inland,1759,hours
-flh_of_energy_power_solar_pv_solar_radiation,792,hours
+flh_of_energy_power_solar_pv_solar_radiation,915,hours
 average_difference_in_air_temperature,-0.613458904,degC

--- a/datasets/nl/curves/weather/2004/weather_properties.csv
+++ b/datasets/nl/curves/weather/2004/weather_properties.csv
@@ -2,5 +2,5 @@ key,value,unit
 flh_of_energy_power_wind_turbine_coastal,1937,hours
 flh_of_energy_power_wind_turbine_offshore,3334,hours
 flh_of_energy_power_wind_turbine_inland,1937,hours
-flh_of_energy_power_solar_pv_solar_radiation,807,hours
+flh_of_energy_power_solar_pv_solar_radiation,933,hours
 average_difference_in_air_temperature,-0.546484018,degC

--- a/datasets/nl2016/curves/weather/1987/weather_properties.csv
+++ b/datasets/nl2016/curves/weather/1987/weather_properties.csv
@@ -2,5 +2,5 @@ key,value,unit
 flh_of_energy_power_wind_turbine_coastal,1765,hours
 flh_of_energy_power_wind_turbine_offshore,2905,hours
 flh_of_energy_power_wind_turbine_inland,1765,hours
-flh_of_energy_power_solar_pv_solar_radiation,738,hours
+flh_of_energy_power_solar_pv_solar_radiation,853,hours
 average_difference_in_air_temperature,-2.026849315,degC

--- a/datasets/nl2016/curves/weather/1997/weather_properties.csv
+++ b/datasets/nl2016/curves/weather/1997/weather_properties.csv
@@ -2,5 +2,5 @@ key,value,unit
 flh_of_energy_power_wind_turbine_coastal,1759,hours
 flh_of_energy_power_wind_turbine_offshore,3025,hours
 flh_of_energy_power_wind_turbine_inland,1759,hours
-flh_of_energy_power_solar_pv_solar_radiation,792,hours
+flh_of_energy_power_solar_pv_solar_radiation,915,hours
 average_difference_in_air_temperature,-0.613458904,degC

--- a/datasets/nl2016/curves/weather/2004/weather_properties.csv
+++ b/datasets/nl2016/curves/weather/2004/weather_properties.csv
@@ -2,5 +2,5 @@ key,value,unit
 flh_of_energy_power_wind_turbine_coastal,1937,hours
 flh_of_energy_power_wind_turbine_offshore,3334,hours
 flh_of_energy_power_wind_turbine_inland,1937,hours
-flh_of_energy_power_solar_pv_solar_radiation,807,hours
+flh_of_energy_power_solar_pv_solar_radiation,933,hours
 average_difference_in_air_temperature,-0.546484018,degC


### PR DESCRIPTION
Fixes https://github.com/quintel/etmodel/issues/3167:
- Update full load hours for solar pv for different weather years (1987, 1997 and 2004) in the `weather_properties.csv` files. This is relevant for the `nl` and `nl2016` datasets (the latter one symlinking to all local datasets).