### PR TITLE
Change merit group for heat pump and geothermal

### DIFF
--- a/nodes/energy/energy_heat_heatpump_water_water_electricity.central_producer.ad
+++ b/nodes/energy/energy_heat_heatpump_water_water_electricity.central_producer.ad
@@ -5,7 +5,7 @@
 - output.steam_hot_water = 1.0
 - groups = [cost_heat_pumps, heat_production, central_production,non_final_electricity_demand_converters, wacc_proven_tech]
 - presentation_group = heat_pumps
-- merit_order.group = households_heating
+- merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
 - merit_order.type = consumer
 - heat_network.subtype = dispatchable

--- a/nodes/energy/energy_heat_well_geothermal.converter.ad
+++ b/nodes/energy/energy_heat_well_geothermal.converter.ad
@@ -5,10 +5,10 @@
 - output.steam_hot_water = 1.0
 - groups = [preset_demand, cost_heat_pumps, heat_production, central_production, non_final_electricity_demand_converters, wacc_proven_tech]
 - presentation_group = heat_pumps
-- merit_order.group = flat
+- merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
 - merit_order.type = consumer
-- heat_network.group = self: electricity_input_curve
+- heat_network.group = flat
 - heat_network.subtype = must_run
 - heat_network.type = producer
 - graph_methods = [demand]


### PR DESCRIPTION
merit_order.group now follows the steam_hot_water output curve rather than a static profile