### PR TITLE
Fix converter group for hot water nodes in chart 56

### DIFF
--- a/gqueries/general/converter_groups/hot_water_converters_in_households.gql
+++ b/gqueries/general/converter_groups/hot_water_converters_in_households.gql
@@ -1,6 +1,6 @@
 - query =
     EXCLUDE(
-      CHILDREN(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h))),
+      CHILDREN(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater))),
       V(households_water_heater_deficit)
     )
 - unit = converters

--- a/gqueries/general/shares/share_of_coal_boiler_in_hot_water_produced_in_households.gql
+++ b/gqueries/general/shares/share_of_coal_boiler_in_hot_water_produced_in_households.gql
@@ -1,4 +1,4 @@
 # Returns how much of the hot water demand of households is provided by coal-powered heaters
 
-- query = V(households_water_heater_coal_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_coal_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor

--- a/gqueries/general/shares/share_of_combined_network_gas_in_hot_water_produced_in_households.gql
+++ b/gqueries/general/shares/share_of_combined_network_gas_in_hot_water_produced_in_households.gql
@@ -1,4 +1,4 @@
 # Returns how much of the hot water demand of households is provided by combined network gas-powered water heaters
 
-- query = V(households_water_heater_combined_network_gas_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_combined_network_gas_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor

--- a/gqueries/input_elements/start_value/share_of_electric_boiler_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_electric_boiler_in_hot_water_production_in_households.gql
@@ -1,2 +1,2 @@
-- query = V(households_water_heater_resistive_electricity_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_resistive_electricity_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor

--- a/gqueries/input_elements/start_value/share_of_gas_boiler_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_gas_boiler_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_network_gas_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_network_gas_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor
 - deprecated_key = hot_water_share_gas_boiler

--- a/gqueries/input_elements/start_value/share_of_heat_network_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_heat_network_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_district_heating_steam_hot_water_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_district_heating_steam_hot_water_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor
 - deprecated_key = hot_water_share_heat_network

--- a/gqueries/input_elements/start_value/share_of_heatpump_ground_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_heatpump_ground_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_heatpump_ground_water_electricity_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_heatpump_ground_water_electricity_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor
 - deprecated_key = hot_water_share_heatpump_ground

--- a/gqueries/input_elements/start_value/share_of_oil_boiler_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_oil_boiler_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_crude_oil_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_crude_oil_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor
 - deprecated_key = hot_water_share_oil_boiler

--- a/gqueries/input_elements/start_value/share_of_wood_stove_in_hot_water_production_in_households.gql
+++ b/gqueries/input_elements/start_value/share_of_wood_stove_in_hot_water_production_in_households.gql
@@ -1,3 +1,3 @@
-- query = V(households_water_heater_wood_pellets_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+- query = V(households_water_heater_wood_pellets_aggregator,share_of_households_useful_demand_for_hot_water_after_solar_heater)
 - unit = factor
 - deprecated_key = hot_water_share_wood_stove

--- a/gqueries/modules/scenario_report/main_report/biggest_water_heater_share_name.gql
+++ b/gqueries/modules/scenario_report/main_report/biggest_water_heater_share_name.gql
@@ -1,13 +1,13 @@
 - query =
     {
-    :coal_heater => V(households_water_heater_coal,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :gas_combined_heater => V(households_water_heater_combined_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :oil_heater => V(households_water_heater_crude_oil,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :district_heater => V(households_water_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :electric_heater => V(households_water_heater_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :air_heat_pump => V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :ground_heat_pump => V(households_water_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :hybrid_heat_pump => V(households_water_heater_hybrid_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :gas_heater => V(households_water_heater_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :wood_pellet_heater => V(households_water_heater_wood_pellets,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+    :coal_heater => V(households_water_heater_coal,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :gas_combined_heater => V(households_water_heater_combined_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :oil_heater => V(households_water_heater_crude_oil,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :district_heater => V(households_water_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :electric_heater => V(households_water_heater_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :air_heat_pump => V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :ground_heat_pump => V(households_water_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :hybrid_heat_pump => V(households_water_heater_hybrid_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :gas_heater => V(households_water_heater_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :wood_pellet_heater => V(households_water_heater_wood_pellets,share_of_households_useful_demand_for_hot_water_after_solar_heater)
     }.sort_by { |name, share| share }.to_a.last[0]

--- a/gqueries/modules/scenario_report/main_report/biggest_water_heater_share_value.gql
+++ b/gqueries/modules/scenario_report/main_report/biggest_water_heater_share_value.gql
@@ -1,13 +1,13 @@
 - query =
      {
-    :coal_heater => V(households_water_heater_coal,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :gas_combined_heater => V(households_water_heater_combined_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :oil_heater => V(households_water_heater_crude_oil,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :district_heater => V(households_water_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :electric_heater => V(households_water_heater_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :air_heat_pump => V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :ground_heat_pump => V(households_water_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :hybrid_heat_pump => V(households_water_heater_hybrid_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :gas_heater => V(households_water_heater_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h),
-    :wood_pellet_heater => V(households_water_heater_wood_pellets,share_of_households_useful_demand_for_hot_water_after_solar_heater_and_p2h)
+    :coal_heater => V(households_water_heater_coal,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :gas_combined_heater => V(households_water_heater_combined_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :oil_heater => V(households_water_heater_crude_oil,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :district_heater => V(households_water_heater_district_heating_steam_hot_water,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :electric_heater => V(households_water_heater_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :air_heat_pump => V(households_water_heater_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :ground_heat_pump => V(households_water_heater_heatpump_ground_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :hybrid_heat_pump => V(households_water_heater_hybrid_heatpump_air_water_electricity,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :gas_heater => V(households_water_heater_network_gas,share_of_households_useful_demand_for_hot_water_after_solar_heater),
+    :wood_pellet_heater => V(households_water_heater_wood_pellets,share_of_households_useful_demand_for_hot_water_after_solar_heater)
     }.sort_by { |name, share| share }.to_a.last[1]

--- a/gqueries/output_elements/output_series/sankey_190_co2/households_coal_for_hot_water_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/households_coal_for_hot_water_in_co2_sankey.gql
@@ -1,7 +1,7 @@
 # CO2 of coal for hot water in households
 
 - unit = tonne
-- query = 
+- query =
     SUM(
-        V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "weighted_carrier_co2_per_mj * demand")
+        V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater)).select {|node| node.input_slots.detect { |slot| slot.carrier.coal? }}, "weighted_carrier_co2_per_mj * demand")
     ) / THOUSANDS

--- a/gqueries/output_elements/output_series/sankey_190_co2/households_gas_for_hot_water_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/households_gas_for_hot_water_in_co2_sankey.gql
@@ -1,7 +1,7 @@
 # CO2 of gas for hot water in households
 
 - unit = tonne
-- query = 
+- query =
     SUM(
-        V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "weighted_carrier_co2_per_mj * demand")
+        V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater)).select {|node| node.input_slots.detect { |slot| slot.carrier.network_gas? }}, "weighted_carrier_co2_per_mj * demand")
     ) / THOUSANDS

--- a/gqueries/output_elements/output_series/sankey_190_co2/households_oil_for_hot_water_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/households_oil_for_hot_water_in_co2_sankey.gql
@@ -1,7 +1,7 @@
 # CO2 of oil for hot water in households
 
 - unit = tonne
-- query = 
+- query =
     SUM(
-        V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater_and_p2h)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "weighted_carrier_co2_per_mj * demand")
+        V(CHILDREN(V(households_useful_demand_for_hot_water_after_solar_heater)).select {|node| node.input_slots.detect { |slot| slot.carrier.crude_oil? }}, "weighted_carrier_co2_per_mj * demand")
     ) / THOUSANDS


### PR DESCRIPTION
Just found out that the hot water queries for chart 56 are not working (no final demand for hot water) and this is the fix

Before
![Screen Shot 2020-01-14 at 16 50 28](https://user-images.githubusercontent.com/32833996/72359391-7cac3b80-36ee-11ea-896a-c1b596ff0743.png)
After
![Screen Shot 2020-01-14 at 16 55 29](https://user-images.githubusercontent.com/32833996/72359503-b0876100-36ee-11ea-8e12-2c858f59fc5c.png)
