### PR TITLE
Fix external coupling for waste CHP

### DIFF
--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2.ad
@@ -3,7 +3,7 @@
         UPDATE(
             V(energy_chp_supercritical_waste_mix),
             number_of_units,
-            (1.0 - DIVIDE(USER_INPUT(),100.0)) * INPUT_VALUE(capacity_of_energy_chp_supercritical_waste_mix) / V(energy_chp_supercritical_waste_mix, electricity_output_capacity)
+            (1.0 - DIVIDE(USER_INPUT(),100.0)) * INPUT_VALUE(external_coupling_energy_chp_supercritical_waste_mix_capacity) / V(energy_chp_supercritical_waste_mix, electricity_output_capacity)
         ),
         UPDATE(
             L(energy_chp_supercritical_waste_mix),
@@ -13,7 +13,7 @@
         UPDATE(
             V(energy_chp_supercritical_ccs_waste_mix),
             number_of_units,
-            DIVIDE(USER_INPUT(),100.0) * INPUT_VALUE(capacity_of_energy_chp_supercritical_waste_mix) / V(energy_chp_supercritical_ccs_waste_mix, electricity_output_capacity)
+            DIVIDE(USER_INPUT(),100.0) * INPUT_VALUE(external_coupling_energy_chp_supercritical_waste_mix_capacity) / V(energy_chp_supercritical_ccs_waste_mix, electricity_output_capacity)
         ),
         UPDATE(
             L(energy_chp_supercritical_ccs_waste_mix),

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_capacity.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_capacity.ad
@@ -3,7 +3,7 @@
         UPDATE(
             V(energy_chp_supercritical_waste_mix),
             number_of_units,
-            (1.0 - DIVIDE(INPUT_VALUE(share_of_energy_chp_supercritical_ccs_waste_mix),100.0)) * USER_INPUT() / V(energy_chp_supercritical_waste_mix, electricity_output_capacity)
+            (1.0 - DIVIDE(INPUT_VALUE(external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2),100.0)) * USER_INPUT() / V(energy_chp_supercritical_waste_mix, electricity_output_capacity)
         ),
         UPDATE(
           	L(energy_chp_supercritical_waste_mix),
@@ -13,7 +13,7 @@
         UPDATE(
             V(energy_chp_supercritical_ccs_waste_mix),
             number_of_units,
-            DIVIDE(INPUT_VALUE(share_of_energy_chp_supercritical_ccs_waste_mix),100.0) * USER_INPUT() / V(energy_chp_supercritical_ccs_waste_mix, electricity_output_capacity)
+            DIVIDE(INPUT_VALUE(external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2),100.0) * USER_INPUT() / V(energy_chp_supercritical_ccs_waste_mix, electricity_output_capacity)
         ),
         UPDATE(
             L(energy_chp_supercritical_ccs_waste_mix),


### PR DESCRIPTION
In the original external coupling input statements, the installed capacity input referred to the 'normal'/'front-end' CCS share input, while the CCS share input referred to the normal installed capacity input. Because the normal sliders are disabled when external coupling is used, this did not work.

This has been fixed by updating the external coupling inputs to refer to each other, just like the normal inputs refer to each other. The implication of this fix is that external coupling should always set both inputs.