### PR TITLE
Add separate queries for p2h industry and p2h district heating

### DIFF
--- a/gqueries/general/flexibility/electricity/electricity_demand_flexible_power_to_heat_district_heating_capacity.gql
+++ b/gqueries/general/flexibility/electricity/electricity_demand_flexible_power_to_heat_district_heating_capacity.gql
@@ -1,0 +1,16 @@
+# Selects the electricity input capacity of power-to-heat technologies for district heating using the p2h node group. Capacity of demand technologies is considered negative for the installed flexible capacities chart.
+
+- query =
+    PRODUCT(
+      -1,
+      SUM(
+        V(
+          FILTER(
+            G(p2h),
+            "heat_network"
+          ),
+          "input_capacity * number_of_units"
+        )
+      )
+    )
+- unit = MW

--- a/gqueries/general/flexibility/electricity/electricity_demand_flexible_power_to_heat_industry_capacity.gql
+++ b/gqueries/general/flexibility/electricity/electricity_demand_flexible_power_to_heat_industry_capacity.gql
@@ -1,0 +1,16 @@
+# Selects the electricity input capacity of power-to-heat technologies for industry using the p2h node group. Capacity of demand technologies is considered negative for the installed flexible capacities chart.
+
+- query =
+    PRODUCT(
+      -1,
+      SUM(
+        V(
+          FILTER(
+            G(p2h),
+            "merit_order && (merit_order.group == :power_to_heat_industry)"
+          ),
+          "input_capacity * number_of_units"
+        )
+      )
+    )
+- unit = MW


### PR DESCRIPTION
In the chart "Installed capacity of flexible technologies" power-to-heat was included as a single consumption group for the electricity carrier. Because only power-to-heat for district heating was included in the heat carrier, this could lead to confusion about the total amount of installed power-to-heat capacity. This pull request adds queries that allow the electricity carrier to show power-to-heat for industry and district heating as two separate labels.