### PR TITLE
Add international transport to Sankey export

### DIFF
--- a/config/sankey_csv.yml
+++ b/config/sankey_csv.yml
@@ -217,7 +217,7 @@ rows:
     Value: electricity_prod_to_p2h_industry_in_sankey
   - Group: Final demand
     Carrier: Electricity
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: electricity_prod_to_transport_in_sankey
   - Group: Final demand
@@ -235,6 +235,11 @@ rows:
     Category: Energy
     Type: Input
     Value: electricity_prod_to_energy_in_sankey
+  - Group: Final demand
+    Carrier: Electricity
+    Category: International transport
+    Type: Input
+    Value: electricity_prod_to_bunkers_in_sankey
   - Group: Final demand
     Carrier: Electricity
     Category: Feedstock
@@ -312,7 +317,7 @@ rows:
     Value: hydrogen_prod_to_industry_in_sankey
   - Group: Final demand
     Carrier: Hydrogen
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: hydrogen_prod_to_transport_in_sankey
   - Group: Final demand
@@ -330,6 +335,11 @@ rows:
     Category: Energy
     Type: Input
     Value: hydrogen_prod_to_energy_in_sankey
+  - Group: Final demand
+    Carrier: Hydrogen
+    Category: International transport
+    Type: Input
+    Value: hydrogen_prod_to_bunkers_in_sankey
   - Group: Final demand
     Carrier: Hydrogen
     Category: Feedstock
@@ -442,7 +452,7 @@ rows:
     Value: final_demand_of_heat_in_industry_energetic
   - Group: Final demand
     Carrier: Steam hot water
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: final_demand_of_heat_in_transport_energetic
   - Group: Final demand
@@ -507,7 +517,7 @@ rows:
     Value: coal_and_derivatives_to_industry_in_sankey
   - Group: Final demand
     Carrier: Coal
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: coal_and_derivatives_to_transport_in_sankey
   - Group: Final demand
@@ -525,6 +535,11 @@ rows:
     Category: Energy
     Type: Input
     Value: coal_and_derivatives_to_energy_in_sankey
+  - Group: Final demand
+    Carrier: Coal
+    Category: International transport
+    Type: Input
+    Value: coal_and_derivatives_to_bunkers_in_sankey
   - Group: Final demand
     Carrier: Coal
     Category: Feedstock
@@ -577,7 +592,7 @@ rows:
     Value: oil_and_derivatives_to_industry_in_sankey
   - Group: Final demand
     Carrier: Oil
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: oil_and_derivatives_to_transport_in_sankey
   - Group: Final demand
@@ -595,6 +610,11 @@ rows:
     Category: Energy
     Type: Input
     Value: oil_and_derivatives_to_energy_in_sankey
+  - Group: Final demand
+    Carrier: Oil
+    Category: International transport
+    Type: Input
+    Value: oil_and_derivatives_to_bunkers_in_sankey
   - Group: Final demand
     Carrier: Oil
     Category: Feedstock
@@ -667,7 +687,7 @@ rows:
     Value: natural_gas_to_industry_in_sankey
   - Group: Final demand
     Carrier: Natural gas
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: natural_gas_to_transport_in_sankey
   - Group: Final demand
@@ -685,6 +705,11 @@ rows:
     Category: Energy
     Type: Input
     Value: natural_gas_to_energy_in_sankey
+  - Group: Final demand
+    Carrier: Natural gas
+    Category: International transport
+    Type: Input
+    Value: natural_gas_to_bunkers_in_sankey
   - Group: Final demand
     Carrier: Natural gas
     Category: Feedstock
@@ -747,7 +772,7 @@ rows:
     Value: biomass_products_to_industry_in_sankey
   - Group: Final demand
     Carrier: Biomass
-    Category: Transport
+    Category: National transport
     Type: Input
     Value: biomass_products_to_transport_in_sankey
   - Group: Final demand
@@ -765,6 +790,11 @@ rows:
     Category: Energy
     Type: Input
     Value: biomass_products_to_energy_in_sankey
+  - Group: Final demand
+    Carrier: Biomass
+    Category: International transport
+    Type: Input
+    Value: biomass_products_to_bunkers_in_sankey
   - Group: Final demand
     Carrier: Biomass
     Category: Feedstock

--- a/gqueries/output_elements/output_series/sankey/coal_and_derivatives_to_bunkers_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/coal_and_derivatives_to_bunkers_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between coal_and_derivatives and bunkers
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(bunkers),G(final_demand_group)), USE(energetic)),"input_of_coal + input_of_lignite + input_of_cokes + input_of_coal_gas")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/electricity_prod_to_bunkers_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/electricity_prod_to_bunkers_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between electricity and bunkers
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(bunkers),G(final_demand_group)), USE(energetic)),"input_of_electricity")),BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/hydrogen_prod_to_bunkers_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/hydrogen_prod_to_bunkers_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for Sankey diagram: connection between hydrogen_production and bunkers
+
+- unit = PJ
+- query = DIVIDE(SUM(V(INTERSECTION(INTERSECTION(SECTOR(bunkers),G(final_demand_group)), USE(energetic)), "input_of_hydrogen")), BILLIONS)


### PR DESCRIPTION
Final demand for international transport (bunkers) was missing from the Sankey export. This has been added and the Category 'Transport' has been renamed to 'National transport'.