### PR TITLE
Adjust COP of HHP and add queries for HHP table

### DIFF
--- a/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_space_heater_hybrid_heatpump_heat_output_share_electricity.gql
+++ b/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_space_heater_hybrid_heatpump_heat_output_share_electricity.gql
@@ -1,0 +1,4 @@
+# This query calculates the share of the produced heat that is heated
+# with electricity.
+- query = 100.0 - Q(households_space_heater_hybrid_heatpump_heat_output_share_network_gas)
+- unit = factor

--- a/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_space_heater_hybrid_heatpump_heat_output_share_network_gas.gql
+++ b/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_space_heater_hybrid_heatpump_heat_output_share_network_gas.gql
@@ -1,0 +1,12 @@
+# This query calculates the share of the produced heat that is heated
+# with gas. The gas efficiency is hard-coded (1.07), because it's not possible
+# to query at the moment.
+- query =
+    DIVIDE(
+      PRODUCT(
+        V(households_space_heater_hybrid_heatpump_air_water_electricity, input_of_network_gas),
+        1.07
+      ),
+      V(households_space_heater_hybrid_heatpump_air_water_electricity, demand)
+    ) * 100.0
+- unit = factor

--- a/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_water_heater_hybrid_heatpump_heat_output_share_electricity.gql
+++ b/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_water_heater_hybrid_heatpump_heat_output_share_electricity.gql
@@ -1,0 +1,4 @@
+# This query calculates the share of the produced hot water that is heated
+# with electricity.
+- query = 100.0 - Q(households_water_heater_hybrid_heatpump_heat_output_share_network_gas)
+- unit = factor

--- a/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_water_heater_hybrid_heatpump_heat_output_share_network_gas.gql
+++ b/gqueries/output_elements/output_series/table_259_hybrid_heat_pump/households_water_heater_hybrid_heatpump_heat_output_share_network_gas.gql
@@ -1,0 +1,12 @@
+# This query calculates the share of the produced hot water that is heated
+# with gas. The gas efficiency is hard-coded (0.9), because it's not possible
+# to query at the moment.
+- query =
+    DIVIDE(
+      PRODUCT(
+        V(households_water_heater_hybrid_heatpump_air_water_electricity, input_of_network_gas),
+        0.9
+      ),
+      V(households_water_heater_hybrid_heatpump_air_water_electricity, demand)
+    ) * 100.0
+- unit = factor

--- a/inputs/flexibility/households/households_flexibility_space_heating_cop_cutoff.ad
+++ b/inputs/flexibility/households/households_flexibility_space_heating_cop_cutoff.ad
@@ -9,6 +9,6 @@
 - max_value = 6.0
 - min_value = 1.0
 - start_value_gql = present:V(households_space_heater_hybrid_heatpump_air_water_electricity,"fever.cop_cutoff")
-- step_value = 0.1
+- step_value = 0.01
 - unit = COP
 - update_period = future

--- a/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -11,11 +11,11 @@
 - groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include]
 - presentation_group = heat_pumps
 - fever.alias_of = households_water_heater_hybrid_heatpump_air_water_electricity
-- fever.base_cop = 3.25
+- fever.base_cop = 2.277
 - fever.capacity.electricity = 0.0012944983818770229
 - fever.capacity.network_gas = 0.022
-- fever.cop_cutoff = 2.6
-- fever.cop_per_degree = 0.0875
+- fever.cop_cutoff = 2.600
+- fever.cop_per_degree = 0.0564
 - fever.defer_for = 4
 - fever.efficiency_balanced_with = ambient_heat
 - fever.efficiency_based_on = electricity

--- a/nodes/households/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
+++ b/nodes/households/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
@@ -11,11 +11,11 @@
 - groups = [cost_heat_pumps, demand_driven, heat_production, etmoses, merit_household_space_heating_producers, application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include]
 - presentation_group = heat_pumps
 - fever.alias_of = households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity
-- fever.base_cop = 3.25
+- fever.base_cop = 2.277
 - fever.capacity.electricity = 0.001294498
 - fever.capacity.hydrogen = 0.022
-- fever.cop_cutoff = 2.6
-- fever.cop_per_degree = 0.0875
+- fever.cop_cutoff = 2.600
+- fever.cop_per_degree = 0.0564
 - fever.defer_for = 4
 - fever.efficiency_balanced_with = ambient_heat
 - fever.efficiency_based_on = electricity


### PR DESCRIPTION
This PR adjusts the COP curve of hybrid heat pumps for gas and hydrogen. Before the output temperature of HHPs was 30 degrees which is really optimistic since HHPs are mostly installed in average insulated houses. Therefore, we have chosen to update the COP curve of HHPs to **44 degrees output temperature**. Now HHPs in label B insulated houses have an electricity share of 54% and gas share of 46%, this is close to the shares CEGOIA uses. 

A table has been added showing the shares of gas and electricity for HHP: 
![Screen Shot 2020-03-31 at 15 30 21](https://user-images.githubusercontent.com/32833996/78033352-93197900-7366-11ea-8ddc-4fe6c28054ba.png)

FYI: documentation will be adjusted soon!

![Screen Shot 2020-03-31 at 15 44 20](https://user-images.githubusercontent.com/32833996/78033452-b6dcbf00-7366-11ea-8838-02ad17cf192a.png)
![Screen Shot 2020-03-31 at 15 44 13](https://user-images.githubusercontent.com/32833996/78033466-ba704600-7366-11ea-8b42-141131aa9687.png)

