### PR TITLE
Added technical and financial properties for pumped storage

### DIFF
--- a/graphs/energy/nodes/energy/energy_flexibility_pumped_storage_electricity.converter.ad
+++ b/graphs/energy/nodes/energy/energy_flexibility_pumped_storage_electricity.converter.ad
@@ -3,6 +3,7 @@
 - output.electricity = 0.80
 - output.loss = elastic
 - groups = [cost_flexibility, hv_net_flexibility, p2p, wacc_proven_tech]
+- presentation_group = p2p
 - merit_order.group = pumped_storage
 - merit_order.level = hv
 - merit_order.subtype = storage


### PR DESCRIPTION
As part of etmodel pull request #3547 the descriptions of the electricity storage sliders have been updated. For pumped storage, no technical and financial properties were present, so these have been added. To properly show the data, the presentation group p2p had to be added to the node source file in etsource.