### PR TITLE
Additional outdated queries found and removed for etmodel #3517

### DIFF
--- a/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/geothermal_used_for_heating_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_56_heat_production_in_households/geothermal_used_for_heating_in_households.gql
@@ -1,7 +1,0 @@
-# Use of carrier group 'geothermal' in housholds heat
-
-- unit = PJ
-- query =
-    SUM(
-      V(Q(individual_heating_converters_in_households), input_of_geothermal)
-    ) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/geothermal_used_for_hot_water_in_households.gql
+++ b/gqueries/output_elements/output_series/bezier_65_source_of_hot_water_in_households/geothermal_used_for_hot_water_in_households.gql
@@ -1,7 +1,0 @@
-# Use of carrier group 'geothermal' in housholds hot water
-
-- unit = PJ
-- query =
-    SUM(
-      V(Q(hot_water_converters_in_households), input_of_geothermal)
-    ) / BILLIONS


### PR DESCRIPTION
The gquery geothermal_used_for_hot_water_in_households geothermal_used_for_heating_in_households are outdated since geothermal heat has been coupled to the heat network, instead of directly to the households. This issue was already addressed in etmodel pull request #3517, but these queries has not yet been deleted.