### PR TITLE
Update max value of P2G capacity input to account for countries without offshore area

### DIFF
--- a/inputs/flexibility/energy/capacity_of_energy_hydrogen_flexibility_p2g_electricity.ad
+++ b/inputs/flexibility/energy/capacity_of_energy_hydrogen_flexibility_p2g_electricity.ad
@@ -9,7 +9,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(AREA(offshore_suitable_for_wind),V(energy_power_wind_turbine_offshore, land_use_per_unit)),V(energy_power_wind_turbine_offshore, electricity_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(SUM(AREA(offshore_suitable_for_wind),AREA(total_land_area)),V(energy_power_wind_turbine_offshore, land_use_per_unit)),V(energy_power_wind_turbine_offshore, electricity_output_capacity)))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_hydrogen_flexibility_p2g_electricity,number_of_units),V(energy_hydrogen_flexibility_p2g_electricity,typical_input_capacity))
 - step_value = 0.1


### PR DESCRIPTION
The maximum value for the capacity of P2G (power-to-gas / electrolysis) was based on the area available for offshore wind. This meant that for regions or countries with no offshore area virtually no P2G capacity could be set. See the screenshot from beta for Austria:

<img width="477" alt="Screenshot 2022-07-15 at 09 44 44" src="https://user-images.githubusercontent.com/67338510/179176969-9ab2ca35-408b-4e57-b897-d13515c84aa5.png">

This PR fixes that by summing the area available for offshore wind **and** the total land area. See the screenshot from the branch for Austria:

<img width="473" alt="Screenshot 2022-07-15 at 09 46 21" src="https://user-images.githubusercontent.com/67338510/179177215-2b25d55a-899e-45bd-b356-e9fc6d1884f3.png">