### PR TITLE
chemical other useful demand extra input statements

### DIFF
--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_electricity.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_electricity.ad
@@ -1,0 +1,11 @@
+# adds an input statement for updating the industry_useful_demand_for_chemical_other_electricity
+
+- query = UPDATE_WITH_FACTOR(V(industry_useful_demand_for_chemical_other_electricity), preset_demand, USER_INPUT())
+- priority = 0
+- max_value = 10000.0
+- min_value = 0.0
+- start_value = 100.0
+- step_value = 0.001
+- unit = %
+- update_period = future
+- update_type = %

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_non_energetic.ad
@@ -1,0 +1,11 @@
+# adds an input statement for updating the industry_useful_demand_for_chemical_other_non_energetic
+
+- query = UPDATE_WITH_FACTOR(V(industry_useful_demand_for_chemical_other_non_energetic), preset_demand, USER_INPUT())
+- priority = 0
+- max_value = 10000.0
+- min_value = 0.0
+- start_value = 100.0
+- step_value = 0.001
+- unit = %
+- update_period = future
+- update_type = %

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_useable_heat.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_useable_heat.ad
@@ -1,0 +1,12 @@
+# adds an input statement for updating the industry_useful_demand_for_chemical_other_useable_heat
+
+
+- query = UPDATE_WITH_FACTOR(V(industry_useful_demand_for_chemical_other_useable_heat), preset_demand, USER_INPUT())
+- priority = 0
+- max_value = 10000.0
+- min_value = 0.0
+- start_value = 100.0
+- step_value = 0.001
+- unit = %
+- update_period = future
+- update_type = %


### PR DESCRIPTION
Add input statements for electricity, useable heat, and non energetic shares in chemical other useful demand.

At the moment the ratio between the electricity, useable heat, and non energetic shares of the total industry_useful_demand_for_chemical_other is fixed when one changes the total chemical other useful demand. For the coupling with the CTM we would like to vary this ratio and therefore communicate directly with these nodes through the API. For this reason we added three new input statements, which are invisible to the user through ETModel and do not affect the model when left at their default value of 100%. 

@noracato @redekok 