### PR TITLE
Change imported heat CO2 input statement

### DIFF
--- a/inputs/supply/heat/energy/co2_emissions_of_imported_heat.ad
+++ b/inputs/supply/heat/energy/co2_emissions_of_imported_heat.ad
@@ -1,15 +1,11 @@
-# The co2_conversion_per_mj is defined in the FCE-module can only be updated by
-# updating shares. Therefore, we have to calculate the shares of renewable heat
-# (0 kg/GJ) and fossil heat (100 kg/GJ) and then update the FCE.
-# NOTE: when updating the slider-max the share calculation should also be updated.
-
 - query =
-    share_fossil_heat = USER_INPUT() / 100.0;
-    share_renewable_heat = 1 - share_fossil_heat;
-
-    EACH(
-      UPDATE_FCE(CARRIER(imported_heat), renewable_heat, share_renewable_heat),
-      UPDATE_FCE(CARRIER(imported_heat), fossil_heat, share_fossil_heat)
+    UPDATE(
+      EDGE(
+        energy_distribution_imported_heat,
+        energy_import_heat
+      ),
+      co2_per_mj,
+      DIVIDE(USER_INPUT(), THOUSANDS)
     )
 - priority = 0
 - max_value = 100.0


### PR DESCRIPTION
The previous statement updated the fossil_heat and renewable_heat properties of the imported_heat.yml FCE file. Since the names of these properties are not necessarily the same across datasets, the CO2 of datasets with differently named properties would not update.

This commit changes the input statement to a similar approach as the imported electricity CO2 input based on node/edge names, making it more robust than the previous approach.

Closes quintel/etmodel#3457