### PR TITLE
Remove industry_final_demand_for_chemical_network_gas from network_gas consumers group on PRO

### DIFF
--- a/nodes/industry/industry_final_demand_for_chemical_network_gas.ad
+++ b/nodes/industry/industry_final_demand_for_chemical_network_gas.ad
@@ -2,5 +2,3 @@
 - energy_balance_group = application
 - groups = [chemical_industry]
 - free_co2_factor = 0.0
-- network_gas.profile = flat
-- network_gas.type = consumer


### PR DESCRIPTION
Relates to https://github.com/quintel/etsource/issues/2200 and https://github.com/quintel/etsource/pull/2201