### PR TITLE
Fix CCUS transport sliders

### DIFF
--- a/inputs/supply/ccus/transport/share_of_molecules_transport_pipelines_co2.ad
+++ b/inputs/supply/ccus/transport/share_of_molecules_transport_pipelines_co2.ad
@@ -1,5 +1,5 @@
 - query =
-    UPDATE(EDGE(molecules_transport_pipelines_co2,molecules_distribution_after_transport_co2), share, DIVIDE(USER_INPUT(),100))
+    UPDATE(MEDGE(molecules_transport_pipelines_co2,molecules_distribution_after_transport_co2), share, DIVIDE(USER_INPUT(),100))
 - share_group = carbon_transport
 - priority = 0
 - max_value = 100.0

--- a/inputs/supply/ccus/transport/share_of_molecules_transport_ships_co2.ad
+++ b/inputs/supply/ccus/transport/share_of_molecules_transport_ships_co2.ad
@@ -1,5 +1,5 @@
 - query =
-    UPDATE(EDGE(molecules_transport_ships_co2,molecules_distribution_after_transport_co2), share, DIVIDE(USER_INPUT(),100))
+    UPDATE(MEDGE(molecules_transport_ships_co2,molecules_distribution_after_transport_co2), share, DIVIDE(USER_INPUT(),100))
 - share_group = carbon_transport
 - priority = 0
 - max_value = 100.0


### PR DESCRIPTION
Input statement used EDGE instead of MEDGE (for manipulating the molecule graph).

Closes quintel/etmodel#3481