### PR TITLE
Separate demand series in electricity production chart

### DIFF
--- a/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/demand_and_export_in_source_of_electricity_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/demand_and_export_in_source_of_electricity_production.gql
@@ -1,0 +1,9 @@
+- unit = PJ
+- query =
+    SUM(
+      Q(demand_in_source_of_electricity_production),
+      DIVIDE(
+        SUM(V(GROUP(electricity_interconnectors_export), input_of_electricity)),
+        BILLIONS
+      )
+    )

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/demand_in_source_of_electricity_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/demand_in_source_of_electricity_production.gql
@@ -4,7 +4,6 @@
       SUM(
         V(GROUP(final_demand_group),input_of_electricity),
         V(GROUP(non_final_electricity_demand_converters),input_of_electricity),
-        V(GROUP(electricity_interconnectors_export),input_of_electricity),
         V(energy_power_hv_network_loss,demand)
       ),
       BILLIONS

--- a/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/future_demand_and_export_in_source_of_electricity_production.gql
+++ b/gqueries/output_elements/output_series/vertical_stacked_bar_99_source_of_electricity_production/future_demand_and_export_in_source_of_electricity_production.gql
@@ -1,0 +1,2 @@
+- unit = PJ
+- query = future:Q(demand_and_export_in_source_of_electricity_production)


### PR DESCRIPTION
Reverts the demand series to domestic demand only (excluding export) which will fix the broken MechanicalTurk test. Adds a separate series which also includes export.