### PR TITLE
Remove duplicate lignite query from co2 of electricity production

### DIFF
--- a/gqueries/general/converter_groups/electricity_producing_coal_converters.gql
+++ b/gqueries/general/converter_groups/electricity_producing_coal_converters.gql
@@ -1,7 +1,7 @@
 - query =
     FILTER(
       G(electricity_production),
-      "coal_input_conversion > 0 || lignite_input_conversion > 0"
+      "coal_input_conversion > 0"
     )
 - unit = nodes
 - deprecated_key = coal_plants

--- a/gqueries/general/converter_groups/electricity_producing_converters.gql
+++ b/gqueries/general/converter_groups/electricity_producing_converters.gql
@@ -3,6 +3,7 @@
 - query =
     V(
       Q(electricity_producing_coal_converters),
+      Q(electricity_producing_lignite_converters),
       Q(electricity_producing_oil_converters),
       Q(electricity_producing_gas_converters),
       Q(electricity_producing_nuclear_converters),

--- a/gqueries/general/converter_groups/electricity_producing_lignite_converters.gql
+++ b/gqueries/general/converter_groups/electricity_producing_lignite_converters.gql
@@ -1,13 +1,7 @@
-# Returns the converters which produce electricity using lignite.
-#
-# It works by looking to converters directly fed by the "Lignite distribution" converter that have output of electricity.
-
 - query =
-    V(
     FILTER(
-      V(
-        PARENTS(V(energy_distribution_lignite))
-        ), "electricity_output_conversion && electricity_output_conversion > 0")
+      G(electricity_production),
+      "lignite_input_conversion > 0"
     )
 - unit = nodes
 - deprecated_key = electricity_producing_converters_lignite

--- a/gqueries/general/converter_groups/electricity_producing_other_converters.gql
+++ b/gqueries/general/converter_groups/electricity_producing_other_converters.gql
@@ -3,6 +3,7 @@
       G(electricity_production),
       V(
         Q(electricity_producing_coal_converters),
+        Q(electricity_producing_lignite_converters),
         Q(electricity_producing_oil_converters),
         Q(electricity_producing_gas_converters),
         Q(electricity_producing_nuclear_converters),

--- a/gqueries/general/converter_groups/electricity_producing_torrefied_biomass_pellets_converters.gql
+++ b/gqueries/general/converter_groups/electricity_producing_torrefied_biomass_pellets_converters.gql
@@ -1,14 +1,7 @@
-# Returns the converters which produce electricity using torrefied_biomass_pellets.
-#
-# It works by looking to converters directly fed by the "biocoal distribution" converter that have output of electricity.
-
 - query =
-    V(
     FILTER(
-      V(
-        PARENTS(V(energy_distribution_torrefied_biomass_pellets))
-        )
-     ,"electricity_output_conversion && electricity_output_conversion > 0")
+      G(electricity_production),
+      "torrefied_biomass_pellets_input_conversion > 0"
     )
 - unit = nodes
 - deprecated_key = electricity_producing_converters_biocoal

--- a/gqueries/general/converter_groups/electricity_producing_waste_converters.gql
+++ b/gqueries/general/converter_groups/electricity_producing_waste_converters.gql
@@ -1,9 +1,7 @@
-# Returns the converters which produce electricity using waste. It works by looking to converters directly fed by the "waste_distribution" converter that have output of electricity.
-
 - query =
     FILTER(
-      PARENTS(V(energy_distribution_waste_mix )),
-      "electricity_output_conversion && electricity_output_conversion > 0"
+      G(electricity_production),
+      "waste_mix_input_conversion > 0"
     )
 - unit = nodes
 - deprecated_key = electricity_producing_converters_waste

--- a/gqueries/general/energy_production/electricity_produced_from_lignite.gql
+++ b/gqueries/general/energy_production/electricity_produced_from_lignite.gql
@@ -1,10 +1,5 @@
 # Returns the produced electricity using lignite.
-#
-# It works by looking to converters directly fed by the "lignite distribution" converter that have output of electricity.
 
 - unit = MJ
 - query =
-    V(
-      Q(electricity_producing_lignite_converters),
-      "output_of_electricity * lignite_input_conversion"
-    ).sum
+    V(G(electricity_production),"output_of_electricity * lignite_input_conversion").sum

--- a/gqueries/general/energy_production/electricity_produced_from_torrefied_biomass_pellets.gql
+++ b/gqueries/general/energy_production/electricity_produced_from_torrefied_biomass_pellets.gql
@@ -3,7 +3,4 @@
 
 - unit = MJ
 - query =
-    V(
-      Q(electricity_producing_torrefied_biomass_pellets_converters),
-      "output_of_electricity * torrefied_biomass_pellets_input_conversion"
-    ).sum
+    V(G(electricity_production),"output_of_electricity * torrefied_biomass_pellets_input_conversion").sum

--- a/gqueries/general/energy_production/electricity_produced_from_waste.gql
+++ b/gqueries/general/energy_production/electricity_produced_from_waste.gql
@@ -1,6 +1,5 @@
 # Returns the produced electricity using waste.
-#
-# It works by looking to waste converters.
 
 - unit = MJ
-- query = V(Q(electricity_producing_waste_converters),output_of_electricity).sum
+- query =
+    V(G(electricity_production),"output_of_electricity * waste_mix_input_conversion").sum

--- a/gqueries/general/flexibility/electricity/electricity_production_flexible_coal_to_power_capacity.gql
+++ b/gqueries/general/flexibility/electricity/electricity_production_flexible_coal_to_power_capacity.gql
@@ -8,6 +8,9 @@
         ),
         Q(
           electricity_producing_torrefied_biomass_pellets_converters
+        )
+        Q(
+          electricity_producing_lignite_converters
         ),
         "input_capacity * electricity_output_conversion * number_of_units"
       )

--- a/gqueries/general/flexibility/electricity/electricity_production_flexible_wood_pellets_to_power_capacity.gql
+++ b/gqueries/general/flexibility/electricity/electricity_production_flexible_wood_pellets_to_power_capacity.gql
@@ -9,7 +9,8 @@
           ),
           V(
             Q(electricity_producing_torrefied_biomass_pellets_converters),
-            Q(electricity_producing_coal_converters)
+            Q(electricity_producing_coal_converters),
+            Q(electricity_producing_lignite_converters)
           )
         ),
         "input_capacity * electricity_output_conversion * number_of_units"


### PR DESCRIPTION
I was notified by a user that the emissions shown in the co2 emissions of electricity production chart seemed rather high compared to official data. The chart (see screenshot below) indicated that the total co2 emissions of electricity production in Germany in 2015 were 448 Mton, while official [data](https://www.umweltbundesamt.de/sites/default/files/medien/384/bilder/dateien/6_datentabelle-zur-abb_entw-co2-emi_2020-03-11.pdf) reported 304 Mton.

<img width="617" alt="Screenshot 2021-03-29 at 14 38 20" src="https://user-images.githubusercontent.com/67338510/112837644-6d6ba080-909c-11eb-9ab5-f70c35212b50.png">

Looking into the underlying queries it turned out that the emissions of coal counted those of both coal and lignite power plants, even though the emissions of lignite were shown separately in the chart. Lignite has therefore been removed from the query `electricity_producing_coal_converters` and affected queries have been adjusted. The resulting emissions for Germany in the updated chart appear to be much more in line with the official data (see screenshot below).

<img width="620" alt="Screenshot 2021-03-29 at 14 39 43" src="https://user-images.githubusercontent.com/67338510/112837792-9d1aa880-909c-11eb-94d2-b5df8686de70.png">

Additionally, the queries `electricity_producing_waste_converters`, `electricity_producing_lignite_converters` and `electricity_producing_torrefied_biomass_pellets_converters` had a query structure which resulted in nodes being selected that could **potentially** use waste/lignite/torrefied wood pellets to produce electricity, instead of nodes that **actually produce** electricity in a certain scenario - which is the case for the other electricity producing converter queries. These queries have been updated to match the other electricity producing converter queries and affected queries have been adjusted.