### PR TITLE
Minor fix of energy balance carriers in transport final demand nodes

### DIFF
--- a/graphs/energy/nodes/transport/transport_final_demand_coal.final_demand.ad
+++ b/graphs/energy/nodes/transport/transport_final_demand_coal.final_demand.ad
@@ -33,8 +33,8 @@
     EB("non-specified (transport)", coke_oven_coke) -
     EB("pipeline transport", coke_oven_coke) +
     EB("transport", gas_coke) -
-    EB("non-specified (transport)", lignite) -
-    EB("pipeline transport", lignite) +
+    EB("non-specified (transport)", gas_coke) -
+    EB("pipeline transport", gas_coke) +
     EB("transport", coal_tar) -
     EB("non-specified (transport)", coal_tar) -
     EB("pipeline transport", coal_tar) +

--- a/graphs/energy/nodes/transport/transport_final_demand_gasoline.final_demand.ad
+++ b/graphs/energy/nodes/transport/transport_final_demand_gasoline.final_demand.ad
@@ -10,7 +10,7 @@
     EB("pipeline transport", motor_gasoline) +
     EB("transport", aviation_gasoline) -
     EB("non-specified (transport)", aviation_gasoline) -
-    EB("pipeline transport", motor_gasoline) +
+    EB("pipeline transport", aviation_gasoline) +
     EB("transport", gasoline_type_jet_fuel) -
-    EB("non-specified (transport)", motor_gasoline) -
-    EB("pipeline transport", motor_gasoline)
+    EB("non-specified (transport)", gasoline_type_jet_fuel) -
+    EB("pipeline transport", gasoline_type_jet_fuel)


### PR DESCRIPTION
Some energy carriers were read from the energy balance twice within a node, while other energy carriers were missing. This is fixed now for the final demand of gasoline and coal in the transport sector.