### PR TITLE
Change biomass import carrier group for dashboard net import chart

### DIFF
--- a/gqueries/general/carrier_groups/all_carriers/carrier_group_biomass_products_import.gql
+++ b/gqueries/general/carrier_groups/all_carriers/carrier_group_biomass_products_import.gql
@@ -1,0 +1,4 @@
+# Carrier group of biomass products (all import)
+
+- query = CARRIER(biogenic_waste, dry_biomass, oily_biomass, wet_biomass)
+- unit =

--- a/gqueries/general/import_export/net_import_of_biomass_derivatives.gql
+++ b/gqueries/general/import_export/net_import_of_biomass_derivatives.gql
@@ -1,9 +1,6 @@
-# bio ethanol and bio diesel are use energetic!
-
 - unit = MJ
 - query =
     SUM(
-      V(G(energy_import),output_of(Q(carrier_group_biomass_products))),
-      NEG(V(G(energy_export),input_of(Q(carrier_group_biomass_products))).sum)
+      V(G(energy_import),output_of(Q(carrier_group_biomass_products_import))),
+      NEG(V(G(energy_export),input_of(Q(carrier_group_biomass_products_import))).sum)
     )
-- deprecated_key = import_of_biomassa_group


### PR DESCRIPTION
This PR closes quintel/etmodel#3958

Instead of using the primary biomass carriers which, with the exception of biogenic waste, are not in the import group, the import biomass carriers are used to query the net biomass imports.