### PR TITLE
Whitelisting FLH in nodes to be able to set them via ETLocal + coal fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',    ref: '06afd1e', github: 'quintel/atlas'
+  gem 'atlas',    ref: '759dc7e', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 06afd1e79eee1c202112155147f7ef6c491f3a6c
-  ref: 06afd1e
+  revision: 759dc7ee74616543bfbb54f70f7a10a2d2d58e05
+  ref: 759dc7e
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/datasets/BEBU4402101_muide_meulestede/graph_values.yml
+++ b/datasets/BEBU4402101_muide_meulestede/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BEGM11002_antwerpen/graph_values.yml
+++ b/datasets/BEGM11002_antwerpen/graph_values.yml
@@ -13,6 +13,7 @@ agriculture_final_demand_hydrogen:
   demand: 0.0
 buildings_solar_pv_solar_radiation:
   demand: 342.26399999999995
+  full_load_hours: 890.0
 buildings_final_demand_wood_pellets:
   demand: 403.62
 buildings_final_demand_coal:
@@ -104,22 +105,27 @@ energy_power_combined_cycle_coal:
   demand: 0.0
 energy_power_wind_turbine_offshore:
   demand: 0.0
+  full_load_hours: 3230.0
 energy_power_solar_pv_solar_radiation:
   demand: 0.0
+  full_load_hours: 890.0
 energy_power_ultra_supercritical_ccs_coal:
   demand: 0.0
 energy_extraction_natural_gas:
   demand: 0.0
 energy_power_ultra_supercritical_network_gas:
   demand: 0.0
+  full_load_hours: 330.0
 energy_power_turbine_network_gas:
   demand: 773.970588235294
+  full_load_hours: 1800.0
 energy_production_wet_biomass:
   max_demand: 0.0
 energy_heat_distribution_loss:
   demand: 0.0
 energy_power_supercritical_waste_mix:
   demand: 1481.44
+  full_load_hours: 4100.0
 energy_heat_solar_thermal:
   demand: 0.0
 energy_power_engine_network_gas:
@@ -128,6 +134,7 @@ energy_heat_burner_network_gas:
   demand: 0.0
 energy_chp_supercritical_waste_mix:
   demand: 0.0
+  full_load_hours: 5100.0
 energy_heat_burner_waste_mix:
   demand: 0.0
 energy_heat_heatpump_water_water_electricity:
@@ -140,10 +147,12 @@ energy_distribution_greengas:
   demand: 0.0
 energy_chp_local_engine_biogas:
   demand: 0.0
+  full_load_hours: 8000.0
 energy_extraction_coal:
   demand: 0.0
 energy_chp_local_engine_network_gas:
   demand: 0.0
+  full_load_hours: 3610.0
 energy_extraction_uranium_oxide:
   demand: 0.0
 energy_power_sector_own_use_electricity:
@@ -167,8 +176,10 @@ energy_power_nuclear_gen3_uranium_oxide:
   demand: 0.0
 energy_power_engine_diesel:
   demand: 0.0
+  full_load_hours: 4000.0
 energy_power_wind_turbine_coastal:
   demand: 0.0
+  full_load_hours: 2850.0
 energy_import_heat:
   demand: 0.0
 energy_power_ultra_supercritical_coal:
@@ -181,12 +192,14 @@ energy_heat_burner_wood_pellets:
   demand: 0.0
 energy_power_combined_cycle_network_gas:
   demand: 0.0
+  full_load_hours: 850.0
 energy_power_ultra_supercritical_cofiring_coal:
   demand: 0.0
 energy_heat_burner_coal:
   demand: 0.0
 energy_power_wind_turbine_inland:
   demand: 254.40206185567013
+  full_load_hours: 2050.0
 energy_heat_burner_crude_oil:
   demand: 0.0
 energy_power_nuclear_gen2_uranium_oxide:
@@ -195,12 +208,16 @@ energy_production_dry_biomass:
   max_demand: 0.0
 energy_chp_local_wood_pellets:
   demand: 0.0
+  full_load_hours: 6000.0
 energy_power_hydro_river:
   demand: 0.0
+  full_load_hours: 3330.0
 energy_power_supercritical_coal:
   demand: 0.0
+  full_load_hours: 7500.0
 energy_chp_combined_cycle_network_gas:
   demand: 0.0
+  full_load_hours: 4900.0
 energy_extraction_crude_oil:
   demand: 0.0
 energy_chp_ultra_supercritical_coal:
@@ -247,6 +264,7 @@ households_final_demand_solar_thermal:
   demand: 28.78
 households_solar_pv_solar_radiation:
   demand: 684.5294117647059
+  full_load_hours: 890.0
 households_final_demand_wood_pellets:
   demand: 310.67
 industry_final_demand_wood_pellets:
@@ -272,6 +290,8 @@ industry_heat_well_geothermal:
   demand: 0.0
 industry_chp_engine_gas_power_fuelmix:
   demand: 0.0
+industry_transformation_generic_coal:
+  output: 1.0
 industry_final_demand_for_other_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
@@ -283,7 +303,7 @@ industry_chp_ultra_supercritical_coal:
 industry_final_demand_crude_oil:
   demand: 402.05
 industry_final_demand_coal:
-  demand: 632.1606779
+  demand: 1081.911138
 industry_heat_burner_crude_oil:
   demand: 0.0
 industry_heat_burner_coal:
@@ -300,9 +320,9 @@ industry_final_demand_wood_pellets_non_energetic:
   demand: 0.0
 industry_other_metals_burner_network_gas:
   input:
-    :coal: 0.025498660939205962
-    :crude_oil: 0.1631397917966249
-    :network_gas: 0.8113615472641692
+    :coal: 0.042862110937228304
+    :crude_oil: 0.16023300295600765
+    :network_gas: 0.796904886106764
 agriculture_final_demand_electricity-agriculture_geothermal@electricity:
   parent_share: 0.0
 agriculture_final_demand_electricity-agriculture_heatpump_water_water_ts_electricity@electricity:
@@ -480,13 +500,13 @@ households_final_demand_for_space_heating_network_gas-households_space_heater_hy
 industry_final_demand_for_chemical_coal_non_energetic-industry_final_demand_for_chemical_refineries_coal_non_energetic@coal:
   parent_share: 0.0
 industry_final_demand_coal-industry_final_demand_for_other_coal@coal:
-  parent_share: 0.9908864973709874
+  parent_share: 0.9908864973714689
 industry_final_demand_for_metal_steam_hot_water-industry_steel_hisarna_consumption_useable_heat@useable_heat:
   parent_share: 0.0
 industry_final_demand_crude_oil-industry_final_demand_for_chemical_crude_oil@crude_oil:
   parent_share: 0.16361149110807113
 industry_final_demand_for_other_coal-industry_final_demand_for_other_food_coal@coal:
-  parent_share: 0.027554655701111798
+  parent_share: 0.027554655699642563
 industry_final_demand_for_other_steam_hot_water-industry_final_demand_for_other_food_steam_hot_water@steam_hot_water:
   parent_share: 0.0
 industry_final_demand_electricity-industry_final_demand_for_metal_electricity@electricity:
@@ -505,6 +525,8 @@ industry_final_demand_for_metal_electricity-industry_aluminium_smeltoven_electri
   parent_share: 0.0
 ? industry_final_demand_for_chemical_wood_pellets_non_energetic-industry_final_demand_for_chemical_refineries_wood_pellets_non_energetic@wood_pellets
 : parent_share: 0.0
+industry_final_demand_for_other_paper_electricity-industry_other_paper_heater_electricity@electricity:
+  parent_share: 0.0
 industry_final_demand_wood_pellets-industry_final_demand_for_chemical_wood_pellets@wood_pellets:
   parent_share: 0.0014239722634967805
 ? industry_final_demand_for_chemical_network_gas_non_energetic-industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic@network_gas
@@ -551,6 +573,8 @@ industry_final_demand_for_other_electricity-industry_final_demand_for_other_food
   parent_share: 0.5067085059009472
 industry_final_demand_for_metal_network_gas-industry_steel_electricfurnace_burner_network_gas@network_gas:
   parent_share: 0.0
+industry_final_demand_for_other_food_electricity-industry_useful_demand_for_other_food_electricity@electricity:
+  parent_share: 1.0
 industry_final_demand_for_metal_electricity-industry_aluminium_electrolysis_current_electricity@electricity:
   parent_share: 0.0
 industry_final_demand_crude_oil-industry_final_demand_for_metal_crude_oil@crude_oil:
@@ -559,6 +583,8 @@ industry_final_demand_crude_oil-industry_final_demand_for_metal_crude_oil@crude_
 : parent_share: 0.04
 industry_final_demand_for_chemical_coal_non_energetic-industry_final_demand_for_chemical_other_coal_non_energetic@coal:
   parent_share: 1.0
+industry_final_demand_for_other_food_electricity-industry_other_food_heater_electricity@electricity:
+  parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_steel_blastfurnace_burner_coal_gas@coal:
   parent_share: 0.0
 industry_final_demand_wood_pellets-industry_final_demand_for_metal_wood_pellets@wood_pellets:
@@ -568,7 +594,7 @@ buildings_local_production_electricity-industry_final_demand_for_other_ict_elect
 industry_final_demand_for_chemical_wood_pellets-industry_final_demand_for_chemical_refineries_wood_pellets@wood_pellets:
   parent_share: 0.0
 industry_final_demand_for_other_coal-industry_final_demand_for_other_paper_coal@coal:
-  parent_share: 0.01069911648245607
+  parent_share: 0.010699116481885587
 industry_final_demand_for_other_wood_pellets-industry_final_demand_for_other_food_wood_pellets@wood_pellets:
   parent_share: 0.15344287449651556
 ? industry_final_demand_for_chemical_crude_oil_non_energetic-industry_final_demand_for_chemical_fertilizers_crude_oil_non_energetic@crude_oil
@@ -610,7 +636,7 @@ industry_final_demand_steam_hot_water-industry_final_demand_for_metal_steam_hot_
 industry_final_demand_wood_pellets_non_energetic-industry_final_demand_for_chemical_wood_pellets_non_energetic@wood_pellets:
   parent_share: 0.0
 industry_final_demand_coal-industry_final_demand_for_metal_coal@coal:
-  parent_share: 0.00911350262901254
+  parent_share: 0.009113502628531032
 industry_final_demand_for_chemical_crude_oil-industry_final_demand_for_chemical_fertilizers_crude_oil@crude_oil:
   parent_share: 0.0
 industry_final_demand_for_other_wood_pellets-industry_final_demand_for_other_paper_wood_pellets@wood_pellets:
@@ -627,6 +653,8 @@ industry_final_demand_for_chemical_network_gas-industry_final_demand_for_chemica
 : parent_share: 0.29
 industry_final_demand_for_chemical_electricity-industry_final_demand_for_chemical_refineries_electricity@electricity:
   parent_share: 0.0
+industry_final_demand_for_other_paper_electricity-industry_useful_demand_for_other_paper_electricity@electricity:
+  parent_share: 1.0
 industry_final_demand_for_chemical_coal_non_energetic-industry_final_demand_for_chemical_fertilizers_coal_non_energetic@coal:
   parent_share: 0.0
 industry_final_demand_for_metal_electricity-industry_steel_hisarna_consumption_useable_heat@electricity:

--- a/datasets/BEGM11002_antwerpen/graph_values.yml
+++ b/datasets/BEGM11002_antwerpen/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BEGM35013_oostende/graph_values.yml
+++ b/datasets/BEGM35013_oostende/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090000_ten_boer/graph_values.yml
+++ b/datasets/BU00090000_ten_boer/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090001_garmerwolde/graph_values.yml
+++ b/datasets/BU00090001_garmerwolde/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090002_thesinge/graph_values.yml
+++ b/datasets/BU00090002_thesinge/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090003_sint_annen/graph_values.yml
+++ b/datasets/BU00090003_sint_annen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090005_achter_thesinge_en_bovenrijge/graph_values.yml
+++ b/datasets/BU00090005_achter_thesinge_en_bovenrijge/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090009_verspreide_huizen_ten_noorden_van_het_eemskanaal/graph_values.yml
+++ b/datasets/BU00090009_verspreide_huizen_ten_noorden_van_het_eemskanaal/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090100_ten_post/graph_values.yml
+++ b/datasets/BU00090100_ten_post/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090101_winneweer_gedeeltelijk/graph_values.yml
+++ b/datasets/BU00090101_winneweer_gedeeltelijk/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090102_woltersum/graph_values.yml
+++ b/datasets/BU00090102_woltersum/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090104_wittewierum/graph_values.yml
+++ b/datasets/BU00090104_wittewierum/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090106_lellens/graph_values.yml
+++ b/datasets/BU00090106_lellens/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00090109_verspreide_huizen_ten_noorden_van_het_eemskanaal/graph_values.yml
+++ b/datasets/BU00090109_verspreide_huizen_ten_noorden_van_het_eemskanaal/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140000_binnenstad_noord/graph_values.yml
+++ b/datasets/BU00140000_binnenstad_noord/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140001_binnenstad_zuid/graph_values.yml
+++ b/datasets/BU00140001_binnenstad_zuid/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140002_binnenstad_oost/graph_values.yml
+++ b/datasets/BU00140002_binnenstad_oost/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140003_binnenstad_west/graph_values.yml
+++ b/datasets/BU00140003_binnenstad_west/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140004_noorderplantsoen/graph_values.yml
+++ b/datasets/BU00140004_noorderplantsoen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140005_hortusbuurt_ebbingekwartier/graph_values.yml
+++ b/datasets/BU00140005_hortusbuurt_ebbingekwartier/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140007_umcg/graph_values.yml
+++ b/datasets/BU00140007_umcg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140008_stationsgebied/graph_values.yml
+++ b/datasets/BU00140008_stationsgebied/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140100_de_meeuwen/graph_values.yml
+++ b/datasets/BU00140100_de_meeuwen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140101_oosterpoort/graph_values.yml
+++ b/datasets/BU00140101_oosterpoort/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140102_herewegbuurt/graph_values.yml
+++ b/datasets/BU00140102_herewegbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140103_rivierenbuurt/graph_values.yml
+++ b/datasets/BU00140103_rivierenbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140104_grunobuurt/graph_values.yml
+++ b/datasets/BU00140104_grunobuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140105_badstratenbuurt/graph_values.yml
+++ b/datasets/BU00140105_badstratenbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140106_zeeheldenbuurt/graph_values.yml
+++ b/datasets/BU00140106_zeeheldenbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140107_laanhuizen/graph_values.yml
+++ b/datasets/BU00140107_laanhuizen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140108_stadspark/graph_values.yml
+++ b/datasets/BU00140108_stadspark/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140109_martini_trade_park/graph_values.yml
+++ b/datasets/BU00140109_martini_trade_park/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140200_oranjebuurt/graph_values.yml
+++ b/datasets/BU00140200_oranjebuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140201_noorderplantsoenbuurt/graph_values.yml
+++ b/datasets/BU00140201_noorderplantsoenbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140202_schildersbuurt/graph_values.yml
+++ b/datasets/BU00140202_schildersbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140203_kostverloren/graph_values.yml
+++ b/datasets/BU00140203_kostverloren/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140300_de_hoogte/graph_values.yml
+++ b/datasets/BU00140300_de_hoogte/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140301_indische_buurt/graph_values.yml
+++ b/datasets/BU00140301_indische_buurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140302_professorenbuurt/graph_values.yml
+++ b/datasets/BU00140302_professorenbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140400_gorechtbuurt/graph_values.yml
+++ b/datasets/BU00140400_gorechtbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140401_vogelbuurt/graph_values.yml
+++ b/datasets/BU00140401_vogelbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140402_bloemenbuurt/graph_values.yml
+++ b/datasets/BU00140402_bloemenbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140403_florabuurt/graph_values.yml
+++ b/datasets/BU00140403_florabuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140404_damsterbuurt/graph_values.yml
+++ b/datasets/BU00140404_damsterbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140500_de_linie/graph_values.yml
+++ b/datasets/BU00140500_de_linie/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140501_europapark/graph_values.yml
+++ b/datasets/BU00140501_europapark/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140502_eemskanaal/graph_values.yml
+++ b/datasets/BU00140502_eemskanaal/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140503_kop_van_oost/graph_values.yml
+++ b/datasets/BU00140503_kop_van_oost/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140504_woonschepenhaven/graph_values.yml
+++ b/datasets/BU00140504_woonschepenhaven/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140505_driebond/graph_values.yml
+++ b/datasets/BU00140505_driebond/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140506_eemspoort/graph_values.yml
+++ b/datasets/BU00140506_eemspoort/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140507_euvelgunne/graph_values.yml
+++ b/datasets/BU00140507_euvelgunne/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140508_winschoterdiep/graph_values.yml
+++ b/datasets/BU00140508_winschoterdiep/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140509_stainkoeln/graph_values.yml
+++ b/datasets/BU00140509_stainkoeln/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140510_roodehaan/graph_values.yml
+++ b/datasets/BU00140510_roodehaan/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140511_waterhuizen/graph_values.yml
+++ b/datasets/BU00140511_waterhuizen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140600_sterrebosbuurt/graph_values.yml
+++ b/datasets/BU00140600_sterrebosbuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140601_coendersborg/graph_values.yml
+++ b/datasets/BU00140601_coendersborg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140602_klein_martijn/graph_values.yml
+++ b/datasets/BU00140602_klein_martijn/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140603_villabuurt/graph_values.yml
+++ b/datasets/BU00140603_villabuurt/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140604_helpman/graph_values.yml
+++ b/datasets/BU00140604_helpman/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140605_de_wijert/graph_values.yml
+++ b/datasets/BU00140605_de_wijert/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140606_de_wijert_zuid/graph_values.yml
+++ b/datasets/BU00140606_de_wijert_zuid/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140700_corpus_den_hoorn/graph_values.yml
+++ b/datasets/BU00140700_corpus_den_hoorn/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140701_hoornse_meer/graph_values.yml
+++ b/datasets/BU00140701_hoornse_meer/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140702_hoornse_park/graph_values.yml
+++ b/datasets/BU00140702_hoornse_park/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140703_van_swieten/graph_values.yml
+++ b/datasets/BU00140703_van_swieten/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140704_piccardthof/graph_values.yml
+++ b/datasets/BU00140704_piccardthof/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140705_bruilweering/graph_values.yml
+++ b/datasets/BU00140705_bruilweering/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140800_hoogkerk_dorp/graph_values.yml
+++ b/datasets/BU00140800_hoogkerk_dorp/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140801_hoogkerk_zuid/graph_values.yml
+++ b/datasets/BU00140801_hoogkerk_zuid/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140802_westpoort/graph_values.yml
+++ b/datasets/BU00140802_westpoort/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140803_vierverlaten/graph_values.yml
+++ b/datasets/BU00140803_vierverlaten/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140804_zuidwending/graph_values.yml
+++ b/datasets/BU00140804_zuidwending/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140805_leegkerk/graph_values.yml
+++ b/datasets/BU00140805_leegkerk/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140806_gravenburg/graph_values.yml
+++ b/datasets/BU00140806_gravenburg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140807_suikerfabriekterrein/graph_values.yml
+++ b/datasets/BU00140807_suikerfabriekterrein/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140808_peizerweg/graph_values.yml
+++ b/datasets/BU00140808_peizerweg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140809_bangeweer/graph_values.yml
+++ b/datasets/BU00140809_bangeweer/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140810_de_buitenhof/graph_values.yml
+++ b/datasets/BU00140810_de_buitenhof/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140811_kranenburg/graph_values.yml
+++ b/datasets/BU00140811_kranenburg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140812_de_kring/graph_values.yml
+++ b/datasets/BU00140812_de_kring/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140900_vinkhuizen_noord/graph_values.yml
+++ b/datasets/BU00140900_vinkhuizen_noord/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140901_vinkhuizen_zuid/graph_values.yml
+++ b/datasets/BU00140901_vinkhuizen_zuid/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140902_hoendiep/graph_values.yml
+++ b/datasets/BU00140902_hoendiep/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140903_friesestraatweg/graph_values.yml
+++ b/datasets/BU00140903_friesestraatweg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140904_reitdiep/graph_values.yml
+++ b/datasets/BU00140904_reitdiep/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140905_dorkwerd/graph_values.yml
+++ b/datasets/BU00140905_dorkwerd/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140906_de_held/graph_values.yml
+++ b/datasets/BU00140906_de_held/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00140907_westpark/graph_values.yml
+++ b/datasets/BU00140907_westpark/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141000_selwerd/graph_values.yml
+++ b/datasets/BU00141000_selwerd/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141001_paddepoel_zuid/graph_values.yml
+++ b/datasets/BU00141001_paddepoel_zuid/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141002_paddepoel_noord/graph_values.yml
+++ b/datasets/BU00141002_paddepoel_noord/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141003_zernike_campus/graph_values.yml
+++ b/datasets/BU00141003_zernike_campus/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141004_selwerderhof/graph_values.yml
+++ b/datasets/BU00141004_selwerderhof/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141005_tuinwijk/graph_values.yml
+++ b/datasets/BU00141005_tuinwijk/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141100_beijum_west/graph_values.yml
+++ b/datasets/BU00141100_beijum_west/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141101_beijum_oost/graph_values.yml
+++ b/datasets/BU00141101_beijum_oost/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141102_de_hunze/graph_values.yml
+++ b/datasets/BU00141102_de_hunze/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141103_van_starkenborgh/graph_values.yml
+++ b/datasets/BU00141103_van_starkenborgh/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141104_noorderhoogebrug/graph_values.yml
+++ b/datasets/BU00141104_noorderhoogebrug/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141105_het_witte_lam/graph_values.yml
+++ b/datasets/BU00141105_het_witte_lam/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141106_koningslaagte/graph_values.yml
+++ b/datasets/BU00141106_koningslaagte/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141107_hunzeboord/graph_values.yml
+++ b/datasets/BU00141107_hunzeboord/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141200_lewenborg_noord/graph_values.yml
+++ b/datasets/BU00141200_lewenborg_noord/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141201_lewenborg_zuid/graph_values.yml
+++ b/datasets/BU00141201_lewenborg_zuid/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141202_lewenborg_west/graph_values.yml
+++ b/datasets/BU00141202_lewenborg_west/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141203_oosterhoogebrug/graph_values.yml
+++ b/datasets/BU00141203_oosterhoogebrug/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141204_ulgersmaborg/graph_values.yml
+++ b/datasets/BU00141204_ulgersmaborg/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141205_hunzepark/graph_values.yml
+++ b/datasets/BU00141205_hunzepark/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141206_zilvermeer/graph_values.yml
+++ b/datasets/BU00141206_zilvermeer/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141207_kardinge/graph_values.yml
+++ b/datasets/BU00141207_kardinge/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141208_drielanden/graph_values.yml
+++ b/datasets/BU00141208_drielanden/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141209_noorddijk/graph_values.yml
+++ b/datasets/BU00141209_noorddijk/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141210_ruischerbrug/graph_values.yml
+++ b/datasets/BU00141210_ruischerbrug/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141211_ruischerwaard/graph_values.yml
+++ b/datasets/BU00141211_ruischerwaard/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141300_middelbert/graph_values.yml
+++ b/datasets/BU00141300_middelbert/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141301_engelbert/graph_values.yml
+++ b/datasets/BU00141301_engelbert/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141302_klein_harkstede/graph_values.yml
+++ b/datasets/BU00141302_klein_harkstede/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141400_meerstad/graph_values.yml
+++ b/datasets/BU00141400_meerstad/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141401_harkstede/graph_values.yml
+++ b/datasets/BU00141401_harkstede/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00141402_lageland/graph_values.yml
+++ b/datasets/BU00141402_lageland/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170000_haren/graph_values.yml
+++ b/datasets/BU00170000_haren/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170001_oosterhaar/graph_values.yml
+++ b/datasets/BU00170001_oosterhaar/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170002_voorveld/graph_values.yml
+++ b/datasets/BU00170002_voorveld/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170003_harenermolen/graph_values.yml
+++ b/datasets/BU00170003_harenermolen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170004_glimmen/graph_values.yml
+++ b/datasets/BU00170004_glimmen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170005_hemmen/graph_values.yml
+++ b/datasets/BU00170005_hemmen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170100_noordlaren/graph_values.yml
+++ b/datasets/BU00170100_noordlaren/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170101_onnen/graph_values.yml
+++ b/datasets/BU00170101_onnen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170102_paterswolde_gedeeltelijk/graph_values.yml
+++ b/datasets/BU00170102_paterswolde_gedeeltelijk/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170103_essen/graph_values.yml
+++ b/datasets/BU00170103_essen/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170106_verspreide_huizen_ten_westen_van_noord_willemskanaal/graph_values.yml
+++ b/datasets/BU00170106_verspreide_huizen_ten_westen_van_noord_willemskanaal/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170107_verspreide_huizen_op_de_hondsrug/graph_values.yml
+++ b/datasets/BU00170107_verspreide_huizen_op_de_hondsrug/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170108_verspreide_huizen_onner_esch/graph_values.yml
+++ b/datasets/BU00170108_verspreide_huizen_onner_esch/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/BU00170109_verspreide_huizen_ten_oosten_van_de_hondsrug/graph_values.yml
+++ b/datasets/BU00170109_verspreide_huizen_ten_oosten_van_de_hondsrug/graph_values.yml
@@ -625,3 +625,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0014_groningen/graph_values.yml
+++ b/datasets/GM0014_groningen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0034_almere/graph_values.yml
+++ b/datasets/GM0034_almere/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0050_zeewolde/graph_values.yml
+++ b/datasets/GM0050_zeewolde/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0058_dongeradeel/graph_values.yml
+++ b/datasets/GM0058_dongeradeel/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0059_achtkarspelen/graph_values.yml
+++ b/datasets/GM0059_achtkarspelen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0060_ameland/graph_values.yml
+++ b/datasets/GM0060_ameland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0079_kollumerland_en_nieuwkruisland/graph_values.yml
+++ b/datasets/GM0079_kollumerland_en_nieuwkruisland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0080_leeuwarden/graph_values.yml
+++ b/datasets/GM0080_leeuwarden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0088_schiermonnikoog/graph_values.yml
+++ b/datasets/GM0088_schiermonnikoog/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0093_terschelling/graph_values.yml
+++ b/datasets/GM0093_terschelling/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0096_vlieland/graph_values.yml
+++ b/datasets/GM0096_vlieland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0141_almelo/graph_values.yml
+++ b/datasets/GM0141_almelo/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0147_borne/graph_values.yml
+++ b/datasets/GM0147_borne/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0148_dalfsen/graph_values.yml
+++ b/datasets/GM0148_dalfsen/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0150_deventer/graph_values.yml
+++ b/datasets/GM0150_deventer/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0153_enschede/graph_values.yml
+++ b/datasets/GM0153_enschede/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0158_haaksbergen/graph_values.yml
+++ b/datasets/GM0158_haaksbergen/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0160_hardenberg/graph_values.yml
+++ b/datasets/GM0160_hardenberg/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0163_hellendoorn/graph_values.yml
+++ b/datasets/GM0163_hellendoorn/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0164_hengelo/graph_values.yml
+++ b/datasets/GM0164_hengelo/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0166_kampen/graph_values.yml
+++ b/datasets/GM0166_kampen/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0168_losser/graph_values.yml
+++ b/datasets/GM0168_losser/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0171_noordoostpolder/graph_values.yml
+++ b/datasets/GM0171_noordoostpolder/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0173_oldenzaal/graph_values.yml
+++ b/datasets/GM0173_oldenzaal/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0175_ommen/graph_values.yml
+++ b/datasets/GM0175_ommen/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0177_raalte/graph_values.yml
+++ b/datasets/GM0177_raalte/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0180_staphorst/graph_values.yml
+++ b/datasets/GM0180_staphorst/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0183_tubbergen/graph_values.yml
+++ b/datasets/GM0183_tubbergen/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0184_urk/graph_values.yml
+++ b/datasets/GM0184_urk/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0189_wierden/graph_values.yml
+++ b/datasets/GM0189_wierden/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0193_zwolle/graph_values.yml
+++ b/datasets/GM0193_zwolle/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0267_nijkerk/graph_values.yml
+++ b/datasets/GM0267_nijkerk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0279_scherpenzeel/graph_values.yml
+++ b/datasets/GM0279_scherpenzeel/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0303_dronten/graph_values.yml
+++ b/datasets/GM0303_dronten/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0307_amersfoort/graph_values.yml
+++ b/datasets/GM0307_amersfoort/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0307_amersfoort_no_highways/graph_values.yml
+++ b/datasets/GM0307_amersfoort_no_highways/graph_values.yml
@@ -607,3 +607,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0308_baarn/graph_values.yml
+++ b/datasets/GM0308_baarn/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0310_de_bilt/graph_values.yml
+++ b/datasets/GM0310_de_bilt/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0312_bunnik/graph_values.yml
+++ b/datasets/GM0312_bunnik/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0313_bunschoten/graph_values.yml
+++ b/datasets/GM0313_bunschoten/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0317_eemnes/graph_values.yml
+++ b/datasets/GM0317_eemnes/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0321_houten/graph_values.yml
+++ b/datasets/GM0321_houten/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0327_leusden/graph_values.yml
+++ b/datasets/GM0327_leusden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0331_lopik/graph_values.yml
+++ b/datasets/GM0331_lopik/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0335_montfoort/graph_values.yml
+++ b/datasets/GM0335_montfoort/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0339_renswoude/graph_values.yml
+++ b/datasets/GM0339_renswoude/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0340_rhenen/graph_values.yml
+++ b/datasets/GM0340_rhenen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0342_soest/graph_values.yml
+++ b/datasets/GM0342_soest/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0344_utrecht/graph_values.yml
+++ b/datasets/GM0344_utrecht/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0345_veenendaal/graph_values.yml
+++ b/datasets/GM0345_veenendaal/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0351_woudenberg/graph_values.yml
+++ b/datasets/GM0351_woudenberg/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0352_wijk_bij_duurstede/graph_values.yml
+++ b/datasets/GM0352_wijk_bij_duurstede/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0353_ijsselstein/graph_values.yml
+++ b/datasets/GM0353_ijsselstein/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0355_zeist/graph_values.yml
+++ b/datasets/GM0355_zeist/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0356_nieuwegein/graph_values.yml
+++ b/datasets/GM0356_nieuwegein/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0358_aalsmeer/graph_values.yml
+++ b/datasets/GM0358_aalsmeer/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0361_alkmaar/graph_values.yml
+++ b/datasets/GM0361_alkmaar/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0362_amstelveen/graph_values.yml
+++ b/datasets/GM0362_amstelveen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0363_amsterdam/graph_values.yml
+++ b/datasets/GM0363_amsterdam/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0370_beemster/graph_values.yml
+++ b/datasets/GM0370_beemster/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0370_beemster_no_highways/graph_values.yml
+++ b/datasets/GM0370_beemster_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0373_bergen/graph_values.yml
+++ b/datasets/GM0373_bergen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0375_beverwijk/graph_values.yml
+++ b/datasets/GM0375_beverwijk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0376_blaricum/graph_values.yml
+++ b/datasets/GM0376_blaricum/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0376_blaricum_no_highways/graph_values.yml
+++ b/datasets/GM0376_blaricum_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0377_bloemendaal/graph_values.yml
+++ b/datasets/GM0377_bloemendaal/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0383_castricum/graph_values.yml
+++ b/datasets/GM0383_castricum/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0383_castricum_no_highways/graph_values.yml
+++ b/datasets/GM0383_castricum_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0384_diemen/graph_values.yml
+++ b/datasets/GM0384_diemen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0384_diemen_no_highways/graph_values.yml
+++ b/datasets/GM0384_diemen_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0385_edam_volendam/graph_values.yml
+++ b/datasets/GM0385_edam_volendam/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0388_enkhuizen/graph_values.yml
+++ b/datasets/GM0388_enkhuizen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0392_haarlem/graph_values.yml
+++ b/datasets/GM0392_haarlem/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0394_haarlemmermeer/graph_values.yml
+++ b/datasets/GM0394_haarlemmermeer/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0394_haarlemmermeer_no_highways/graph_values.yml
+++ b/datasets/GM0394_haarlemmermeer_no_highways/graph_values.yml
@@ -607,3 +607,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0396_heemskerk/graph_values.yml
+++ b/datasets/GM0396_heemskerk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0397_heemstede/graph_values.yml
+++ b/datasets/GM0397_heemstede/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0398_heerhugowaard/graph_values.yml
+++ b/datasets/GM0398_heerhugowaard/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0399_heiloo/graph_values.yml
+++ b/datasets/GM0399_heiloo/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0400_den_helder/graph_values.yml
+++ b/datasets/GM0400_den_helder/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0402_hilversum/graph_values.yml
+++ b/datasets/GM0402_hilversum/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0405_hoorn/graph_values.yml
+++ b/datasets/GM0405_hoorn/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0406_huizen/graph_values.yml
+++ b/datasets/GM0406_huizen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0415_landsmeer/graph_values.yml
+++ b/datasets/GM0415_landsmeer/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0416_langedijk/graph_values.yml
+++ b/datasets/GM0416_langedijk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0417_laren/graph_values.yml
+++ b/datasets/GM0417_laren/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0417_laren_no_highways/graph_values.yml
+++ b/datasets/GM0417_laren_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0420_medemblik/graph_values.yml
+++ b/datasets/GM0420_medemblik/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0431_oostzaan/graph_values.yml
+++ b/datasets/GM0431_oostzaan/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0431_oostzaan_no_highways/graph_values.yml
+++ b/datasets/GM0431_oostzaan_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0432_opmeer/graph_values.yml
+++ b/datasets/GM0432_opmeer/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0437_ouder-amstel_no_highways/graph_values.yml
+++ b/datasets/GM0437_ouder-amstel_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0437_ouder_amstel/graph_values.yml
+++ b/datasets/GM0437_ouder_amstel/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0439_purmerend/graph_values.yml
+++ b/datasets/GM0439_purmerend/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0441_schagen/graph_values.yml
+++ b/datasets/GM0441_schagen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0448_texel/graph_values.yml
+++ b/datasets/GM0448_texel/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0450_uitgeest/graph_values.yml
+++ b/datasets/GM0450_uitgeest/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0450_uitgeest_no_highways/graph_values.yml
+++ b/datasets/GM0450_uitgeest_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0451_uithoorn/graph_values.yml
+++ b/datasets/GM0451_uithoorn/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0453_velsen/graph_values.yml
+++ b/datasets/GM0453_velsen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0453_velsen_no_steel/graph_values.yml
+++ b/datasets/GM0453_velsen_no_steel/graph_values.yml
@@ -607,3 +607,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0457_weesp/graph_values.yml
+++ b/datasets/GM0457_weesp/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0473_zandvoort/graph_values.yml
+++ b/datasets/GM0473_zandvoort/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0479_zaanstad/graph_values.yml
+++ b/datasets/GM0479_zaanstad/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0482_alblasserdam/graph_values.yml
+++ b/datasets/GM0482_alblasserdam/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0484_alphen_aan_den_rijn/graph_values.yml
+++ b/datasets/GM0484_alphen_aan_den_rijn/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0489_barendrecht/graph_values.yml
+++ b/datasets/GM0489_barendrecht/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0498_drechterland/graph_values.yml
+++ b/datasets/GM0498_drechterland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0501_brielle/graph_values.yml
+++ b/datasets/GM0501_brielle/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0502_capelle_aan_den_ijssel/graph_values.yml
+++ b/datasets/GM0502_capelle_aan_den_ijssel/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0503_delft/graph_values.yml
+++ b/datasets/GM0503_delft/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0505_dordrecht/graph_values.yml
+++ b/datasets/GM0505_dordrecht/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0512_gorinchem/graph_values.yml
+++ b/datasets/GM0512_gorinchem/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0513_gouda/graph_values.yml
+++ b/datasets/GM0513_gouda/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0518_s_gravenhage/graph_values.yml
+++ b/datasets/GM0518_s_gravenhage/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0523_hardinxveld_giessendam/graph_values.yml
+++ b/datasets/GM0523_hardinxveld_giessendam/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0530_hellevoetsluis/graph_values.yml
+++ b/datasets/GM0530_hellevoetsluis/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0531_hendrik_ido_ambacht/graph_values.yml
+++ b/datasets/GM0531_hendrik_ido_ambacht/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0532_stede_broec/graph_values.yml
+++ b/datasets/GM0532_stede_broec/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0534_hillegom/graph_values.yml
+++ b/datasets/GM0534_hillegom/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0537_katwijk/graph_values.yml
+++ b/datasets/GM0537_katwijk/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0542_krimpen_aan_den_ijssel/graph_values.yml
+++ b/datasets/GM0542_krimpen_aan_den_ijssel/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0545_leerdam/graph_values.yml
+++ b/datasets/GM0545_leerdam/graph_values.yml
@@ -615,3 +615,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0546_leiden/graph_values.yml
+++ b/datasets/GM0546_leiden/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0547_leiderdorp/graph_values.yml
+++ b/datasets/GM0547_leiderdorp/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0553_lisse/graph_values.yml
+++ b/datasets/GM0553_lisse/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0556_maassluis/graph_values.yml
+++ b/datasets/GM0556_maassluis/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0569_nieuwkoop/graph_values.yml
+++ b/datasets/GM0569_nieuwkoop/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0575_noordwijk/graph_values.yml
+++ b/datasets/GM0575_noordwijk/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0579_oegstgeest/graph_values.yml
+++ b/datasets/GM0579_oegstgeest/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0584_oud_beijerland/graph_values.yml
+++ b/datasets/GM0584_oud_beijerland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0585_binnenmaas/graph_values.yml
+++ b/datasets/GM0585_binnenmaas/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0588_korendijk/graph_values.yml
+++ b/datasets/GM0588_korendijk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0589_oudewater/graph_values.yml
+++ b/datasets/GM0589_oudewater/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0590_papendrecht/graph_values.yml
+++ b/datasets/GM0590_papendrecht/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0597_ridderkerk/graph_values.yml
+++ b/datasets/GM0597_ridderkerk/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0599_rotterdam/graph_values.yml
+++ b/datasets/GM0599_rotterdam/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0603_rijswijk/graph_values.yml
+++ b/datasets/GM0603_rijswijk/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0606_schiedam/graph_values.yml
+++ b/datasets/GM0606_schiedam/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0610_sliedrecht/graph_values.yml
+++ b/datasets/GM0610_sliedrecht/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0611_cromstrijen/graph_values.yml
+++ b/datasets/GM0611_cromstrijen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0613_albrandswaard/graph_values.yml
+++ b/datasets/GM0613_albrandswaard/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0614_westvoorne/graph_values.yml
+++ b/datasets/GM0614_westvoorne/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0617_strijen/graph_values.yml
+++ b/datasets/GM0617_strijen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0620_vianen/graph_values.yml
+++ b/datasets/GM0620_vianen/graph_values.yml
@@ -615,3 +615,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0622_vlaardingen/graph_values.yml
+++ b/datasets/GM0622_vlaardingen/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0626_voorschoten/graph_values.yml
+++ b/datasets/GM0626_voorschoten/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0627_waddinxveen/graph_values.yml
+++ b/datasets/GM0627_waddinxveen/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0629_wassenaar/graph_values.yml
+++ b/datasets/GM0629_wassenaar/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0632_woerden/graph_values.yml
+++ b/datasets/GM0632_woerden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0637_zoetermeer/graph_values.yml
+++ b/datasets/GM0637_zoetermeer/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0638_zoeterwoude/graph_values.yml
+++ b/datasets/GM0638_zoeterwoude/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0642_zwijndrecht/graph_values.yml
+++ b/datasets/GM0642_zwijndrecht/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0654_borsele/graph_values.yml
+++ b/datasets/GM0654_borsele/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0664_goes/graph_values.yml
+++ b/datasets/GM0664_goes/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0677_hulst/graph_values.yml
+++ b/datasets/GM0677_hulst/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0678_kapelle/graph_values.yml
+++ b/datasets/GM0678_kapelle/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0687_middelburg/graph_values.yml
+++ b/datasets/GM0687_middelburg/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0689_giessenlanden/graph_values.yml
+++ b/datasets/GM0689_giessenlanden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0703_reimerswaal/graph_values.yml
+++ b/datasets/GM0703_reimerswaal/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0707_zederik/graph_values.yml
+++ b/datasets/GM0707_zederik/graph_values.yml
@@ -615,3 +615,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0715_terneuzen/graph_values.yml
+++ b/datasets/GM0715_terneuzen/graph_values.yml
@@ -623,3 +623,7 @@ energy_heat_solar_thermal:
   demand: 0.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0716_tholen/graph_values.yml
+++ b/datasets/GM0716_tholen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0717_veere/graph_values.yml
+++ b/datasets/GM0717_veere/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0718_vlissingen/graph_values.yml
+++ b/datasets/GM0718_vlissingen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0733_lingewaal/graph_values.yml
+++ b/datasets/GM0733_lingewaal/graph_values.yml
@@ -615,3 +615,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0736_de_ronde_venen/graph_values.yml
+++ b/datasets/GM0736_de_ronde_venen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0737_tytsjerksteradiel/graph_values.yml
+++ b/datasets/GM0737_tytsjerksteradiel/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0738_aalburg/graph_values.yml
+++ b/datasets/GM0738_aalburg/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0744_baarle_nassau/graph_values.yml
+++ b/datasets/GM0744_baarle_nassau/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0748_bergen_op_zoom/graph_values.yml
+++ b/datasets/GM0748_bergen_op_zoom/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0758_breda/graph_values.yml
+++ b/datasets/GM0758_breda/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0765_pekela/graph_values.yml
+++ b/datasets/GM0765_pekela/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0766_dongen/graph_values.yml
+++ b/datasets/GM0766_dongen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0777_etten_leur/graph_values.yml
+++ b/datasets/GM0777_etten_leur/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0779_geertruidenberg/graph_values.yml
+++ b/datasets/GM0779_geertruidenberg/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0784_gilze_en_rijen/graph_values.yml
+++ b/datasets/GM0784_gilze_en_rijen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0785_goirle/graph_values.yml
+++ b/datasets/GM0785_goirle/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0797_heusden/graph_values.yml
+++ b/datasets/GM0797_heusden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0798_hilvarenbeek/graph_values.yml
+++ b/datasets/GM0798_hilvarenbeek/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0809_loon_op_zand/graph_values.yml
+++ b/datasets/GM0809_loon_op_zand/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0824_oisterwijk/graph_values.yml
+++ b/datasets/GM0824_oisterwijk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0826_oosterhout/graph_values.yml
+++ b/datasets/GM0826_oosterhout/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0840_rucphen/graph_values.yml
+++ b/datasets/GM0840_rucphen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0851_steenbergen/graph_values.yml
+++ b/datasets/GM0851_steenbergen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0852_waterland/graph_values.yml
+++ b/datasets/GM0852_waterland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0852_waterland_no_highways/graph_values.yml
+++ b/datasets/GM0852_waterland_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0855_tilburg/graph_values.yml
+++ b/datasets/GM0855_tilburg/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0861_veldhoven/graph_values.yml
+++ b/datasets/GM0861_veldhoven/graph_values.yml
@@ -623,3 +623,7 @@ energy_heat_solar_thermal:
   demand: 0.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0867_waalwijk/graph_values.yml
+++ b/datasets/GM0867_waalwijk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0870_werkendam/graph_values.yml
+++ b/datasets/GM0870_werkendam/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0880_wormerland/graph_values.yml
+++ b/datasets/GM0880_wormerland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0880_wormerland_no_highways/graph_values.yml
+++ b/datasets/GM0880_wormerland_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM0995_lelystad/graph_values.yml
+++ b/datasets/GM0995_lelystad/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1525_teylingen/graph_values.yml
+++ b/datasets/GM1525_teylingen/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1581_utrechtse_heuvelrug/graph_values.yml
+++ b/datasets/GM1581_utrechtse_heuvelrug/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1598_koggenland/graph_values.yml
+++ b/datasets/GM1598_koggenland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1621_lansingerland/graph_values.yml
+++ b/datasets/GM1621_lansingerland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1651_eemsmond/graph_values.yml
+++ b/datasets/GM1651_eemsmond/graph_values.yml
@@ -605,3 +605,7 @@ energy_heat_solar_thermal:
   demand: 0.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1655_halderberge/graph_values.yml
+++ b/datasets/GM1655_halderberge/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1663_de_marne/graph_values.yml
+++ b/datasets/GM1663_de_marne/graph_values.yml
@@ -619,3 +619,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1674_roosendaal/graph_values.yml
+++ b/datasets/GM1674_roosendaal/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1676_schouwen_duiveland/graph_values.yml
+++ b/datasets/GM1676_schouwen_duiveland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1680_aa_en_hunze/graph_values.yml
+++ b/datasets/GM1680_aa_en_hunze/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1681_borger_odoorn/graph_values.yml
+++ b/datasets/GM1681_borger_odoorn/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1690_de_wolden/graph_values.yml
+++ b/datasets/GM1690_de_wolden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1695_noord_beveland/graph_values.yml
+++ b/datasets/GM1695_noord_beveland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1696_wijdemeren/graph_values.yml
+++ b/datasets/GM1696_wijdemeren/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1699_noordenveld/graph_values.yml
+++ b/datasets/GM1699_noordenveld/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1700_twenterand/graph_values.yml
+++ b/datasets/GM1700_twenterand/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1701_westerveld/graph_values.yml
+++ b/datasets/GM1701_westerveld/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1708_steenwijkerland/graph_values.yml
+++ b/datasets/GM1708_steenwijkerland/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1709_moerdijk/graph_values.yml
+++ b/datasets/GM1709_moerdijk/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1714_sluis/graph_values.yml
+++ b/datasets/GM1714_sluis/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1719_drimmelen/graph_values.yml
+++ b/datasets/GM1719_drimmelen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1722_ferwerderadiel/graph_values.yml
+++ b/datasets/GM1722_ferwerderadiel/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1723_alphen_chaam/graph_values.yml
+++ b/datasets/GM1723_alphen_chaam/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1728_bladel/graph_values.yml
+++ b/datasets/GM1728_bladel/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1730_tynaarlo/graph_values.yml
+++ b/datasets/GM1730_tynaarlo/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1731_midden_drenthe/graph_values.yml
+++ b/datasets/GM1731_midden_drenthe/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1735_hof_van_twente/graph_values.yml
+++ b/datasets/GM1735_hof_van_twente/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1742_rijssen_holten/graph_values.yml
+++ b/datasets/GM1742_rijssen_holten/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1773_olst_wijhe/graph_values.yml
+++ b/datasets/GM1773_olst_wijhe/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1774_dinkelland/graph_values.yml
+++ b/datasets/GM1774_dinkelland/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1783_westland/graph_values.yml
+++ b/datasets/GM1783_westland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1842_midden_delfland/graph_values.yml
+++ b/datasets/GM1842_midden_delfland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1884_kaag_en_braassem/graph_values.yml
+++ b/datasets/GM1884_kaag_en_braassem/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1891_dantumadiel/graph_values.yml
+++ b/datasets/GM1891_dantumadiel/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1892_zuidplas/graph_values.yml
+++ b/datasets/GM1892_zuidplas/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1895_oldambt/graph_values.yml
+++ b/datasets/GM1895_oldambt/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1896_zwartewaterland/graph_values.yml
+++ b/datasets/GM1896_zwartewaterland/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1901_bodegraven_reeuwijk/graph_values.yml
+++ b/datasets/GM1901_bodegraven_reeuwijk/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1904_stichtse_vecht/graph_values.yml
+++ b/datasets/GM1904_stichtse_vecht/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1911_hollands_kroon/graph_values.yml
+++ b/datasets/GM1911_hollands_kroon/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1916_leidschendam_voorburg/graph_values.yml
+++ b/datasets/GM1916_leidschendam_voorburg/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1924_goeree_overflakkee/graph_values.yml
+++ b/datasets/GM1924_goeree_overflakkee/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1926_pijnacker_nootdorp/graph_values.yml
+++ b/datasets/GM1926_pijnacker_nootdorp/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1927_molenwaard/graph_values.yml
+++ b/datasets/GM1927_molenwaard/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1930_nissewaard/graph_values.yml
+++ b/datasets/GM1930_nissewaard/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1931_krimpenerwaard/graph_values.yml
+++ b/datasets/GM1931_krimpenerwaard/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1940_de_fryske_marren/graph_values.yml
+++ b/datasets/GM1940_de_fryske_marren/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1942_gooise_meren/graph_values.yml
+++ b/datasets/GM1942_gooise_meren/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1942_gooise_meren_no_highways/graph_values.yml
+++ b/datasets/GM1942_gooise_meren_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1948_meierijstad/graph_values.yml
+++ b/datasets/GM1948_meierijstad/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1950_westerwolde/graph_values.yml
+++ b/datasets/GM1950_westerwolde/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1952_midden_groningen/graph_values.yml
+++ b/datasets/GM1952_midden_groningen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1960_west_betuwe/graph_values.yml
+++ b/datasets/GM1960_west_betuwe/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1961_vijfheerenlanden/graph_values.yml
+++ b/datasets/GM1961_vijfheerenlanden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1963_hoeksche_waard/graph_values.yml
+++ b/datasets/GM1963_hoeksche_waard/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1966_het_hogeland/graph_values.yml
+++ b/datasets/GM1966_het_hogeland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/GM1978_molenlanden/graph_values.yml
+++ b/datasets/GM1978_molenlanden/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV20_groningen/graph_values.yml
+++ b/datasets/PV20_groningen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV21_friesland/graph_values.yml
+++ b/datasets/PV21_friesland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV22_drenthe/graph_values.yml
+++ b/datasets/PV22_drenthe/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV23_overijssel/graph_values.yml
+++ b/datasets/PV23_overijssel/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV24_flevoland/graph_values.yml
+++ b/datasets/PV24_flevoland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV25_gelderland/graph_values.yml
+++ b/datasets/PV25_gelderland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV26_utrecht/graph_values.yml
+++ b/datasets/PV26_utrecht/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV27_noord_holland/graph_values.yml
+++ b/datasets/PV27_noord_holland/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0004769856509884627
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV28_zuid_holland/graph_values.yml
+++ b/datasets/PV28_zuid_holland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.6116543903920708
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV29_zeeland/graph_values.yml
+++ b/datasets/PV29_zeeland/graph_values.yml
@@ -623,3 +623,7 @@ energy_heat_solar_thermal:
   demand: 0.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV30_noord_brabant/graph_values.yml
+++ b/datasets/PV30_noord_brabant/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.08239710189131064
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/PV31_limburg/graph_values.yml
+++ b/datasets/PV31_limburg/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES01_achterhoek/graph_values.yml
+++ b/datasets/RES01_achterhoek/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES02_drechtsteden/graph_values.yml
+++ b/datasets/RES02_drechtsteden/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.012016324896113517
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES03_regio_drenthe/graph_values.yml
+++ b/datasets/RES03_regio_drenthe/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES04_flevoland/graph_values.yml
+++ b/datasets/RES04_flevoland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES05_foodvalley/graph_values.yml
+++ b/datasets/RES05_foodvalley/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES06_regio_friesland/graph_values.yml
+++ b/datasets/RES06_regio_friesland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES07_goeree_overflakkee/graph_values.yml
+++ b/datasets/RES07_goeree_overflakkee/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES08_groningen/graph_values.yml
+++ b/datasets/RES08_groningen/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.5229807258428414
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES09_hart_van_brabant/graph_values.yml
+++ b/datasets/RES09_hart_van_brabant/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES10_hoeksewaard/graph_values.yml
+++ b/datasets/RES10_hoeksewaard/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES11_holland_rijnland/graph_values.yml
+++ b/datasets/RES11_holland_rijnland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES12_metropoolregio_eindhoven/graph_values.yml
+++ b/datasets/RES12_metropoolregio_eindhoven/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES13_rotterdam_denhaag/graph_values.yml
+++ b/datasets/RES13_rotterdam_denhaag/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.8458716915782949
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES14_midden_holland/graph_values.yml
+++ b/datasets/RES14_midden_holland/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES16_noord_holland_noord/graph_values.yml
+++ b/datasets/RES16_noord_holland_noord/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES17_noord_holland_zuid/graph_values.yml
+++ b/datasets/RES17_noord_holland_zuid/graph_values.yml
@@ -625,3 +625,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0001835098851999041
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES17_noord_holland_zuid_no_steel/graph_values.yml
+++ b/datasets/RES17_noord_holland_zuid_no_steel/graph_values.yml
@@ -607,3 +607,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES18_noord_veluwe/graph_values.yml
+++ b/datasets/RES18_noord_veluwe/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES19_noord_en_midden_limburg/graph_values.yml
+++ b/datasets/RES19_noord_en_midden_limburg/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES20_noord_oost_brabant/graph_values.yml
+++ b/datasets/RES20_noord_oost_brabant/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES21_alblasserwaard/graph_values.yml
+++ b/datasets/RES21_alblasserwaard/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES22_amersfoort/graph_values.yml
+++ b/datasets/RES22_amersfoort/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES23_arnhem_nijmegen/graph_values.yml
+++ b/datasets/RES23_arnhem_nijmegen/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES24_u16/graph_values.yml
+++ b/datasets/RES24_u16/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES25_rivierenland_fruitdelta/graph_values.yml
+++ b/datasets/RES25_rivierenland_fruitdelta/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES26_cleantechregio/graph_values.yml
+++ b/datasets/RES26_cleantechregio/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES27_twente/graph_values.yml
+++ b/datasets/RES27_twente/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES28_west_brabant/graph_values.yml
+++ b/datasets/RES28_west_brabant/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES29_west_overijssel/graph_values.yml
+++ b/datasets/RES29_west_overijssel/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES30_zeeland/graph_values.yml
+++ b/datasets/RES30_zeeland/graph_values.yml
@@ -623,3 +623,7 @@ energy_heat_solar_thermal:
   demand: 0.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RES31_zuid_limburg/graph_values.yml
+++ b/datasets/RES31_zuid_limburg/graph_values.yml
@@ -647,3 +647,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 0.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGGD01_groningen_drenthe/graph_values.yml
+++ b/datasets/RGGD01_groningen_drenthe/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGGR12_groningen_zonder_gemeente/graph_values.yml
+++ b/datasets/RGGR12_groningen_zonder_gemeente/graph_values.yml
@@ -627,3 +627,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNB01_west_en_midden_brabant/graph_values.yml
+++ b/datasets/RGNB01_west_en_midden_brabant/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH01_ijmond_zuid_kennemerland/graph_values.yml
+++ b/datasets/RGNH01_ijmond_zuid_kennemerland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH01_ijmond_zuid_kennemerland_no_steel/graph_values.yml
+++ b/datasets/RGNH01_ijmond_zuid_kennemerland_no_steel/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH02_zaanstreek_waterland/graph_values.yml
+++ b/datasets/RGNH02_zaanstreek_waterland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH03_gooi_en_vechtstreek/graph_values.yml
+++ b/datasets/RGNH03_gooi_en_vechtstreek/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH04_amstelland_meerlanden/graph_values.yml
+++ b/datasets/RGNH04_amstelland_meerlanden/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH04_amstelland_meerlanden_no_highways/graph_values.yml
+++ b/datasets/RGNH04_amstelland_meerlanden_no_highways/graph_values.yml
@@ -609,3 +609,7 @@ industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH05_kop_van_noord_holland/graph_values.yml
+++ b/datasets/RGNH05_kop_van_noord_holland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH06_regio_alkmaar/graph_values.yml
+++ b/datasets/RGNH06_regio_alkmaar/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH07_west_friesland/graph_values.yml
+++ b/datasets/RGNH07_west_friesland/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/RGNH08_buch_regio/graph_values.yml
+++ b/datasets/RGNH08_buch_regio/graph_values.yml
@@ -621,3 +621,7 @@ industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@co
   parent_share: 1.0
 energy_heat_distribution_loss:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/haven_stad/graph_values.yml
+++ b/datasets/haven_stad/graph_values.yml
@@ -639,3 +639,7 @@ industry_final_demand_for_metal_network_gas-industry_aluminium_burner_network_ga
   parent_share: 1.0
 industry_final_demand_for_metal_coal-industry_other_metals_burner_network_gas@coal:
   parent_share: 1.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/hengstdal/graph_values.yml
+++ b/datasets/hengstdal/graph_values.yml
@@ -427,3 +427,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_aalten/graph_values.yml
+++ b/datasets/om_aalten/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_achterhoek/graph_values.yml
+++ b/datasets/om_achterhoek/graph_values.yml
@@ -415,3 +415,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_apeldoorn/graph_values.yml
+++ b/datasets/om_apeldoorn/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_arnhem/graph_values.yml
+++ b/datasets/om_arnhem/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_barneveld/graph_values.yml
+++ b/datasets/om_barneveld/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_berg-en-dal/graph_values.yml
+++ b/datasets/om_berg-en-dal/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_berkelland/graph_values.yml
+++ b/datasets/om_berkelland/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_beuningen/graph_values.yml
+++ b/datasets/om_beuningen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_bronckhorst/graph_values.yml
+++ b/datasets/om_bronckhorst/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_brummen/graph_values.yml
+++ b/datasets/om_brummen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_buren/graph_values.yml
+++ b/datasets/om_buren/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_cleantech-regio/graph_values.yml
+++ b/datasets/om_cleantech-regio/graph_values.yml
@@ -415,3 +415,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_culemborg/graph_values.yml
+++ b/datasets/om_culemborg/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_deventer/graph_values.yml
+++ b/datasets/om_deventer/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_doesburg/graph_values.yml
+++ b/datasets/om_doesburg/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_doetinchem/graph_values.yml
+++ b/datasets/om_doetinchem/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_druten/graph_values.yml
+++ b/datasets/om_druten/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_duiven/graph_values.yml
+++ b/datasets/om_duiven/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_ede/graph_values.yml
+++ b/datasets/om_ede/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_elburg/graph_values.yml
+++ b/datasets/om_elburg/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_epe/graph_values.yml
+++ b/datasets/om_epe/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_ermelo/graph_values.yml
+++ b/datasets/om_ermelo/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_foodvalley/graph_values.yml
+++ b/datasets/om_foodvalley/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_gelderland/graph_values.yml
+++ b/datasets/om_gelderland/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_geldermalsen/graph_values.yml
+++ b/datasets/om_geldermalsen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_harderwijk/graph_values.yml
+++ b/datasets/om_harderwijk/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_hattem/graph_values.yml
+++ b/datasets/om_hattem/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_heerde/graph_values.yml
+++ b/datasets/om_heerde/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_heumen/graph_values.yml
+++ b/datasets/om_heumen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_lingewaal/graph_values.yml
+++ b/datasets/om_lingewaal/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_lingewaard/graph_values.yml
+++ b/datasets/om_lingewaard/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_lochem/graph_values.yml
+++ b/datasets/om_lochem/graph_values.yml
@@ -415,3 +415,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_maasdriel/graph_values.yml
+++ b/datasets/om_maasdriel/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_montferland/graph_values.yml
+++ b/datasets/om_montferland/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_mook-en-middelaar/graph_values.yml
+++ b/datasets/om_mook-en-middelaar/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_neder-betuwe/graph_values.yml
+++ b/datasets/om_neder-betuwe/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_neerijnen/graph_values.yml
+++ b/datasets/om_neerijnen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_nijkerk/graph_values.yml
+++ b/datasets/om_nijkerk/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_nijmegen/graph_values.yml
+++ b/datasets/om_nijmegen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_noord-veluwe/graph_values.yml
+++ b/datasets/om_noord-veluwe/graph_values.yml
@@ -415,3 +415,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_nunspeet/graph_values.yml
+++ b/datasets/om_nunspeet/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_oldebroek/graph_values.yml
+++ b/datasets/om_oldebroek/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_oost-gelre/graph_values.yml
+++ b/datasets/om_oost-gelre/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_oude-ijsselstreek/graph_values.yml
+++ b/datasets/om_oude-ijsselstreek/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_overbetuwe/graph_values.yml
+++ b/datasets/om_overbetuwe/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_putten/graph_values.yml
+++ b/datasets/om_putten/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_regio_arnhem-nijmegen/graph_values.yml
+++ b/datasets/om_regio_arnhem-nijmegen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_renkum/graph_values.yml
+++ b/datasets/om_renkum/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_renswoude/graph_values.yml
+++ b/datasets/om_renswoude/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_rheden/graph_values.yml
+++ b/datasets/om_rheden/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_rhenen/graph_values.yml
+++ b/datasets/om_rhenen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_rivierenland/graph_values.yml
+++ b/datasets/om_rivierenland/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_rozendaal/graph_values.yml
+++ b/datasets/om_rozendaal/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_scherpenzeel/graph_values.yml
+++ b/datasets/om_scherpenzeel/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_tiel/graph_values.yml
+++ b/datasets/om_tiel/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_veenendaal/graph_values.yml
+++ b/datasets/om_veenendaal/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_voorst/graph_values.yml
+++ b/datasets/om_voorst/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_wageningen/graph_values.yml
+++ b/datasets/om_wageningen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_west-maas-en-waal/graph_values.yml
+++ b/datasets/om_west-maas-en-waal/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_westervoort/graph_values.yml
+++ b/datasets/om_westervoort/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_wijchen/graph_values.yml
+++ b/datasets/om_wijchen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_winterswijk/graph_values.yml
+++ b/datasets/om_winterswijk/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_zaltbommel/graph_values.yml
+++ b/datasets/om_zaltbommel/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_zevenaar/graph_values.yml
+++ b/datasets/om_zevenaar/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/om_zutphen/graph_values.yml
+++ b/datasets/om_zutphen/graph_values.yml
@@ -417,3 +417,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/rotterdam/graph_values.yml
+++ b/datasets/rotterdam/graph_values.yml
@@ -411,3 +411,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 2117041.719243961
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/datasets/warmerwijk/graph_values.yml
+++ b/datasets/warmerwijk/graph_values.yml
@@ -607,3 +607,7 @@ energy_heat_distribution_loss:
   demand: 0.0
 industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic:
   demand: 0.0
+industry_transformation_generic_coal:
+  output:
+    :coal: 1.0
+    :loss: 0.0

--- a/nodes/buildings/buildings_solar_pv_solar_radiation.central_producer.ad
+++ b/nodes/buildings/buildings_solar_pv_solar_radiation.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = lv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.05

--- a/nodes/energy/energy_chp_combined_cycle_network_gas.central_producer.ad
+++ b/nodes/energy/energy_chp_combined_cycle_network_gas.central_producer.ad
@@ -13,7 +13,7 @@
 - heat_network.group = self: electricity_output_curve
 - heat_network.subtype = must_run
 - heat_network.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - waste_outputs = [steam_hot_water]
 - availability = 0.9
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_chp_local_engine_biogas.central_producer.ad
+++ b/nodes/energy/energy_chp_local_engine_biogas.central_producer.ad
@@ -12,7 +12,7 @@
 - heat_network.group = self: electricity_output_curve
 - heat_network.subtype = must_run
 - heat_network.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_chp_local_engine_network_gas.central_producer.ad
+++ b/nodes/energy/energy_chp_local_engine_network_gas.central_producer.ad
@@ -13,7 +13,7 @@
 - heat_network.type = producer
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_chp_local_wood_pellets.central_producer.ad
+++ b/nodes/energy/energy_chp_local_wood_pellets.central_producer.ad
@@ -11,7 +11,7 @@
 - heat_network.group = self: electricity_output_curve
 - heat_network.subtype = must_run
 - heat_network.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - waste_outputs = [steam_hot_water]
 - availability = 0.91
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_chp_supercritical_waste_mix.central_producer.ad
@@ -11,7 +11,7 @@
 - heat_network.group = self: electricity_output_curve
 - heat_network.subtype = must_run
 - heat_network.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - waste_outputs = [steam_hot_water]
 - availability = 0.9
 - free_co2_factor = 0.0

--- a/nodes/energy/energy_power_combined_cycle_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_combined_cycle_network_gas.central_producer.ad
@@ -9,7 +9,7 @@
 - merit_order.type = producer
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_engine_diesel.central_producer.ad
+++ b/nodes/energy/energy_power_engine_diesel.central_producer.ad
@@ -7,7 +7,7 @@
 - merit_order.level = hv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_hydro_river.central_producer.ad
+++ b/nodes/energy/energy_power_hydro_river.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = hv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_solar_pv_solar_radiation.central_producer.ad
+++ b/nodes/energy/energy_power_solar_pv_solar_radiation.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = hv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.05

--- a/nodes/energy/energy_power_supercritical_coal.central_producer.ad
+++ b/nodes/energy/energy_power_supercritical_coal.central_producer.ad
@@ -7,7 +7,7 @@
 - merit_order.level = hv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.89
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_supercritical_waste_mix.central_producer.ad
+++ b/nodes/energy/energy_power_supercritical_waste_mix.central_producer.ad
@@ -9,7 +9,7 @@
 - merit_order.level = hv
 - merit_order.subtype = must_run
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_turbine_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_turbine_network_gas.central_producer.ad
@@ -9,7 +9,7 @@
 - merit_order.type = producer
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_ultra_supercritical_network_gas.central_producer.ad
+++ b/nodes/energy/energy_power_ultra_supercritical_network_gas.central_producer.ad
@@ -9,7 +9,7 @@
 - merit_order.type = producer
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.9
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/energy/energy_power_wind_turbine_coastal.central_producer.ad
+++ b/nodes/energy/energy_power_wind_turbine_coastal.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = hv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.05

--- a/nodes/energy/energy_power_wind_turbine_inland.central_producer.ad
+++ b/nodes/energy/energy_power_wind_turbine_inland.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = hv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.95
 - free_co2_factor = 0.0
 - forecasting_error = 0.05

--- a/nodes/energy/energy_power_wind_turbine_offshore.central_producer.ad
+++ b/nodes/energy/energy_power_wind_turbine_offshore.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = hv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.92
 - free_co2_factor = 0.0
 - forecasting_error = 0.05

--- a/nodes/households/households_solar_pv_solar_radiation.central_producer.ad
+++ b/nodes/households/households_solar_pv_solar_radiation.central_producer.ad
@@ -8,7 +8,7 @@
 - merit_order.level = lv
 - merit_order.subtype = volatile
 - merit_order.type = producer
-- graph_methods = [demand]
+- graph_methods = [demand, full_load_hours]
 - availability = 0.98
 - free_co2_factor = 0.0
 - forecasting_error = 0.05

--- a/nodes/industry/industry_transformation_generic_coal.ad
+++ b/nodes/industry/industry_transformation_generic_coal.ad
@@ -1,6 +1,7 @@
 - use = energetic
 - energy_balance_group = coal conversion
 - output.loss = elastic
+- graph_methods = [output]
 - groups = []
 - free_co2_factor = 0.0
 

--- a/sparse_graph_queries/buildings/buildings_solar_pv_solar_radiation+full_load_hours.ad
+++ b/sparse_graph_queries/buildings/buildings_solar_pv_solar_radiation+full_load_hours.ad
@@ -1,0 +1,1 @@
+- query = DATASET_INPUT(input_solar_panels_roofs_and_parks_full_load_hours)

--- a/sparse_graph_queries/energy/electricity_production/energy_power_solar_pv_solar_radiation+full_load_hours.ad
+++ b/sparse_graph_queries/energy/electricity_production/energy_power_solar_pv_solar_radiation+full_load_hours.ad
@@ -1,0 +1,1 @@
+- query = DATASET_INPUT(input_solar_panels_roofs_and_parks_full_load_hours)

--- a/sparse_graph_queries/households/households_solar_pv_solar_radiation+full_load_hours.ad
+++ b/sparse_graph_queries/households/households_solar_pv_solar_radiation+full_load_hours.ad
@@ -1,0 +1,1 @@
+- query = DATASET_INPUT(input_solar_panels_roofs_and_parks_full_load_hours)

--- a/sparse_graph_queries/industry/industry_transformation_generic_coal+output.ad
+++ b/sparse_graph_queries/industry/industry_transformation_generic_coal+output.ad
@@ -1,0 +1,8 @@
+# this query sets the output of coal for the industry_transformation_generic_coal
+# node to 100% and thus the losses to zero. for the NL2015 data set this node has 51%
+# losses to make up for the primary demand / final demand difference of the Dutch steel
+# industry in the energy balance. these losses do not apply to other datasets.
+
+- query =
+    coal: 1.0
+    losses: 0.0


### PR DESCRIPTION
Whitelisting FLH in nodes to be able to set them via ETLocal. After merge it will be possible to set FLH for the power plants below. Goes with: https://github.com/quintel/etlocal/pull/233
![Screenshot 2020-05-27 at 16 09 53](https://user-images.githubusercontent.com/32833996/83031158-88145980-a034-11ea-8830-d7f333a0ee4b.png)

Additionally we've removed the percentage of losses in the `industry_transformation_generic_coal` node. For the NL2015 dataset this node has 51%
losses to make up for the primary demand / final demand difference of the Dutch steel industry in the energy balance. these losses do not apply to other datasets.