### PR TITLE
Add efficiency slider for solar PV

### DIFF
--- a/inputs/costs/technical_solar_pv_efficiency.ad
+++ b/inputs/costs/technical_solar_pv_efficiency.ad
@@ -1,17 +1,14 @@
 # This updates the efficiency of solar PV. This affects the output conversion,
-# output capacity per panel, and, for households and buildings, total electricity production.
+# output capacity per panel, and, for energy_power and energy_hydrogen, number of units
 # For solar PV farms and solar H2 farms the user sets the installed capacity.
 # Since installed capacity is given by the user, a higher efficiency means
-# a lower number of units installed. This is achieved by updating both the
-# electricity conversion and output capacity (per panel), keeping production stable.
+# a lower number of units installed. This is achieved reducing the installed NoU.
 # For solar panels in households and buildings the user sets the percentage of roof surface covered.
-# Since the share of roof surface covered does not change when updating efficiency, the install number of units
-# should remain stable. This is achieved by updating total electricity production, in addition
-# to electricity conversion and output capacity per panel.
+# The installed number of units remain the same.
 #
 # The priority of this input is set to be higher than that of the
-# capacity_of_energy_hydrogen_solar_pv_solar_radiation input, as the capacity
-# input will use the output shares to set the demand of the H2 solar PV node.
+# solar capacity/penetration input, as these inputs
+# will use the output shares to set the demand.
 
 - query =
       start_value = QUERY_PRESENT(-> {V(households_solar_pv_solar_radiation,electricity_output_conversion)}) * 100;
@@ -37,16 +34,6 @@
           USER_INPUT() / start_value),
 
         UPDATE_WITH_FACTOR(
-          V(
-            OUTPUT_SLOTS(
-              LOOKUP(households_solar_pv_solar_radiation,
-                     buildings_solar_pv_solar_radiation),
-                     electricity),
-              "links.detect{|l| !l.flexible? }"),
-          share,
-          USER_INPUT() / start_value),
-
-        UPDATE_WITH_FACTOR(
           V(energy_hydrogen_solar_pv_solar_radiation),
             number_of_units,
             1 / (USER_INPUT() / start_value)),
@@ -57,7 +44,7 @@
           V(energy_power_solar_pv_solar_radiation, number_of_units) / (USER_INPUT() / start_value)),
       )
 - priority = 2
-- max_value = 100.0
+- max_value = 50.0
 - min_value = 10.0
 - start_value_gql = present:V(households_solar_pv_solar_radiation,electricity_output_conversion) * 100.0
 - step_value = 1.0

--- a/inputs/costs/technical_solar_pv_efficiency.ad
+++ b/inputs/costs/technical_solar_pv_efficiency.ad
@@ -8,6 +8,10 @@
 # Since the share of roof surface covered does not change when updating efficiency, the install number of units
 # should remain stable. This is achieved by updating total electricity production, in addition
 # to electricity conversion and output capacity per panel.
+#
+# The priority of this input is set to be higher than that of the
+# capacity_of_energy_hydrogen_solar_pv_solar_radiation input, as the capacity
+# input will use the output shares to set the demand of the H2 solar PV node.
 
 - query =
       start_value = QUERY_PRESENT(-> {V(households_solar_pv_solar_radiation,electricity_output_conversion)}) * 100;
@@ -49,7 +53,7 @@
             number_of_units,
             1 / (USER_INPUT() / start_value)),
       )
-- priority = 0
+- priority = 2
 - max_value = 100.0
 - min_value = 10.0
 - start_value_gql = present:V(households_solar_pv_solar_radiation,electricity_output_conversion) * 100.0

--- a/inputs/costs/technical_solar_pv_efficiency.ad
+++ b/inputs/costs/technical_solar_pv_efficiency.ad
@@ -47,11 +47,14 @@
           USER_INPUT() / start_value),
 
         UPDATE_WITH_FACTOR(
-          V(
-            energy_power_solar_pv_solar_radiation,
-            energy_hydrogen_solar_pv_solar_radiation),
+          V(energy_hydrogen_solar_pv_solar_radiation),
             number_of_units,
             1 / (USER_INPUT() / start_value)),
+
+        UPDATE(
+          V(energy_power_solar_pv_solar_radiation),
+          number_of_units,
+          V(energy_power_solar_pv_solar_radiation, number_of_units) / (USER_INPUT() / start_value)),
       )
 - priority = 2
 - max_value = 100.0

--- a/inputs/costs/technical_solar_pv_efficiency.ad
+++ b/inputs/costs/technical_solar_pv_efficiency.ad
@@ -1,0 +1,58 @@
+# This updates the efficiency of solar PV. This affects the output conversion,
+# output capacity per panel, and, for households and buildings, total electricity production.
+# For solar PV farms and solar H2 farms the user sets the installed capacity.
+# Since installed capacity is given by the user, a higher efficiency means
+# a lower number of units installed. This is achieved by updating both the
+# electricity conversion and output capacity (per panel), keeping production stable.
+# For solar panels in households and buildings the user sets the percentage of roof surface covered.
+# Since the share of roof surface covered does not change when updating efficiency, the install number of units
+# should remain stable. This is achieved by updating total electricity production, in addition
+# to electricity conversion and output capacity per panel.
+
+- query =
+      start_value = QUERY_PRESENT(-> {V(households_solar_pv_solar_radiation,electricity_output_conversion)}) * 100;
+      EACH(
+        UPDATE_WITH_FACTOR(
+          OUTPUT_SLOTS(
+            V(
+              households_solar_pv_solar_radiation,
+              buildings_solar_pv_solar_radiation,
+              energy_power_solar_pv_solar_radiation,
+              energy_hydrogen_solar_pv_solar_radiation),
+              electricity),
+          conversion,
+          USER_INPUT() / start_value),
+
+        UPDATE_WITH_FACTOR(
+          V(
+            households_solar_pv_solar_radiation,
+            buildings_solar_pv_solar_radiation,
+            energy_power_solar_pv_solar_radiation,
+            energy_hydrogen_solar_pv_solar_radiation),
+          electricity_output_capacity,
+          USER_INPUT() / start_value),
+
+        UPDATE_WITH_FACTOR(
+          V(
+            OUTPUT_SLOTS(
+              LOOKUP(households_solar_pv_solar_radiation,
+                     buildings_solar_pv_solar_radiation),
+                     electricity),
+              "links.detect{|l| !l.flexible? }"),
+          share,
+          USER_INPUT() / start_value),
+
+        UPDATE_WITH_FACTOR(
+          V(
+            energy_power_solar_pv_solar_radiation,
+            energy_hydrogen_solar_pv_solar_radiation),
+            number_of_units,
+            1 / (USER_INPUT() / start_value)),
+      )
+- priority = 0
+- max_value = 100.0
+- min_value = 10.0
+- start_value_gql = present:V(households_solar_pv_solar_radiation,electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future


### PR DESCRIPTION
Allows users to set efficiency of solar PV panels. This affects solar PV in households, buildings, energy_power and energy_hydrogen.

- For households and buildings, increasing efficiency leads to a higher electricity production of solar PV and a higher installed capacity. Number of units stays constant. Demand (= input of ``solar_radiation``) stays constant. The reasoning behind this is that users set a share of roof surface covered with PV. If PV becomes more efficient, the same number of panels produce more electricity with the same amount of radiation
- For energy_power and energy_hydrogen, increasing efficiency leads to a lower number of installed units / lower demand of solar radiation. Produced electricity and installed capacity stay constant. The reasoning behind this is that users set the amount of installed capacity. If PV becomes more efficient, less panels are needed for the same amount of production/installed capacity.

Goes with: https://github.com/quintel/etmodel/pull/3320
Closes: https://github.com/quintel/etmodel/issues/1893

SO to @antw for his help! 🚀 