### PR TITLE
Deleted queries for outdated "Heat and electricity sources in agriculture" chart for #2443

### DIFF
--- a/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/centrally_produced_electricity_in_source_of_heat_and_electricity_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/centrally_produced_electricity_in_source_of_heat_and_electricity_in_agriculture.gql
@@ -1,9 +1,0 @@
-- unit = PJ
-- query =
-    MAX(
-      SUM(
-        V(agriculture_final_demand_electricity,demand) / BILLIONS,
-        - Q(chp_electricity_in_source_of_heat_and_electricity_in_agriculture)
-      ),
-      0
-    )

--- a/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/centrally_produced_heat_in_source_of_heat_and_electricity_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/centrally_produced_heat_in_source_of_heat_and_electricity_in_agriculture.gql
@@ -1,9 +1,0 @@
-- unit = PJ
-- query =
-    MAX(
-      SUM(
-        V(agriculture_locally_available_steam_hot_water,demand) / BILLIONS,
-        - Q(chp_heat_in_source_of_heat_and_electricity_in_agriculture)
-      ),
-      0
-    )

--- a/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/other_heat_in_source_of_heat_and_electricity_in_agriculture.gql
+++ b/gqueries/output_elements/output_series/bezier_62_source_of_heat_and_electricity_used_in_agriculture/other_heat_in_source_of_heat_and_electricity_in_agriculture.gql
@@ -1,6 +1,0 @@
-- unit = PJ
-- query =
-      SUM(
-        V(agriculture_useful_demand_useable_heat, input_of_useable_heat),
-        - V(agriculture_final_demand_steam_hot_water, demand))
-      / BILLIONS


### PR DESCRIPTION
The chart "Heat and electricity sources in agriculture" was outdated and crashed the model upon opening, see issue #2443  for details. The chart has been removed from etmodel in https://github.com/quintel/etmodel/pull/3697. This pull request removes the queries for the chart.