### PR TITLE
Set HV network electricity output to be dynamic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',    ref: 'f73251e', github: 'quintel/atlas'
+  gem 'atlas',    ref: '79f76c4', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: f73251ecd4df7a1d1a7e48b1ebd531147bcf6992
-  ref: f73251e
+  revision: 79f76c43c583a63ca104eac9fdec065b4c3357a9
+  ref: 79f76c4
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)
@@ -43,7 +43,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)

--- a/nodes/energy/energy_power_hv_network_electricity.ad
+++ b/nodes/energy/energy_power_hv_network_electricity.ad
@@ -1,5 +1,6 @@
 - use = undefined
 - energy_balance_group = electricity network
+- output.electricity = etengine_dynamic
 - output.loss = elastic
 - groups = [cost_other, wacc_public_infra]
 - availability = 0.0

--- a/nodes/energy/energy_power_hv_network_loss.ad
+++ b/nodes/energy/energy_power_hv_network_loss.ad
@@ -4,6 +4,7 @@
 - graph_methods = [demand]
 - merit_order.group = flat
 - merit_order.type = consumer
+- merit_order.subtype = electricity_loss
 - merit_order.level = hv
 - free_co2_factor = 0.0
 


### PR DESCRIPTION
Instructs ETEngine to recalculate the conversion of the electricity output after time-resolved calculations have run to ensure that it remains consistent with the energy flows.

As an elastic output, the loss share will adapt automatically.

---

This fixes that the heat network causes unexpected HV surpluses or shortages depending on the selection of heat technologies. The electricity merit order is not currently capable of calculating loss dynamically as not all electricity flows occur through the HV network. Instead we calculate HV loss [as before](https://github.com/quintel/etengine/blob/a11c91e6257895ba2f1da9b864d05af83e95db0b/app/models/qernel/graph_api.rb#L165-L205) and then adjust the electricity and loss conversions of the HV network node to ensure that outward flows are consistent with what the merit order calculated.