### PR TITLE
Missing nodes for total electricity demand

### DIFF
--- a/gqueries/general/merit/hv/hv_industry_other_load_curve.gql
+++ b/gqueries/general/merit/hv/hv_industry_other_load_curve.gql
@@ -4,8 +4,10 @@
       industry_final_demand_for_other_non_specified_electricity,
       industry_useful_demand_for_other_paper_electricity,
       industry_other_paper_captured_co2_electricity,
+      industry_other_paper_heater_electricity,
       industry_useful_demand_for_other_food_electricity,
       industry_other_food_captured_co2_electricity,
+      industry_other_food_heater_electricity,
       industry_final_demand_for_other_ict_electricity,
       electricity_input_curve
     ))


### PR DESCRIPTION
For the 'Industry - Other' sector two nodes were missing from the query that determines the electricity demand, specifically for the food and paper industry. This caused the total electricity demand line in the graphs to 'float' above the total demand from the sectors. By adding these two nodes the total demand line and the total demand from the sectors align.