### PR TITLE
Include emissions of exported electricity in the 'domestic' emissions dashboard item

### DIFF
--- a/gqueries/general/co2/co2_emissions_of_final_demand_excluding_energy_produced_abroad.gql
+++ b/gqueries/general/co2/co2_emissions_of_final_demand_excluding_energy_produced_abroad.gql
@@ -1,3 +1,3 @@
 - query =
-    Q(total_co2_emissions) - Q(co2_emissions_of_energy_produced_abroad)
+    Q(total_co2_emissions) + Q(co2_emissions_of_exported_electricity) - Q(co2_emissions_of_energy_produced_abroad)
 - unit = kg


### PR DESCRIPTION
This dashboard item should show all emissions taking place in the area, excluding production/fuel chain emissions of imported carriers.