### PR TITLE
Add energy_steel_hisarna_transformation_coal

### DIFF
--- a/gqueries/output_elements/output_series/biomass_sankey/dry_biomass_to_industry_in_biomass_sankey.gql
+++ b/gqueries/output_elements/output_series/biomass_sankey/dry_biomass_to_industry_in_biomass_sankey.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
      DIVIDE(
-      SUM(V(INTERSECTION(G(final_demand_group), SECTOR(industry)), input_of(wood_pellets, torrefied_biomass_pellets))),
+      SUM(V(INTERSECTION(G(final_demand_group), SECTOR(industry)), energy_steel_hisarna_transformation_coal, input_of(wood_pellets, torrefied_biomass_pellets))),
       BILLIONS
       )


### PR DESCRIPTION
Torrefied biomass can be used as feedstock in hisarna. This was missing from the biomass sankey, resulting in dry biomass production/import in the sankey but no demand.

BEFORE:
![image](https://user-images.githubusercontent.com/32056448/117415056-2765f000-af18-11eb-92b4-9449e34cb9f0.png)

AFTER:
![image](https://user-images.githubusercontent.com/32056448/117414987-14532000-af18-11eb-951b-59fbd7611de0.png)
