### PR TITLE
Add hydrogen, solar thermal and solar pvt heating and hot water technologies to final demand chart

### DIFF
--- a/gqueries/output_elements/output_series/bezier_213_final_demand_in_households_per_utility/households_final_demand_hot_water.gql
+++ b/gqueries/output_elements/output_series/bezier_213_final_demand_in_households_per_utility/households_final_demand_hot_water.gql
@@ -1,12 +1,14 @@
 - unit = PJ
 - query =
       SUM(V(
+        households_final_demand_for_hot_water_solar_thermal,
+        households_final_demand_for_hot_water_solar_thermal_pvt,
         households_final_demand_for_hot_water_coal,
         households_final_demand_for_hot_water_crude_oil,
         households_final_demand_for_hot_water_network_gas,
         households_final_demand_for_hot_water_wood_pellets,
         households_final_demand_for_hot_water_electricity,
         households_final_demand_for_hot_water_steam_hot_water,
-        EDGE(households_water_heater_solar_thermal, households_useful_demand_for_hot_water_for_houses_with_solar_heater),
+        households_final_demand_for_hot_water_hydrogen,
         demand
       )) / BILLIONS

--- a/gqueries/output_elements/output_series/bezier_213_final_demand_in_households_per_utility/households_final_demand_space_heating.gql
+++ b/gqueries/output_elements/output_series/bezier_213_final_demand_in_households_per_utility/households_final_demand_space_heating.gql
@@ -1,11 +1,13 @@
 - unit = PJ
 - query =
       SUM(V(
+        households_final_demand_for_space_heating_solar_thermal_pvt,
         households_final_demand_for_space_heating_coal,
         households_final_demand_for_space_heating_crude_oil,
         households_final_demand_for_space_heating_network_gas,
         households_final_demand_for_space_heating_wood_pellets,
         households_final_demand_for_space_heating_electricity,
         households_final_demand_for_space_heating_steam_hot_water,
+        households_final_demand_for_space_heating_hydrogen
         demand
       )) / BILLIONS


### PR DESCRIPTION
This PR adds missing heating technologies to the households final demand per application chart:

<img width="626" alt="Screenshot 2022-03-22 at 10 09 09" src="https://user-images.githubusercontent.com/67338510/159445846-68babe66-16a6-4f1b-8f0d-f11aae596cea.png">

@Charlottevm could you check whether the chart is consistent now?