### PR TITLE
Electricity demand charts fixes

### DIFF
--- a/gqueries/general/merit/hv/hv_agriculture_load_curve.gql
+++ b/gqueries/general/merit/hv/hv_agriculture_load_curve.gql
@@ -1,2 +1,0 @@
-- query = V(agriculture_final_demand_electricity, electricity_input_curve)
-- unit = curve

--- a/gqueries/general/merit/hv/hv_energy_export_load_curve.gql
+++ b/gqueries/general/merit/hv/hv_energy_export_load_curve.gql
@@ -1,0 +1,6 @@
+- query =
+    SUM_CURVES(V(
+      G(electricity_interconnectors_export),
+      electricity_input_curve
+    ))
+- unit = curve

--- a/gqueries/general/merit/merit_agriculture_demand.gql
+++ b/gqueries/general/merit/merit_agriculture_demand.gql
@@ -1,2 +1,2 @@
-- query = Q(hv_agriculture_load_curve)
+- query = Q(mv_agriculture_load_curve)
 - unit = curve

--- a/gqueries/general/merit/merit_energy_export_demand.gql
+++ b/gqueries/general/merit/merit_energy_export_demand.gql
@@ -1,0 +1,2 @@
+- query = Q(hv_energy_export_load_curve)
+- unit = curve

--- a/gqueries/general/merit/mv/mv_agriculture_load_curve.gql
+++ b/gqueries/general/merit/mv/mv_agriculture_load_curve.gql
@@ -1,0 +1,8 @@
+- query =
+    SUM_CURVES(V(
+      agriculture_useful_demand_electricity,
+      agriculture_geothermal,
+      agriculture_heatpump_water_water_ts_electricity,
+      electricity_input_curve
+    ))
+- unit = curve

--- a/nodes/agriculture/agriculture_geothermal.converter.ad
+++ b/nodes/agriculture/agriculture_geothermal.converter.ad
@@ -6,6 +6,7 @@
 - presentation_group = heat_pumps
 - merit_order.group = weather/agriculture_heating
 - merit_order.type = consumer
+- merit_order.level = mv
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
+++ b/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
@@ -6,6 +6,7 @@
 - presentation_group = heat_pumps
 - merit_order.group = weather/agriculture_heating
 - merit_order.type = consumer
+- merit_order.level = mv
 - availability = 0.0
 - free_co2_factor = 0.0
 - forecasting_error = 0.0

--- a/nodes/agriculture/agriculture_useful_demand_electricity.demand.ad
+++ b/nodes/agriculture/agriculture_useful_demand_electricity.demand.ad
@@ -3,5 +3,6 @@
 - groups = [preset_demand, useful_demand, useful_demand_electric, application_group]
 - merit_order.group = agriculture_electricity
 - merit_order.type = consumer
+- merit_order.level = mv
 - free_co2_factor = 0.0
 


### PR DESCRIPTION
- Add agriculture electricity participants to MV grid (in the graph this is the case but in the queries/charts agriculture was included in HV)
- Fix agriculture query to take into account useful, geothermal and heatpump curves rather than final demand
- Add queries to add export to dynamic demand curve and HV demand curve

Goes with: https://github.com/quintel/etmodel/pull/3382
Closes: quintel/etmodel#3367

![How does the Energy Transition Model work - Welcome! - Energy Transition Model - localhost 2020-06-11 09-42-39](https://user-images.githubusercontent.com/32056448/84359567-1bb75f80-abc9-11ea-916a-8cf522e0b495.png)
