### PR TITLE
Fixes for Electricity Sankey

### DIFF
--- a/gqueries/general/electricity/energy_flexibility_flow_batteries_electricity_losses.gql
+++ b/gqueries/general/electricity/energy_flexibility_flow_batteries_electricity_losses.gql
@@ -1,0 +1,9 @@
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
+
+- query =
+    V(energy_flexibility_flow_batteries_electricity, input_of_electricity) -
+    PRODUCT(SUM(V(energy_flexibility_flow_batteries_electricity, electricity_output_curve)),MJ_PER_MWH)
+- unit = MJ

--- a/gqueries/general/electricity/energy_flexibility_hv_opac_electricity_losses.gql
+++ b/gqueries/general/electricity/energy_flexibility_hv_opac_electricity_losses.gql
@@ -1,0 +1,9 @@
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
+
+- query =
+    V(energy_flexibility_hv_opac_electricity, input_of_electricity) -
+    PRODUCT(SUM(V(energy_flexibility_hv_opac_electricity, electricity_output_curve)),MJ_PER_MWH)
+- unit = MJ

--- a/gqueries/general/electricity/energy_flexibility_mv_batteries_electricity_losses.gql
+++ b/gqueries/general/electricity/energy_flexibility_mv_batteries_electricity_losses.gql
@@ -1,0 +1,9 @@
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
+
+- query =
+    V(energy_flexibility_mv_batteries_electricity, input_of_electricity) -
+    PRODUCT(SUM(V(energy_flexibility_mv_batteries_electricity, electricity_output_curve)),MJ_PER_MWH)
+- unit = MJ

--- a/gqueries/general/electricity/energy_flexibility_pumped_storage_electricity_losses.gql
+++ b/gqueries/general/electricity/energy_flexibility_pumped_storage_electricity_losses.gql
@@ -1,0 +1,9 @@
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
+
+- query =
+    V(energy_flexibility_pumped_storage_electricity, input_of_electricity) -
+    PRODUCT(SUM(V(energy_flexibility_pumped_storage_electricity, electricity_output_curve)),MJ_PER_MWH)
+- unit = MJ

--- a/gqueries/general/electricity/households_flexibility_p2p_electricity_losses.gql
+++ b/gqueries/general/electricity/households_flexibility_p2p_electricity_losses.gql
@@ -1,0 +1,9 @@
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
+
+- query =
+    V(households_flexibility_p2p_electricity, input_of_electricity) -
+    PRODUCT(SUM(V(households_flexibility_p2p_electricity, electricity_output_curve)),MJ_PER_MWH)
+- unit = MJ

--- a/gqueries/general/electricity/transport_car_flexibility_p2p_electricity_losses.gql
+++ b/gqueries/general/electricity/transport_car_flexibility_p2p_electricity_losses.gql
@@ -1,0 +1,9 @@
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
+
+- query =
+    V(transport_car_flexibility_p2p_electricity, input_of_electricity) -
+    PRODUCT(SUM(V(transport_car_flexibility_p2p_electricity, electricity_output_curve)),MJ_PER_MWH)
+- unit = MJ

--- a/gqueries/mechanical_turk/supply/electricity/turk_electricity_sankey_supply.gql
+++ b/gqueries/mechanical_turk/supply/electricity/turk_electricity_sankey_supply.gql
@@ -12,5 +12,6 @@
       Q(import3_to_network_in_sankey),
       Q(import4_to_network_in_sankey),
       Q(import5_to_network_in_sankey),
-      Q(import6_to_network_in_sankey)
+      Q(import6_to_network_in_sankey),
+      Q(shortage_to_network_in_sankey)
     )

--- a/gqueries/mechanical_turk/supply/electricity/turk_electricity_total_supply.gql
+++ b/gqueries/mechanical_turk/supply/electricity/turk_electricity_total_supply.gql
@@ -2,6 +2,7 @@
     DIVIDE(
       SUM(
         Q(total_electricity_produced),
+        V(energy_power_hv_network_shortage, demand),
         V(energy_import_electricity, demand)
       ),
       BILLIONS

--- a/gqueries/output_elements/output_series/sankey/electricity_prod_to_energy_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/electricity_prod_to_energy_in_sankey.gql
@@ -5,6 +5,7 @@
     DIVIDE(
       SUM(
         SUM(V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)), USE(energetic)),"input_of_electricity")),
-        V(energy_production_synthetic_kerosene_electricity, demand)
+        V(energy_production_synthetic_kerosene_electricity, demand),
+        V(energy_production_synthetic_methanol_electricity, demand)
         ),
       BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/electricity_prod_to_energy_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/electricity_prod_to_energy_in_sankey.gql
@@ -5,7 +5,6 @@
     DIVIDE(
       SUM(
         SUM(V(INTERSECTION(INTERSECTION(SECTOR(energy),G(final_demand_group)), USE(energetic)),"input_of_electricity")),
-        V(energy_production_synthetic_kerosene_electricity, demand),
-        V(energy_production_synthetic_methanol_electricity, demand)
+        V(energy_production_synthetic_methanol_electricity, input_of_electricity)
         ),
       BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/p2p_to_conversion_loss_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/p2p_to_conversion_loss_in_sankey.gql
@@ -1,5 +1,5 @@
 # Group for Sankey: p2p to electricity production
 
 - query =
-    DIVIDE(SUM(V(Q(p2p_producing_converters_sankey), "input_of_electricity - demand * electricity_output_conversion")), BILLIONS)
-- unit = MJ
+    Q(losses_in_storage)
+- unit = PJ

--- a/gqueries/output_elements/output_series/sankey/p2p_to_electricity_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/p2p_to_electricity_prod_in_sankey.gql
@@ -1,5 +1,8 @@
-# Group for Sankey: p2p to electricity production
+# Electricity output curve is queried instead of the output of electricity
+# The electricity output curve shows the actual electricity supplied to the grid
+# The output of electricity does not take unused and decayed electricity into account
+# See https://github.com/quintel/mechanical_turk/issues/152#issuecomment-1060882609
 
 - query =
-    DIVIDE(SUM(V(Q(p2p_producing_converters_sankey), "demand * electricity_output_conversion")), BILLIONS)
-- unit = MJ
+    DIVIDE(PRODUCT(SUM(V(G(p2p), electricity_output_curve)),MJ_PER_MWH),BILLIONS)
+- unit = PJ

--- a/gqueries/output_elements/output_series/sankey_electrical_interconnection/network_to_loss_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_electrical_interconnection/network_to_loss_in_sankey.gql
@@ -1,5 +1,5 @@
 # Query for Sankey diagram: connection between electricity network and transport losses HV network
-# Also included are roundtrip efficiency losses by P2P technologies
+# Also included are the losses in electricity storage technologies
 
 - unit = PJ
 - query = 

--- a/gqueries/output_elements/output_series/sankey_electrical_interconnection/network_to_other_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_electrical_interconnection/network_to_other_in_sankey.gql
@@ -7,5 +7,6 @@
       Q(electricity_prod_to_central_heat_prod_in_sankey),
       Q(electricity_prod_to_energy_in_sankey),
       Q(electricity_prod_to_feedstock_in_sankey),
-      DIVIDE(V(energy_compressor_network_gas,input_of_electricity),BILLIONS)
+      DIVIDE(V(energy_compressor_network_gas,input_of_electricity),BILLIONS),
+      DIVIDE(V(energy_production_synthetic_kerosene_electricity, input_of_electricity),BILLIONS)
     )

--- a/gqueries/output_elements/output_series/sankey_electrical_interconnection/shortage_to_network_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_electrical_interconnection/shortage_to_network_in_sankey.gql
@@ -1,0 +1,8 @@
+# Query for Sankey diagram: connection between shortage and electricity network
+
+- query = 
+    DIVIDE(
+      V(energy_power_hv_network_shortage,demand),
+      BILLIONS
+    )
+- unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_flow_batteries_electricity_output.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_flow_batteries_electricity_output.gql
@@ -1,2 +1,6 @@
-- query = V(energy_flexibility_flow_batteries_electricity, "demand * electricity_output_conversion") / BILLIONS
+- query = 
+    DIVIDE(
+      PRODUCT(SUM(V(energy_flexibility_flow_batteries_electricity, electricity_output_curve)),MJ_PER_MWH),
+      BILLIONS
+    )
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_mv_batteries_electricity_output.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_mv_batteries_electricity_output.gql
@@ -1,2 +1,6 @@
-- query = V(energy_flexibility_mv_batteries_electricity, "demand * electricity_output_conversion") / BILLIONS
+- query = 
+    DIVIDE(
+      PRODUCT(SUM(V(energy_flexibility_mv_batteries_electricity, electricity_output_curve)),MJ_PER_MWH),
+      BILLIONS
+    )
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_opac_electricity_output.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_opac_electricity_output.gql
@@ -1,2 +1,6 @@
-- query = V(energy_flexibility_hv_opac_electricity, "demand * electricity_output_conversion") / BILLIONS
+- query = 
+    DIVIDE(
+      PRODUCT(SUM(V(energy_flexibility_hv_opac_electricity, electricity_output_curve)),MJ_PER_MWH),
+      BILLIONS
+    )
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_pumped_storage_electricity_output.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/energy_flexibility_pumped_storage_electricity_output.gql
@@ -1,2 +1,6 @@
-- query = V(energy_flexibility_pumped_storage_electricity, "demand * electricity_output_conversion") / BILLIONS
+- query = 
+    DIVIDE(
+      PRODUCT(SUM(V(energy_flexibility_pumped_storage_electricity, electricity_output_curve)),MJ_PER_MWH),
+      BILLIONS
+    )
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2p_electricity_output.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/households_flexibility_p2p_electricity_output.gql
@@ -1,2 +1,6 @@
-- query = V(households_flexibility_p2p_electricity, output_of_electricity) / BILLIONS
+- query = 
+    DIVIDE(
+      PRODUCT(SUM(V(households_flexibility_p2p_electricity, electricity_output_curve)),MJ_PER_MWH),
+      BILLIONS
+    )
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/losses_in_storage.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/losses_in_storage.gql
@@ -1,13 +1,13 @@
-# This gquery includes all losses related to storage of electricity by flexible demand technologies
-# This includes losses for charging and discharging of P2P technologies
+# This gquery includes all losses in electricity storage technologies
+# This includes conversion losses, unused electricity and decayed electricity
 
 - query =
     SUM(
-      V(households_flexibility_p2p_electricity, "input_of_electricity - output_of_electricity"),
-      V(transport_car_flexibility_p2p_electricity, "input_of_electricity - (demand * electricity_output_conversion)"),
-      V(energy_flexibility_pumped_storage_electricity, "input_of_electricity - (demand * electricity_output_conversion)"),
-      V(energy_flexibility_hv_opac_electricity, "input_of_electricity - (demand * electricity_output_conversion)"),
-      V(energy_flexibility_mv_batteries_electricity, "input_of_electricity - (demand * electricity_output_conversion)"),
-      V(energy_flexibility_flow_batteries_electricity, "input_of_electricity - (demand * electricity_output_conversion)")
+      Q(households_flexibility_p2p_electricity_losses),
+      Q(transport_car_flexibility_p2p_electricity_losses),
+      Q(energy_flexibility_mv_batteries_electricity_losses),
+      Q(energy_flexibility_hv_opac_electricity_losses),
+      Q(energy_flexibility_pumped_storage_electricity_losses),
+      Q(energy_flexibility_flow_batteries_electricity_losses)
     ) / BILLIONS
 - unit = PJ

--- a/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_output.gql
+++ b/gqueries/output_elements/output_series/table_164_storage_options/transport_car_using_electricity_output.gql
@@ -1,2 +1,7 @@
-- query = V(transport_car_flexibility_p2p_electricity, "demand * electricity_output_conversion") / BILLIONS
+- query = 
+    DIVIDE(
+      PRODUCT(SUM(V(transport_car_flexibility_p2p_electricity, electricity_output_curve)),MJ_PER_MWH),
+      BILLIONS
+    )
 - unit = PJ
+


### PR DESCRIPTION
Based on the Electricity Sankey spec on Mechanical Turk (see https://github.com/quintel/mechanical_turk/issues/152) the following issues in the Sankey were identified and fixed in this PR:

- Losses in storage were not properly queried. They queried output of electricity, which did not include losses due to decayed electricity and unused electricity. New queries have been written for this.
- Shortages due to blackout were not included. They have now been added.
- The electricity demand from synthetic methanol production was not included. This has now been added.

Corresponding PR on ETModel: https://github.com/quintel/etmodel/pull/3921.
Before merging this PR, the following to do should be checked:

- [x] Determine fallout of issues addressed above for other charts/tables/calculations such as the demand in the Source of electricity production chart (https://github.com/quintel/etmodel/issues/3905), or the output of electricity in the Flexibility table