### PR TITLE
Read electricity curves from the carrier

### DIFF
--- a/gqueries/modules/security_of_supply/peak_electricity_demand.gql
+++ b/gqueries/modules/security_of_supply/peak_electricity_demand.gql
@@ -1,5 +1,5 @@
 # Returns the peak electricity demand by using the demand_curve method. This method returns an array of the hourly demand.
 # The peak electricity demand is taken to be the maximum of this array.
 
-- query = MAX(GRAPH(electricity_demand_curve))
+- query = MAX(V(CARRIER(electricity), demand_curve))
 - unit = mw

--- a/gqueries/output_elements/output_series/d3_172_merit_order_hourly_supply/total_demand.gql
+++ b/gqueries/output_elements/output_series/d3_172_merit_order_hourly_supply/total_demand.gql
@@ -1,2 +1,2 @@
-- query = GRAPH(electricity_demand_curve)
+- query = V(CARRIER(electricity), demand_curve)
 - unit = curve

--- a/gqueries/output_elements/output_series/d3_174_merit_order_price_curve/merit_order_price_curve.gql
+++ b/gqueries/output_elements/output_series/d3_174_merit_order_price_curve/merit_order_price_curve.gql
@@ -1,2 +1,2 @@
-- query = MERIT_PRICE_CURVE()
+- query = V(CARRIER(electricity), cost_curve)
 - unit = curve


### PR DESCRIPTION
Updates some queries to read electricity demand and price curves from the carrier, instead of from the graph.

See quintel/etengine#1087