### PR TITLE
Add electricity output capacity to car using electricity

### DIFF
--- a/graphs/energy/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_electricity.converter.ad
@@ -17,6 +17,7 @@
 - part_load_efficiency_penalty = 0.0
 - part_load_operating_point = 0.0
 - typical_input_capacity = 0.0037
+- electricity_output_capacity = 0.0037
 - initial_investment = 0.0
 - ccs_investment = 0.0
 - cost_of_installing = 0.0


### PR DESCRIPTION
For the storage of electricity in electric vehicles (`transport_car_using_electricity`) no output electricity capacity was indicated. The consequence of this was that the output capacity was set automatically: the input capacity multiplied by the electricity output of 87%. 

For storage technologies the efficiency should only affect the energy **volume** that is extracted relative to the energy **volume** that was put into the storage technology. Both the input capacity and output capacity should be defined separately and independently from the efficiency.

For all other storage technologies the capacities have been properly defined in a recent update. This pull request adds the electricity output capacity for electricity storage in electric vehicles. The electricity output capacity is assumed to be equal to the input capacity, since this is also the case for household batteries. A separate issue will be created to indicate the need for a more structural update of both the `transport_car_using_electricity` and `transport_car_flexibility_p2p_electricity` nodes and corresponding datasets.

@antw can you verify that this addition does not affect the calculations for transport demand?