### PR TITLE
Add input to toggle heat network storage

### DIFF
--- a/inputs/supply/heat/energy/heat_storage_enabled.ad
+++ b/inputs/supply/heat/energy/heat_storage_enabled.ad
@@ -1,0 +1,15 @@
+- query =
+    EACH(
+      UPDATE(
+        V(energy_heat_network_storage),
+        number_of_units,
+        IF(USER_INPUT() == 0.0, -> { 0.0 }, -> { 1.0 })
+      )
+    )
+- priority = 1
+- max_value = 1.0
+- min_value = 0.0
+- start_value_gql = present:0.0
+- step_value = 1.0
+- unit = x
+- update_period = both

--- a/nodes/energy/energy_heat_network_storage.ad
+++ b/nodes/energy/energy_heat_network_storage.ad
@@ -3,7 +3,7 @@
 - output.steam_hot_water = 1.0
 - output.loss = elastic
 - groups = [wacc_unproven_tech]
-- heat_network.group = storage
+- heat_network.group = infinite
 - heat_network.subtype = storage
 - heat_network.type = flex
 - storage.cost_per_mwh = 20.0
@@ -12,7 +12,7 @@
 - number_of_units = 0.0
 - availability = 1.0
 - full_load_hours = 0.0
-- heat_output_capacity = 0.0
+- heat_output_capacity = 1000.0
 - wacc = 0.07
 
 ~ demand = 0.0


### PR DESCRIPTION
Adds an input which allows the user to toggle on or off the heat network storage.

It defaults to off. When turned on, it is given infinite capacity. ETEngine will set the real storage volume (to the maximum amount which was stored) after calculating the heat network.

See also: https://github.com/quintel/etmodel/pull/3196