### PR TITLE
Update primary production potentials for all country datasets

### DIFF
--- a/datasets/be/primary_production.csv
+++ b/datasets/be/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,1.23396300000000E+04,3.45127133733380E+04
 energy_production_non_biogenic_waste,3.01462100000000E+04,2.82375544766853E+04
-energy_production_oily_biomass,1.23396300000000E+04,3.45127133733380E+04
-energy_production_wet_biomass,1.23396300000000E+04,3.45127133733380E+04
-energy_production_dry_biomass,,0.00000000000000E+00
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,0.0,2551

--- a/datasets/br/primary_production.csv
+++ b/datasets/br/primary_production.csv
@@ -4,4 +4,4 @@ energy_production_biogenic_waste,0.00000000000000E+00,0.00000000000000E+00
 energy_production_non_biogenic_waste,0.00000000000000E+00,0.00000000000000E+00
 energy_production_oily_biomass,0.00000000000000E+00,0.00000000000000E+00
 energy_production_wet_biomass,0.00000000000000E+00,0.00000000000000E+00
-energy_production_dry_biomass,,6.32534160100000E+04
+energy_production_dry_biomass,,1271966

--- a/datasets/de/primary_production.csv
+++ b/datasets/de/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,1.25359990000000E+05,1.78379329489559E+05
 energy_production_non_biogenic_waste,1.78019010000000E+05,2.53309781216440E+05
-energy_production_oily_biomass,1.78019010000000E+05,2.53309781216440E+05
-energy_production_wet_biomass,1.78019010000000E+05,2.53309781216440E+05
-energy_production_dry_biomass,,8.56300460320886E+05
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,,92315.45

--- a/datasets/dk/primary_production.csv
+++ b/datasets/dk/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,1.89440100000000E+04,1.95500000000000E+04
 energy_production_non_biogenic_waste,1.54999900000000E+04,1.59950000000000E+04
-energy_production_oily_biomass,1.54999900000000E+04,1.59950000000000E+04
-energy_production_wet_biomass,1.54999900000000E+04,1.59950000000000E+04
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
 energy_production_dry_biomass,,6.59430000000000E+04

--- a/datasets/es/primary_production.csv
+++ b/datasets/es/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,7.35357000000000E+03,5.59930000000000E+04
 energy_production_non_biogenic_waste,7.35357000000000E+03,5.59930000000000E+04
-energy_production_oily_biomass,7.35357000000000E+03,5.59930000000000E+04
-energy_production_wet_biomass,7.35357000000000E+03,5.59930000000000E+04
-energy_production_dry_biomass,,2.76816826805760E+05
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,0.0,34309

--- a/datasets/eu/primary_production.csv
+++ b/datasets/eu/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,3.55857610000000E+05,1.07913100000000E+06
 energy_production_non_biogenic_waste,5.71304180000000E+05,1.73246800000000E+06
-energy_production_oily_biomass,5.71304180000000E+05,1.73246800000000E+06
-energy_production_wet_biomass,5.71304180000000E+05,1.73246800000000E+06
-energy_production_dry_biomass,,4.46236791441408E+06
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,0.0,821802

--- a/datasets/fr/primary_production.csv
+++ b/datasets/fr/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,5.28148500000000E+04,1.02035000000000E+05
 energy_production_non_biogenic_waste,5.28148500000000E+04,1.02035000000000E+05
-energy_production_oily_biomass,5.28148500000000E+04,1.02035000000000E+05
-energy_production_wet_biomass,5.28148500000000E+04,1.02035000000000E+05
-energy_production_dry_biomass,,5.82942025657440E+05
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,0.0,231286

--- a/datasets/pl/primary_production.csv
+++ b/datasets/pl/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,1.35975000000000E+03,1.07000000000000E+05
 energy_production_non_biogenic_waste,2.53811400000000E+04,1.07000000000000E+05
-energy_production_oily_biomass,2.53811400000000E+04,1.07000000000000E+05
-energy_production_wet_biomass,2.53811400000000E+04,1.07000000000000E+05
-energy_production_dry_biomass,,3.04903455442560E+05
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,0.0,44365

--- a/datasets/uk/primary_production.csv
+++ b/datasets/uk/primary_production.csv
@@ -2,6 +2,6 @@ key,demand,max_demand
 energy_distribution_greengas,4.06285142857140E+03,
 energy_production_biogenic_waste,3.24237500000000E+04,1.40483000000000E+05
 energy_production_non_biogenic_waste,3.19548700000000E+04,1.38451000000000E+05
-energy_production_oily_biomass,3.19548700000000E+04,1.38451000000000E+05
-energy_production_wet_biomass,3.19548700000000E+04,1.38451000000000E+05
-energy_production_dry_biomass,,1.31891376175200E+05
+energy_production_oily_biomass,0.0,0.0
+energy_production_wet_biomass,0.0,0.0
+energy_production_dry_biomass,0.0,11718


### PR DESCRIPTION
For the NL datasets we have information about biomass potentials (TNO). However, for all other countries we do not. Therefore we replace currenty dummy values and set the potentials to zero in all datasets.  In this way we do not give false information and this does not limit the user's possibilities:

Goes with https://github.com/quintel/etdataset/pull/850