### PR TITLE
Update energy use of domestic navigation (inland shipping) technologies

### DIFF
--- a/graphs/energy/nodes/transport/transport_ship_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_diesel_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = technologies
-- output.freight_tonne_kms = 1.0115635994646872
+- output.freight_tonne_kms = 3.17460317460317
 - output.loss = elastic
 - groups = [application_group, freight_transport]
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_ship_using_lng_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_lng_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - energy_balance_group = technologies
-- output.freight_tonne_kms = 0.9779009172859809
+- output.freight_tonne_kms = 3.17460317460317
 - output.loss = elastic
 - groups = [application_group, freight_transport]
 - free_co2_factor = 0.0


### PR DESCRIPTION
The energy use of domestic navigation technologies has been updated as part of etdataset issue #859 (see also etdataset pull request #860). The corresponding converter nodes `transport_ship_using_diesl_mix` and `transport_ship_using_lng_mix` have been updated in ETSource accordingly.