### PR TITLE
Fixing gquery so scenario report works again

### DIFF
--- a/gqueries/modules/scenario_report/regional_report/non_energetic_co2_emissions_percentage.gql
+++ b/gqueries/modules/scenario_report/regional_report/non_energetic_co2_emissions_percentage.gql
@@ -7,7 +7,7 @@
             Q(co2_sheet_non_energy_emissions_agriculture),
             Q(co2_sheet_non_energy_emissions_built_environment),
             Q(co2_sheet_non_energy_emissions_transport),
-            Q(co2_sheet_non_energy_emissions_industry)
+            Q(co2_sheet_non_energy_emissions_industry_energy)
         ),
         SUM(
             Q(co2_sheet_agriculture_total_co2_emissions),


### PR DESCRIPTION
Closes https://github.com/quintel/etmodel/issues/3211#issuecomment-572444570

I do not really understand why this error pops up now. The scenario report and failing gqueries haven't been updated recently.... Maybe this error was there already for some time, but nobody opens the Dutch scenario report?!

Anyway, this fixes the issue. `co2_sheet_non_energy_emissions_industry` does not exist, but `co2_sheet_non_energy_emissions_industry_energy` does, so I suppose this gquery should go here!

Notifying @MartLubben @antw 

