### PR TITLE
Add missing nodes to application group

### DIFF
--- a/nodes/energy/energy_heat_dumped_steam_hot_water.ad
+++ b/nodes/energy/energy_heat_dumped_steam_hot_water.ad
@@ -1,3 +1,3 @@
 - use = energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, co2_emissions_primary]
+- groups = [final_demand_group, co2_emissions_primary, application_group]

--- a/nodes/industry/industry_final_demand_hydrogen_non_energetic.final_demand.ad
+++ b/nodes/industry/industry_final_demand_hydrogen_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use]
+- groups = [final_demand_group, non_energetic_use, application_group]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 ~ demand = 0


### PR DESCRIPTION
Add `energy_heat_dumped_steam_hot_water` and `industry_final_demand_hydrogen_non_energetic` to the `application_group` to make sure that the applications data-export is complete--i.e., the gqueries `SUM(V(G(application_group),final_demand))` and `SUM(V(G(final_demand_group),demand))` result in the same output values.

Fixes https://github.com/quintel/etmodel/issues/3260