### PR TITLE
Remove graph methods for edge and node

### DIFF
--- a/graphs/energy/edges/buildings/buildings_final_demand_for_space_heating_electricity-buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity@electricity.ad
+++ b/graphs/energy/edges/buildings/buildings_final_demand_for_space_heating_electricity-buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity@electricity.ad
@@ -1,6 +1,5 @@
 - type = share
 - reversed = false
 - groups = [final_demand]
-- graph_methods = [parent_share]
 
 ~ parent_share = 0.0

--- a/graphs/energy/nodes/bunkers/bunkers_final_demand_hydrogen.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_final_demand_hydrogen.ad
@@ -3,7 +3,6 @@
 - groups = [final_demand_group, co2_emissions_primary]
 - hydrogen.profile = flat
 - hydrogen.type = consumer
-- graph_methods = [demand]
 - free_co2_factor = 0.0
 
 ~ demand = 0


### PR DESCRIPTION
Because the demand for hydrogen in international navigation and for hydrogen from the hybrid hydrogen heatpump in buildings is assumed to be 0.0 PJ in the starting year, these are currently not included in the Dataset Manager. This means that the graph methods are redundant.

This closes quintel/etlocal#401