### PR TITLE
Fix free_co2, final_demand and application for industry non-energetic gas nodes

### DIFF
--- a/graphs/energy/nodes/energy/energy_offshore_sequestration_co2_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_offshore_sequestration_co2_electricity.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [preset_demand, final_demand_group, co2_emissions_primary]
+- groups = [preset_demand, final_demand_group, co2_emissions_primary, application_group]
 - merit_order.group = flat
 - merit_order.type = consumer
 - merit_order.level = mv

--- a/graphs/energy/nodes/energy/energy_production_synthetic_methanol.ad
+++ b/graphs/energy/nodes/energy/energy_production_synthetic_methanol.ad
@@ -3,7 +3,7 @@
 - output.methanol = 1.0
 - input.hydrogen = 1.22
 - input.electricity = 0.05
-- groups = [preset_demand, cost_ccus, wacc_unproven_tech]
+- groups = [preset_demand, cost_ccus, wacc_unproven_tech, application_group]
 - free_co2_factor = 0.0
 - full_load_hours = 8322
 - land_use_per_unit = 0.0

--- a/graphs/energy/nodes/industry/industry_final_demand_coal_non_energetic.final_demand.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_coal_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use]
+- groups = [final_demand_group, non_energetic_use, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_fertilizers_crude_oil_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_fertilizers_crude_oil_non_energetic.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [final_demand_group,chemical_industry, fertilizers_industry]
+- groups = [final_demand_group,chemical_industry, fertilizers_industry, co2_emissions_primary]
 - free_co2_factor = 1.0

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_fertilizers_hydrogen_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_fertilizers_hydrogen_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [chemical_industry, fertilizers_industry]
+- groups = [chemical_industry, fertilizers_industry, application_group]
 - hydrogen.profile = flat
 - hydrogen.type = consumer
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [chemical_industry, fertilizers_industry, co2_emissions_primary]
+- groups = [chemical_industry, fertilizers_industry, co2_emissions_primary, final_demand_group]
 - free_co2_factor = 0.0
 - network_gas.profile = flat
 - network_gas.type = consumer

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_other_crude_oil_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_other_crude_oil_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [final_demand_group, chemical_industry, other_chemical_industry]
+- groups = [final_demand_group, chemical_industry, other_chemical_industry, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_other_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_other_network_gas_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [chemical_industry, other_chemical_industry]
+- groups = [chemical_industry, other_chemical_industry, final_demand_group]
 - free_co2_factor = 1.0
 - network_gas.profile = flat
 - network_gas.type = consumer

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_other_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_other_network_gas_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [chemical_industry, other_chemical_industry, final_demand_group]
+- groups = [chemical_industry, other_chemical_industry, final_demand_group, co2_emissions_primary]
 - free_co2_factor = 1.0
 - network_gas.profile = flat
 - network_gas.type = consumer

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_refineries_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_refineries_network_gas_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [chemical_industry, refineries_industry, final_demand_group]
+- groups = [chemical_industry, refineries_industry, final_demand_group, co2_emissions_primary]
 - free_co2_factor = 1.0
 - network_gas.profile = flat
 - network_gas.type = consumer

--- a/graphs/energy/nodes/industry/industry_final_demand_for_chemical_refineries_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_chemical_refineries_network_gas_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [chemical_industry, refineries_industry]
+- groups = [chemical_industry, refineries_industry, final_demand_group]
 - free_co2_factor = 1.0
 - network_gas.profile = flat
 - network_gas.type = consumer

--- a/graphs/energy/nodes/industry/industry_final_demand_for_other_crude_oil_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_other_crude_oil_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [final_demand_group, other_industry, non_energetic_use]
+- groups = [final_demand_group, co2_emissions_primary, other_industry, non_energetic_use]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 

--- a/graphs/energy/nodes/industry/industry_final_demand_for_other_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_other_network_gas_non_energetic.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [other_industry]
+- groups = [other_industry, final_demand_group]
 - free_co2_factor = 1.0

--- a/graphs/energy/nodes/industry/industry_final_demand_for_other_network_gas_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_for_other_network_gas_non_energetic.ad
@@ -1,4 +1,4 @@
 - use = non_energetic
 - energy_balance_group = application
-- groups = [other_industry, final_demand_group]
+- groups = [other_industry, final_demand_group, co2_emissions_primary]
 - free_co2_factor = 1.0

--- a/graphs/energy/nodes/industry/industry_final_demand_hydrogen_non_energetic.final_demand.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_hydrogen_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use, application_group, co2_emissions_primary]
+- groups = [final_demand_group, non_energetic_use, co2_emissions_primary]
 - graph_methods = [demand]
 - free_co2_factor = 0.0
 ~ demand = 0

--- a/graphs/energy/nodes/industry/industry_final_demand_network_gas_non_energetic.final_demand.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_network_gas_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use]
+- groups = [non_energetic_use]
 - graph_methods = [demand]
 
 ~ demand =

--- a/graphs/energy/nodes/industry/industry_final_demand_wood_pellets_non_energetic.final_demand.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_wood_pellets_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use]
+- groups = [final_demand_group, co2_emissions_primary, non_energetic_use]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_chemical_fertilizers_network_gas_non_energetic.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_chemical_fertilizers_network_gas_non_energetic.demand.ad
@@ -1,4 +1,3 @@
 - use = non_energetic
 - energy_balance_group = application
 - groups = [non_energetic_use, useful_demand, useful_demand_non_energetic, chemical_industry, fertilizers_industry, application_group]
-- free_co2_factor = 1.0

--- a/graphs/energy/nodes/other/other_final_demand_crude_oil_non_energetic.final_demand.ad
+++ b/graphs/energy/nodes/other/other_final_demand_crude_oil_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use]
+- groups = [final_demand_group, co2_emissions_primary, non_energetic_use]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 

--- a/graphs/energy/nodes/transport/transport_final_demand_crude_oil_non_energetic.final_demand.ad
+++ b/graphs/energy/nodes/transport/transport_final_demand_crude_oil_non_energetic.final_demand.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - energy_balance_group = final consumption
-- groups = [final_demand_group, non_energetic_use, freight_transport]
+- groups = [final_demand_group, co2_emissions_primary, non_energetic_use, freight_transport]
 - graph_methods = [demand]
 - free_co2_factor = 1.0
 


### PR DESCRIPTION
The primary CO2 of the final_demand_group and application_group should be the same.

This wasn't the case because industry_final_demand_network_gas_non_energetic was in the final_demand_group (which has free_co2_factor = 0) whereas only part of the non-energetic gas application nodes have free_co2_factor = 0. I.e. industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic has free_co2_factor = 0 because it is included in the CO2 calculation. The other non-energetic gas nodes have free_co2_factor = 1 because they are not (yet) included in the CO2 calculation.

The result was that the primary_co2_emission of industry_final_demand_network_gas_non_energetic is higher than the primary_co2_emission of its child nodes.

This commit removes industry_final_demand_network_gas_non_energetic from the final_demand_group and instead includes its child nodes.

As an added benefit, this also means co2_emissions_primary and final_demand_group are aligned again (previously industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic was in the co2_emissions_primary group because it is included in the CO2 calculation, whereas industry_final_demand_network_gas_non_energetic was in the final demand group).