### PR TITLE
Remove non-energetic coal in industry from CO2 calculation

### DIFF
--- a/nodes/industry/industry_final_demand_coal_non_energetic.final_demand.ad
+++ b/nodes/industry/industry_final_demand_coal_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, co2_emissions_primary, non_energetic_use]
+- groups = [final_demand_group, non_energetic_use]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 


### PR DESCRIPTION
While trying to fix mechanical turk I found that this node is included in our CO2 calculations and I guess this should not be the case. Removing this node from the CO2 calculations has no impact in the CO2 emissions in the start year of a `nl` scenario, since the demand of this node is 286.05 TJ.