### PR TITLE
User curve fixes

### DIFF
--- a/config/user_curves.yml
+++ b/config/user_curves.yml
@@ -180,13 +180,14 @@ network_gas_import:
   type: profile
   display_group: gas_import_export
 
-solar_pv:
+weather/solar_pv_profile_1:
   type: profile
   display_group: electricity_production
   reduce:
     as: full_load_hours
     sets:
       - flh_of_solar_pv_solar_radiation
+      - flh_of_solar_pv_solar_radiation_user_curve
 
 weather/solar_thermal:
   type: profile
@@ -212,34 +213,29 @@ river:
     sets:
       - flh_of_hydro_river
 
-wind_offshore:
+weather/wind_offshore_baseline:
   type: profile
   display_group: electricity_production
   reduce:
     as: full_load_hours
     sets:
       - flh_of_energy_power_wind_turbine_offshore
+      - flh_of_energy_power_wind_turbine_offshore_user_curve
 
-wind_coastal:
+weather/wind_coastal_baseline:
   type: profile
   display_group: electricity_production
   reduce:
     as: full_load_hours
     sets:
       - flh_of_energy_power_wind_turbine_coastal
+      - flh_of_energy_power_wind_turbine_coastal_user_curve
 
-wind_inland:
+weather/wind_inland_baseline:
   type: profile
   display_group: electricity_production
   reduce:
     as: full_load_hours
     sets:
       - flh_of_energy_power_wind_turbine_inland
-
-weather/air_temperature:
-  type: temperature
-  display_group: weather
-  reduce:
-    as: temperature
-    sets:
-      - flexibility_outdoor_temperature
+      - flh_of_energy_power_wind_turbine_inland_user_curve

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal.ad
@@ -3,6 +3,9 @@
 # to prevent ETEngine from calculating a new (lower) NoU.
 #
 # See https://github.com/quintel/etmodel/issues/2906
+#
+# Note: When updating this input statement, please update
+# flh_of_energy_power_wind_turbine_coastal_user_curve as well!
 - query =
     IF(
       EQUALS(AREA(weather_curve_set), "default"),

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal.ad
@@ -24,7 +24,7 @@
       },
       -> {},
     )
-- priority = 1
+- priority = 3
 - max_value = 4500.0
 - min_value_gql = present:V(energy_power_wind_turbine_coastal, full_load_hours)
 - start_value_gql = present:V(energy_power_wind_turbine_coastal, full_load_hours)

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal_user_curve.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_coastal_user_curve.ad
@@ -1,0 +1,21 @@
+# This input is closely linked with flh_of_energy_power_wind_turbine_coastal
+# It is used when a custom curve is uploaded by the user. In contrast with
+# flh_of_energy_power_wind_turbine_coastal it runs regardless of the chosen
+# weather year.
+- query =
+    original_nou = V(energy_power_wind_turbine_coastal, number_of_units);
+    EACH(
+      UPDATE(V(energy_power_wind_turbine_coastal), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_power_wind_turbine_coastal), number_of_units, original_nou),
+      UPDATE(
+        V(energy_power_wind_turbine_coastal),
+        preset_demand_by_electricity_production,
+        V(energy_power_wind_turbine_coastal, production_based_on_number_of_units)
+      )
+    )
+- priority = 1
+- max_value = 8760.0
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_wind_turbine_coastal, full_load_hours)
+- unit = hours
+- update_period = future

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland.ad
@@ -24,7 +24,7 @@
       },
       -> {}
     )
-- priority = 1
+- priority = 3
 - max_value = 3500.0
 - min_value_gql = present:V(energy_power_wind_turbine_inland, full_load_hours)
 - start_value_gql = present:V(energy_power_wind_turbine_inland, full_load_hours)

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland.ad
@@ -3,6 +3,9 @@
 # to prevent ETEngine from calculating a new (lower) NoU.
 #
 # See https://github.com/quintel/etmodel/issues/2906
+#
+# Note: When updating this input statement, please update
+# flh_of_energy_power_wind_turbine_inland_user_curve as well!
 - query =
     IF(
       EQUALS(AREA(weather_curve_set), "default"),

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland_user_curve.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_inland_user_curve.ad
@@ -1,0 +1,21 @@
+# This input is closely linked with flh_of_energy_power_wind_turbine_inland
+# It is used when a custom curve is uploaded by the user. In contrast with
+# flh_of_energy_power_wind_turbine_inland it runs regardless of the chosen
+# weather year.
+- query =
+    original_nou = V(energy_power_wind_turbine_inland, number_of_units);
+    EACH(
+      UPDATE(V(energy_power_wind_turbine_inland), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_power_wind_turbine_inland), number_of_units, original_nou),
+      UPDATE(
+        V(energy_power_wind_turbine_inland),
+        preset_demand_by_electricity_production,
+        V(energy_power_wind_turbine_inland, production_based_on_number_of_units)
+      )
+    )
+- priority = 1
+- max_value = 8760.0
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_wind_turbine_inland, full_load_hours)
+- unit = hours
+- update_period = future

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore.ad
@@ -3,6 +3,9 @@
 # to prevent ETEngine from calculating a new (lower) NoU.
 #
 # See https://github.com/quintel/etmodel/issues/2906
+#
+# Note: When updating this input statement, please update
+# flh_of_energy_power_wind_turbine_offshore_user_curve as well!
 - query =
     IF(
       EQUALS(AREA(weather_curve_set), "default"),

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore.ad
@@ -24,7 +24,7 @@
       },
       -> {}
     )
-- priority = 1
+- priority = 3
 - max_value = 6500.0
 - min_value_gql = present:V(energy_power_wind_turbine_offshore, full_load_hours)
 - start_value_gql = present:V(energy_power_wind_turbine_offshore, full_load_hours)

--- a/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore_user_curve.ad
+++ b/inputs/full_load_hours/flh_of_energy_power_wind_turbine_offshore_user_curve.ad
@@ -1,0 +1,22 @@
+# This input is closely linked with flh_of_energy_power_wind_turbine_offshore
+# It is used when a custom curve is uploaded by the user. In contrast with
+# flh_of_energy_power_wind_turbine_offshore it runs regardless of the chosen
+# weather year.
+
+- query =
+    original_nou = V(energy_power_wind_turbine_offshore, number_of_units);
+    EACH(
+      UPDATE(V(energy_power_wind_turbine_offshore), full_load_hours, USER_INPUT()),
+      UPDATE(V(energy_power_wind_turbine_offshore), number_of_units, original_nou),
+      UPDATE(
+        V(energy_power_wind_turbine_offshore),
+        preset_demand_by_electricity_production,
+        V(energy_power_wind_turbine_offshore, production_based_on_number_of_units)
+      )
+    )
+- priority = 1
+- max_value = 8760.0
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_wind_turbine_offshore, full_load_hours)
+- unit = hours
+- update_period = future

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
@@ -32,7 +32,7 @@
       },
       -> {}
     )
-- priority = 1
+- priority = 3
 - max_value_gql = present:AREA(flh_solar_pv_solar_radiation_max)
 - min_value_gql = present:V(energy_power_solar_pv_solar_radiation, full_load_hours)
 - start_value_gql = present:V(energy_power_solar_pv_solar_radiation, full_load_hours)

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation_user_curve.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation_user_curve.ad
@@ -1,0 +1,28 @@
+# This input is closely linked with flh_of_solar_pv_solar_radiation
+# It is used when a custom curve is uploaded by the user. In contrast with
+# flh_of_solar_pv_solar_radiation it runs regardless of the chosen
+# weather year. In addition, it sets solar_pv_profile_1_share to 1.0
+# to prevent interpolation.
+
+- query =
+    original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+    EACH(
+        UPDATE(V(energy_power_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
+        UPDATE(V(energy_hydrogen_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
+        UPDATE(V(buildings_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
+        UPDATE(V(households_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
+        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, original_nou),
+        UPDATE(
+        V(energy_power_solar_pv_solar_radiation),
+        preset_demand_by_electricity_production,
+        V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
+        ),
+        UPDATE(AREA(), solar_pv_profile_1_share, 1.0),
+        UPDATE(AREA(), solar_pv_profile_2_share, 0.0)
+    )
+- priority = 1
+- max_value = 8760.0
+- min_value = 0.0
+- start_value_gql = present:V(energy_power_solar_pv_solar_radiation, full_load_hours)
+- unit = hours
+- update_period = future


### PR DESCRIPTION
* Add custom FLH inputs for solar and wind that can be set regardless of the selected weather year. For solar, the `solar_pv_profile_1_share` is set to 1 to prevent interpolation
Question: do we have to make sure that the custom solar FLH input is applied after the regular one? To make sure `solar_pv_profile_1_share` is always set to 1?

* Update the curve config file to set both the original FLH sliders for wind and solar and the new custom inputs. The former is included in order to disable it, the latter to correctly update the FLHs/prevent interpolation

* Use `solar_pv_profile_1` rather than `solar_pv`. Idem for `wind_inland_baseline` vs. `wind_inland`. Same for coastal and offshore. I think this is the reason these curves were not updated correctly.

