### PR TITLE
Add queries for total costs of new p2h converters

### DIFF
--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_other_flexibility_p2h_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_other_flexibility_p2h_electricity.gql
@@ -1,5 +1,0 @@
-# Return total cost of industry_chemicals_other_flexibility_p2h_electricity
-
-- unit = euro
-- query = V(industry_chemicals_other_flexibility_p2h_electricity, total_costs_per(:plant))
-

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_other_flexibility_p2h_hydrogen_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_other_flexibility_p2h_hydrogen_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_chemicals_other_flexibility_p2h_hydrogen_electricity
+
+- unit = euro
+- query = V(industry_chemicals_other_flexibility_p2h_hydrogen_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_other_flexibility_p2h_network_gas_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_other_flexibility_p2h_network_gas_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_chemicals_other_flexibility_p2h_network_gas_electricity
+
+- unit = euro
+- query = V(industry_chemicals_other_flexibility_p2h_network_gas_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_refineries_flexibility_p2h_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_refineries_flexibility_p2h_electricity.gql
@@ -1,5 +1,0 @@
-# Return total cost of industry_chemicals_refineries_flexibility_p2h_electricity
-
-- unit = euro
-- query = V(industry_chemicals_refineries_flexibility_p2h_electricity, total_costs_per(:plant))
-

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity
+
+- unit = euro
+- query = V(industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_refineries_flexibility_p2h_network_gas_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_chemicals_refineries_flexibility_p2h_network_gas_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_chemicals_refineries_flexibility_p2h_network_gas_electricity
+
+- unit = euro
+- query = V(industry_chemicals_refineries_flexibility_p2h_network_gas_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_other_food_flexibility_p2h_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_other_food_flexibility_p2h_electricity.gql
@@ -1,5 +1,0 @@
-# Return total cost of industry_other_food_flexibility_p2h_electricity
-
-- unit = euro
-- query = V(industry_other_food_flexibility_p2h_electricity, total_costs_per(:plant))
-

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_other_food_flexibility_p2h_hydrogen_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_other_food_flexibility_p2h_hydrogen_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_other_food_flexibility_p2h_hydrogen_electricity
+
+- unit = euro
+- query = V(industry_other_food_flexibility_p2h_hydrogen_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_other_food_flexibility_p2h_network_gas_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_other_food_flexibility_p2h_network_gas_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_other_food_flexibility_p2h_network_gas_electricity
+
+- unit = euro
+- query = V(industry_other_food_flexibility_p2h_network_gas_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_other_paper_flexibility_p2h_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_other_paper_flexibility_p2h_electricity.gql
@@ -1,5 +1,0 @@
-# Return total cost of industry_other_paper_flexibility_p2h_electricity
-
-- unit = euro
-- query = V(industry_other_paper_flexibility_p2h_electricity, total_costs_per(:plant))
-

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_other_paper_flexibility_p2h_hydrogen_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_other_paper_flexibility_p2h_hydrogen_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_other_paper_flexibility_p2h_hydrogen_electricity
+
+- unit = euro
+- query = V(industry_other_paper_flexibility_p2h_hydrogen_electricity, total_costs_per(:plant))

--- a/gqueries/mechanical_turk/costs/total_cost_of_industry_other_paper_flexibility_p2h_network_gas_electricity.gql
+++ b/gqueries/mechanical_turk/costs/total_cost_of_industry_other_paper_flexibility_p2h_network_gas_electricity.gql
@@ -1,0 +1,4 @@
+# Return total cost of industry_other_paper_flexibility_p2h_network_gas_electricity
+
+- unit = euro
+- query = V(industry_other_paper_flexibility_p2h_network_gas_electricity, total_costs_per(:plant))


### PR DESCRIPTION
The total costs queries are updated for the following converter updates:
- The p2h converters in the industry sectors (e.g. `industry_chemicals_other_flexibility_p2h_electricity`) are replaced by a network gas and hydrogen variant (e.g. `industry_chemicals_other_flexibility_p2h_hydrogen_electricity` and `industry_chemicals_other_flexibility_p2h_network_gas_electricity`).

@marliekeverweij I briefly checked for fall-out (in charts, etc.) but couldn't find anything. If you can think of any fall-out that should be checked before merging this PR, let me know.