### PR TITLE
Must-run / dispatchable toggle for nuclear plants

### DIFF
--- a/inputs/supply/electricity/nuclear_plants/merit_order_subtype_of_energy_power_nuclear_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/merit_order_subtype_of_energy_power_nuclear_uranium_oxide.ad
@@ -1,0 +1,18 @@
+- query =
+  IF(
+    EQUALS(USER_INPUT(), 1.0),
+    -> {
+      UPDATE(V(energy_power_nuclear_gen2_uranium_oxide, merit_order), subtype, must_run);
+      UPDATE(V(energy_power_nuclear_gen2_uranium_oxide, merit_order), group, flat);
+      UPDATE(V(energy_power_nuclear_gen3_uranium_oxide, merit_order), subtype, must_run);
+      UPDATE(V(energy_power_nuclear_gen3_uranium_oxide, merit_order), group, flat);
+    },
+    -> {}
+  )
+- priority = 0
+- max_value = 1.0
+- min_value = 0.0
+- start_value = 0.0
+- step_value = 1.0
+- unit = x
+- update_period = future


### PR DESCRIPTION
Adding input statement for must-run / dispatchable toggle for nuclear plants. Default setting is "dispatchable" for nuclear plants, however it's apparently not realistic that nuclear plants generate with a load factor <50%. Therefore the possibility is added to make them "must-run"

![Screen Shot 2020-01-22 at 15 49 53](https://user-images.githubusercontent.com/32833996/72904460-3cbd0800-3d2f-11ea-9c02-d29841c967e6.png)
![Screen Shot 2020-01-22 at 15 49 31](https://user-images.githubusercontent.com/32833996/72904468-40508f00-3d2f-11ea-9928-b0e74d674df0.png)

Notifying @ChaelKruip 