### PR TITLE
Add sustainability_share to primary demand nodes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',    ref: '0546b99', github: 'quintel/atlas'
+  gem 'atlas',    ref: 'd80297d', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 0546b99596e7b5234113c49eba307f389e0b311d
-  ref: 0546b99
+  revision: d80297d705bca0e81733d1a04c74acf090372d30
+  ref: d80297d
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)
@@ -29,9 +29,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4)
-      activesupport (= 6.1.4)
-    activesupport (6.1.4)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/graphs/energy/nodes/buildings/buildings_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/buildings/buildings_solar_pv_solar_radiation.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 16.67
 - hours_maint_nl = 0.33
 - hours_remov_nl = 0.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(buildings_solar_pv_solar_radiation, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(buildings_solar_pv_solar_radiation, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_heat_solar_thermal.converter.ad
+++ b/graphs/energy/nodes/energy/energy_heat_solar_thermal.converter.ad
@@ -26,6 +26,7 @@
 - construction_time = 2.0
 - technical_lifetime = 25.0
 - wacc = 0.04
+- sustainability_share = 1.0
 
 ~ demand = 0.0
 

--- a/graphs/energy/nodes/energy/energy_hydrogen_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_solar_pv_solar_radiation.ad
@@ -27,6 +27,7 @@
 - hours_place_nl = 222222.2222
 - hours_maint_nl = 4444.444444
 - hours_remov_nl = 0.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_hydrogen_solar_pv_solar_radiation, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_hydrogen_solar_pv_solar_radiation, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_hydrogen_wind_turbine_offshore.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_wind_turbine_offshore.ad
@@ -27,6 +27,7 @@
 - hours_place_nl = 41236.36364
 - hours_maint_nl = 500.0
 - hours_remov_nl = 1740.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_hydrogen_wind_turbine_offshore, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_hydrogen_wind_turbine_offshore, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_geothermal.ad
+++ b/graphs/energy/nodes/energy/energy_power_geothermal.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 39060.0
 - hours_maint_nl = 21420.0
 - hours_remov_nl = 0.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_geothermal, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_geothermal, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_hydro_mountain.ad
+++ b/graphs/energy/nodes/energy/energy_power_hydro_mountain.ad
@@ -27,6 +27,7 @@
 - construction_time = 4.0
 - technical_lifetime = 50.0
 - wacc = 0.04
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_hydro_mountain, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_hydro_mountain, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_hydro_river.ad
+++ b/graphs/energy/nodes/energy/energy_power_hydro_river.ad
@@ -28,6 +28,7 @@
 - construction_time = 2.0
 - technical_lifetime = 45.0
 - wacc = 0.04
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_hydro_river, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_hydro_river, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_solar_csp_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_power_solar_csp_solar_radiation.ad
@@ -27,6 +27,7 @@
 - construction_time = 0.5
 - technical_lifetime = 30.0
 - wacc = 0.04
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_solar_csp_solar_radiation, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_solar_csp_solar_radiation, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_power_solar_pv_solar_radiation.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 222222.2222
 - hours_maint_nl = 4444.444444
 - hours_remov_nl = 0.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_solar_pv_solar_radiation, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_solar_pv_solar_radiation, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_wind_turbine_coastal.ad
+++ b/graphs/energy/nodes/energy/energy_power_wind_turbine_coastal.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 4120.2
 - hours_maint_nl = 750.0
 - hours_remov_nl = 1740.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_wind_turbine_coastal, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_wind_turbine_coastal, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_wind_turbine_inland.ad
+++ b/graphs/energy/nodes/energy/energy_power_wind_turbine_inland.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 4120.2
 - hours_maint_nl = 750.0
 - hours_remov_nl = 1740.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_wind_turbine_inland, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_wind_turbine_inland, full_load_hours)

--- a/graphs/energy/nodes/energy/energy_power_wind_turbine_offshore.ad
+++ b/graphs/energy/nodes/energy/energy_power_wind_turbine_offshore.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 41236.36364
 - hours_maint_nl = 500.0
 - hours_remov_nl = 1740.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(energy_power_wind_turbine_offshore, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(energy_power_wind_turbine_offshore, full_load_hours)

--- a/graphs/energy/nodes/households/households_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/households/households_solar_pv_solar_radiation.ad
@@ -33,6 +33,7 @@
 - hours_place_nl = 16.67
 - hours_maint_nl = 0.33
 - hours_remov_nl = 0.0
+- sustainability_share = 1.0
 
 ~ demand = CENTRAL_PRODUCTION(households_solar_pv_solar_radiation, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(households_solar_pv_solar_radiation, full_load_hours)


### PR DESCRIPTION
Some primary demand nodes which are sustainable had no `sustainability_share` assigned, and relied on ETEngine treating nodes with "infinite" carriers differently when calculating the share.

This is the ETSource part of the implementation for [the second option discussed etmodel#3795](https://github.com/quintel/etmodel/issues/3795#issuecomment-897645801) whereby we'll raise an error if we cannot find a `sustainability_share` – or carriers with a `sustainable` value – when reaching "primary_energy_demand" nodes.