### PR TITLE
Remove co2_conversion_per_mj from network gas carrier and use hard-coded factor for from_energy.conversion.network_gas

### DIFF
--- a/carriers/network_gas.ad
+++ b/carriers/network_gas.ad
@@ -1,3 +1,2 @@
 - sustainable = 0.0
 - infinite = false
-- co2_conversion_per_mj = 0.0564

--- a/graphs/molecules/nodes/energy/energy_power_combined_cycle_ccs_network_gas_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_power_combined_cycle_ccs_network_gas_co2.ad
@@ -1,4 +1,4 @@
 - from_energy.source = energy_power_combined_cycle_ccs_network_gas
 - from_energy.direction = input
-- from_energy.conversion.network_gas = carrier: co2_conversion_per_mj
+- from_energy.conversion.network_gas = 0.0564
 - input.co2 = 1.0

--- a/graphs/molecules/nodes/industry/industry_final_demand_for_chemical_fertilizers_network_gas_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_final_demand_for_chemical_fertilizers_network_gas_co2.ad
@@ -1,4 +1,4 @@
 - from_energy.source = industry_final_demand_for_chemical_fertilizers_network_gas
 - from_energy.direction = input
-- from_energy.conversion.network_gas = carrier: co2_conversion_per_mj
+- from_energy.conversion.network_gas = 0.0564
 - input.co2 = 1.0

--- a/graphs/molecules/nodes/industry/industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2.ad
@@ -1,7 +1,7 @@
 - groups = [emitted_non_energetic_emissions_industry]
 - from_energy.source = industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic
 - from_energy.direction = input
-- from_energy.conversion.network_gas = carrier: co2_conversion_per_mj
+- from_energy.conversion.network_gas = 0.0564
 - input.co2 = 1.0
 
 ~ demand = DEMAND(fertilizers_ccus_demands, industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2)

--- a/graphs/molecules/nodes/industry/industry_final_demand_for_other_food_network_gas_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_final_demand_for_other_food_network_gas_co2.ad
@@ -1,4 +1,4 @@
 - from_energy.source = industry_final_demand_for_other_food_network_gas
 - from_energy.direction = input
-- from_energy.conversion.network_gas = carrier: co2_conversion_per_mj
+- from_energy.conversion.network_gas = 0.0564
 - input.co2 = 1.0

--- a/graphs/molecules/nodes/industry/industry_final_demand_for_other_paper_network_gas_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_final_demand_for_other_paper_network_gas_co2.ad
@@ -1,4 +1,4 @@
 - from_energy.source = industry_final_demand_for_other_paper_network_gas
 - from_energy.direction = input
-- from_energy.conversion.network_gas = carrier: co2_conversion_per_mj
+- from_energy.conversion.network_gas = 0.0564
 - input.co2 = 1.0

--- a/graphs/molecules/nodes/industry/industry_steel_electricfurnace_burner_network_gas_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_electricfurnace_burner_network_gas_co2.ad
@@ -1,4 +1,4 @@
 - from_energy.source = industry_steel_electricfurnace_burner_network_gas
 - from_energy.direction = input
-- from_energy.conversion.network_gas = carrier: co2_conversion_per_mj
+- from_energy.conversion.network_gas = 0.0564
 - input.co2 = 1.0


### PR DESCRIPTION
Setting co2_conversion_per_mj on the network_gas carrier resulted in unintended side effects, e.g. increasing green gas no longer decreases the weighted_carrier_co2_per_mj of network gas. This again affects the amount of CO2 credits gas power plants have to pay and hence their position in the merit order.

This commit removes the co2_conversion_per_mj attribute from the network_gas carrier file. Molecule nodes using `from_energy.conversion.network_gas = carrier: co2_conversion_per_mj` now use a hard-coded conversion factor of methane (0.0564).

In the future, we may want to explore adding separate methods for on-the-spot emissions (including bio emissions) and IPCC emissions (relevant for CO2 credits).

Notifying @Charlottevm 