### PR TITLE
Add must-run type to queries for must-run power plants in the merit order

### DIFF
--- a/gqueries/output_elements/output_series/table_116_merit_order/local_chp_biogas_merit_order.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/local_chp_biogas_merit_order.gql
@@ -5,5 +5,6 @@
     full_load_hours: Q(merit_order_local_chp_biogas_full_load_hours_in_merit_order_table),
     load_factor:     Q(merit_order_local_chp_biogas_load_factor_in_merit_order_table),
     operating_costs: Q(merit_order_local_chp_biogas_operating_costs_in_merit_order_table),
-    position:        Q(merit_order_local_chp_biogas_position_in_merit_order_table)
+    position:        Q(merit_order_local_chp_biogas_position_in_merit_order_table),
+    type:            'must_run'
   }

--- a/gqueries/output_elements/output_series/table_116_merit_order/waste_power_merit_order.gql
+++ b/gqueries/output_elements/output_series/table_116_merit_order/waste_power_merit_order.gql
@@ -5,5 +5,6 @@
     full_load_hours: Q(merit_order_waste_power_full_load_hours_in_merit_order_table),
     load_factor:     Q(merit_order_waste_power_load_factor_in_merit_order_table),
     operating_costs: Q(merit_order_waste_power_operating_costs_in_merit_order_table),
-    position:        Q(merit_order_waste_power_position_in_merit_order_table)
+    position:        Q(merit_order_waste_power_position_in_merit_order_table),
+    type:            'must_run'
   }


### PR DESCRIPTION
For etmodel issue https://github.com/quintel/etmodel/issues/3651 the must-run power plant group needed to be split into the two underlying nodes in the merit order chart. The marginal costs displayed in the merit order chart were hard-coded to 0 for the must-run power plant group. In https://github.com/quintel/etmodel/commit/cc2217f23f7273c4542535f9320835d0feb52ff8 this has been changed so that must-run power plants now need to have a `type` attribute in the relevant merit order query stating that they are `must-run`.

This attribute has been added to the merit order query for the power plants `waste incinerator` and `local chp biogas`.