### PR TITLE
Remove share group from external coal gas output shares coupling

### DIFF
--- a/inputs/modules/external_coupling/metal_steel/external_coupling_energy_distribution_coal_gas_chemical_feedstock_share.ad
+++ b/inputs/modules/external_coupling/metal_steel/external_coupling_energy_distribution_coal_gas_chemical_feedstock_share.ad
@@ -8,7 +8,6 @@
       share,
       DIVIDE(USER_INPUT(), 100.0)
     )
-- share_group = external_coupling_coal_gas_ccus
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0

--- a/inputs/modules/external_coupling/metal_steel/external_coupling_energy_distribution_coal_gas_energy_production_share.ad
+++ b/inputs/modules/external_coupling/metal_steel/external_coupling_energy_distribution_coal_gas_energy_production_share.ad
@@ -15,7 +15,6 @@
         DIVIDE(USER_INPUT(), 100) * chp_share / total_share
       )
     )
-- share_group = external_coupling_coal_gas_ccus
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0


### PR DESCRIPTION
For https://github.com/quintel/etengine/issues/1243, the share groups in the external coupling inputs that set the output shares of the energy distribution coal gas node were updated.

The two inputs now need to sum to 100%, or else the external coupling crashes. This presents an issue, because the two inputs only set 3 of the 4 output shares of the energy distribution coal gas node. The industry final demand coal gas share cannot be set directly. This means that in order for the coupling to work the final demand share should always be 0%, which is undesirable.

There is no must-have requirement for the client to keep this share group, so they are removed in this PR, which should solve the issue.