### PR TITLE
Use input curve instead of output curve for heat storage capacity calculation

### DIFF
--- a/gqueries/output_elements/output_series/heat_cost_capacity_chart/heat_cost_capacity_chart_energy_heat_network_storage_capacity.gql
+++ b/gqueries/output_elements/output_series/heat_cost_capacity_chart/heat_cost_capacity_chart_energy_heat_network_storage_capacity.gql
@@ -1,2 +1,2 @@
-- query = MAX(V(energy_heat_network_storage, steam_hot_water_output_curve))
+- query = MAX(V(energy_heat_network_storage, steam_hot_water_input_curve))
 - unit = MW


### PR DESCRIPTION
When installed storage capacity is calculated based on the storage output curve a bug could arise where storage would disappear from the heat merit sortable even though heat was stored. This happened in scenarios with lots of dispatchables installed and  heat storage was assigned a low position in the heat merit order. The storage output curve can be zero in that case, i.e. only heat is put into storage but no heat is taken from it. This resulted in the capacity query to return 0, causing storage to disappear from the heat sortable as only option with a non-zero capacity are shown. Using the heat input curve to calculate the capacity solves this.

SO to @MartLubben for finding this bug :)