### PR TITLE
Set EV flex availability; replacing reserved_fraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',    ref: '4775a22', github: 'quintel/atlas'
+  gem 'atlas',    ref: '06afd1e', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 4775a22fea689c68c189d73aa827e6c94d111a69
-  ref: 4775a22
+  revision: 06afd1e79eee1c202112155147f7ef6c491f3a6c
+  ref: 06afd1e
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)
@@ -29,9 +29,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.2.1)
-      activesupport (= 6.0.2.1)
-    activesupport (6.0.2.1)
+    activemodel (6.0.2.2)
+      activesupport (= 6.0.2.2)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -78,7 +78,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     turbine-graph (0.1.3)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     virtus (1.0.5)
@@ -86,7 +86,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    zeitwerk (2.2.2)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_capacity.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_capacity.gql
@@ -1,2 +1,7 @@
-- query = V(transport_car_using_electricity, "number_of_units*input_capacity * (1 - reserved_fraction)")
+- query =
+    PRODUCT(
+      V(transport_car_using_electricity, "number_of_units * input_capacity"),
+      V(transport_car_flexibility_p2p_electricity, availability)
+    )
+
 - unit = MW

--- a/inputs/flexibility/transport/transport_car_using_electricity_availability.ad
+++ b/inputs/flexibility/transport/transport_car_using_electricity_availability.ad
@@ -1,8 +1,8 @@
-- query = UPDATE(V(transport_car_using_electricity), reserved_fraction, 1 - USER_INPUT() / 100.0)  
+- query = UPDATE(V(transport_car_flexibility_p2p_electricity), availability, USER_INPUT() / 100.0)
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value = 0.0
+- start_value_gql = present:V(transport_car_flexibility_p2p_electricity, availability)
 - step_value = 0.1
 - unit = %
 - update_period = future

--- a/nodes/transport/transport_car_flexibility_p2p_electricity.converter.ad
+++ b/nodes/transport/transport_car_flexibility_p2p_electricity.converter.ad
@@ -8,6 +8,7 @@
 - merit_order.level = lv
 - merit_order.subtype = storage
 - merit_order.type = flex
+- availability = 0.0
 
 ~ input.electricity = 1.0 / 0.89
 

--- a/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/nodes/transport/transport_car_using_electricity.converter.ad
@@ -27,4 +27,3 @@
 - construction_time = 0.0
 - technical_lifetime = 13.0
 - wacc = 0.04
-- reserved_fraction = 1.0


### PR DESCRIPTION
Sets the availability on the EV flex node, rather than using the special `reserved_fraction` attribute. This has the effect of changing both the volume _and_ input capacity available for flex.

Please also review and merge quintel/etengine#1107.
Closes quintel/etmodel#3327.