### PR TITLE
Remove final demand hydrogen from CCS slider 

### DIFF
--- a/gqueries/general/co2/co2_captured_by_ccs_in_industry.gql
+++ b/gqueries/general/co2/co2_captured_by_ccs_in_industry.gql
@@ -6,9 +6,9 @@
       V(industry_final_demand_network_gas, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
       V(industry_final_demand_wood_pellets, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
       V(industry_final_demand_coal_gas, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
-      V(industry_final_demand_hydrogen, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
       V(industry_chp_combined_cycle_gas_power_fuelmix, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
       V(industry_chp_engine_gas_power_fuelmix, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
       V(industry_chp_turbine_gas_power_fuelmix, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
-      V(industry_chp_ultra_supercritical_coal, "weighted_carrier_co2_per_mj * demand * free_co2_factor")
+      V(industry_chp_ultra_supercritical_coal, "weighted_carrier_co2_per_mj * demand * free_co2_factor"),
+      V(energy_steel_hisarna_transformation_coal, "weighted_carrier_co2_per_mj * demand * free_co2_factor")
     ) / THOUSANDS

--- a/inputs/ccs/industry_ccs_in_industry.ad
+++ b/inputs/ccs/industry_ccs_in_industry.ad
@@ -5,7 +5,6 @@
       UPDATE(V(industry_final_demand_network_gas), free_co2_factor, USER_INPUT()/100),
       UPDATE(V(industry_final_demand_wood_pellets), free_co2_factor, USER_INPUT()/100),
       UPDATE(V(industry_final_demand_coal_gas), free_co2_factor, USER_INPUT()/100),
-      UPDATE(V(industry_final_demand_hydrogen), free_co2_factor, USER_INPUT()/100),
       UPDATE(V(industry_chp_combined_cycle_gas_power_fuelmix), free_co2_factor, USER_INPUT()/100),
       UPDATE(V(industry_chp_engine_gas_power_fuelmix), free_co2_factor, USER_INPUT()/100),
       UPDATE(V(industry_chp_turbine_gas_power_fuelmix), free_co2_factor, USER_INPUT()/100),


### PR DESCRIPTION
A client pointed out that final demand hydrogen should be removed from this slider, since there's no CO2 emitted when burning hydrogen in industry and this slider only captures CO2 in industry. So CO2 emitted during hydrogen production will now not be captured with this slider anymore!
See: https://github.com/quintel/etsource/pull/2207