### PR TITLE
Update preset demand for heat supply inputs

### DIFF
--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_coal.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_coal.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_burner_coal),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_burner_coal,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_burner_coal),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_burner_coal,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_burner_coal),
+            preset_demand,
+            V(energy_heat_burner_coal, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_coal, output_of_steam_hot_water)*2), V(energy_heat_burner_coal,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_crude_oil.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_crude_oil.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_burner_crude_oil),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_burner_crude_oil,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_burner_crude_oil),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_burner_crude_oil,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_burner_crude_oil),
+            preset_demand,
+            V(energy_heat_burner_crude_oil, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_crude_oil, output_of_steam_hot_water)*2), V(energy_heat_burner_crude_oil,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_hydrogen.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_hydrogen.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_burner_hydrogen),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_burner_hydrogen,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_burner_hydrogen),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_burner_hydrogen,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_burner_hydrogen),
+            preset_demand,
+            V(energy_heat_burner_hydrogen, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_hydrogen, output_of_steam_hot_water)*2), V(energy_heat_burner_hydrogen,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_network_gas.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_network_gas.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_burner_network_gas),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_burner_network_gas,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_burner_network_gas),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_burner_network_gas,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_burner_network_gas),
+            preset_demand,
+            V(energy_heat_burner_network_gas, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_network_gas, output_of_steam_hot_water)*2), V(energy_heat_burner_network_gas,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_waste_mix.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_waste_mix.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_burner_waste_mix),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_burner_waste_mix,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_burner_waste_mix),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_burner_waste_mix,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_burner_waste_mix),
+            preset_demand,
+            V(energy_heat_burner_waste_mix, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_waste_mix, output_of_steam_hot_water)*2), V(energy_heat_burner_waste_mix,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_wood_pellets.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_wood_pellets.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_burner_wood_pellets),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_burner_wood_pellets,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_burner_wood_pellets),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_burner_wood_pellets,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_burner_wood_pellets),
+            preset_demand,
+            V(energy_heat_burner_wood_pellets, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_wood_pellets, output_of_steam_hot_water)*2), V(energy_heat_burner_wood_pellets,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_heatpump_water_water_electricity.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_heatpump_water_water_electricity.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_heatpump_water_water_electricity),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_heatpump_water_water_electricity,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_heatpump_water_water_electricity),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_heatpump_water_water_electricity,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_heatpump_water_water_electricity),
+            preset_demand,
+            V(energy_heat_heatpump_water_water_electricity, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_heatpump_water_water_electricity, output_of_steam_hot_water)*2), V(energy_heat_heatpump_water_water_electricity,full_load_hours)), MJ_PER_MWH)

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_solar_thermal.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_solar_thermal.ad
@@ -1,8 +1,15 @@
 - query =
-    UPDATE(
-        V(energy_heat_solar_thermal),
-        number_of_units,
-        USER_INPUT() / V(energy_heat_solar_thermal,heat_output_capacity)
+    EACH(
+        UPDATE(
+            V(energy_heat_solar_thermal),
+            number_of_units,
+            USER_INPUT() / V(energy_heat_solar_thermal,heat_output_capacity)
+        ),
+        UPDATE(
+            V(energy_heat_solar_thermal),
+            preset_demand,
+            V(energy_heat_solar_thermal, production_based_on_number_of_heat_units)
+        )
     )
 - priority = 0
 - max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_solar_thermal, output_of_steam_hot_water)*2), V(energy_heat_solar_thermal,full_load_hours)), MJ_PER_MWH)


### PR DESCRIPTION
This ensures that heat production is as expected in scenarios where time-resolved calculations are turned off

Before:
![beta-pro energytransitionmodel com - Merit order - Merit order - Energy Transition Model - Mozilla Firefox 2020-03-04 12-19-56](https://user-images.githubusercontent.com/32056448/75874699-94f92680-5e12-11ea-8dc3-3f9c47a23feb.png)

After:
![localhost - Energy Transition Model - Your free, independent, comprehensive, fact-based scenario builder  - Mozilla Firefox 2020-03-04 12-12-49](https://user-images.githubusercontent.com/32056448/75874713-99254400-5e12-11ea-8eab-57cfa740335e.png)
