### PR TITLE
Fixing small bugs in EV and heat storage queries

### DIFF
--- a/gqueries/output_elements/output_series/heat_cost_capacity_chart/heat_cost_capacity_chart_energy_heat_network_storage_capacity.gql
+++ b/gqueries/output_elements/output_series/heat_cost_capacity_chart/heat_cost_capacity_chart_energy_heat_network_storage_capacity.gql
@@ -1,3 +1,7 @@
 - query =
-    V(energy_heat_network_storage, heat_output_capacity)
+    IF(
+      GREATER(V(energy_heat_network_storage, number_of_units), 0),
+      -> { V(energy_heat_network_storage, heat_output_capacity) },
+      -> { 0.0 }
+  )
 - unit = MW

--- a/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_volume.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_volume.gql
@@ -1,2 +1,6 @@
-- query = V(transport_car_using_electricity, "number_of_units * storage.volume * (1 - reserved_fraction)")
+- query =
+    PRODUCT(
+        V(transport_car_using_electricity, "number_of_units * storage.volume"),
+        V(transport_car_flexibility_p2p_electricity, availability)
+      )
 - unit = MWh


### PR DESCRIPTION
If time permits, cherry-pick to PRO:
- Removed reference to deprecated `reserved_fraction` in EV volume query (table 164)
- Added check to heat storage capacity query to only display a non-zero number if heat storage is enabled. This prevents storage from showing up in the heat merit order and cost/capacity chart when storage is off.