### PR TITLE
Updated slider max for electricity and heat plants

### DIFF
--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_coal.ad
@@ -11,7 +11,7 @@
         	V(energy_chp_ultra_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_coal, output_of_electricity)*2), V(energy_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_ultra_supercritical_coal,number_of_units),V(energy_chp_ultra_supercritical_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_cofiring_coal.ad
@@ -11,7 +11,7 @@
         	V(energy_chp_ultra_supercritical_cofiring_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_cofiring_coal, output_of_electricity)*2), V(energy_chp_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_ultra_supercritical_cofiring_coal,number_of_units),V(energy_chp_ultra_supercritical_cofiring_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_lignite.ad
@@ -11,7 +11,7 @@
         	V(energy_chp_ultra_supercritical_lignite, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_lignite, output_of_electricity)*2), V(energy_chp_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_ultra_supercritical_lignite,number_of_units),V(energy_chp_ultra_supercritical_lignite,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_coal.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_coal, output_of_electricity)*2), V(energy_power_combined_cycle_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_combined_cycle_ccs_coal, "number_of_units*electricity_output_capacity"),V(energy_power_combined_cycle_coal, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_supercritical_coal.ad
@@ -11,7 +11,7 @@
         	V(energy_power_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_supercritical_coal, output_of_electricity)*2), V(energy_power_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_supercritical_coal ,number_of_units),V(energy_power_supercritical_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_coal.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_coal, output_of_electricity)*2), V(energy_power_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_ultra_supercritical_ccs_coal, "number_of_units*electricity_output_capacity"),V(energy_power_ultra_supercritical_coal, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_cofiring_coal.ad
@@ -11,7 +11,7 @@
         	V(energy_power_ultra_supercritical_cofiring_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_cofiring_coal, output_of_electricity)*2), V(energy_power_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_cofiring_coal,number_of_units),V(energy_power_ultra_supercritical_cofiring_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_lignite.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_lignite, output_of_electricity)*2), V(energy_power_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite, "number_of_units*electricity_output_capacity"),V(energy_power_ultra_supercritical_lignite, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_combined_cycle_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_combined_cycle_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_chp_combined_cycle_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_combined_cycle_network_gas, output_of_electricity)*2), V(energy_chp_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_combined_cycle_network_gas,number_of_units),V(energy_chp_combined_cycle_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_local_engine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_local_engine_network_gas.ad
@@ -11,7 +11,7 @@
           V(energy_chp_local_engine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_local_engine_network_gas, output_of_electricity)*2), V(energy_chp_local_engine_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_local_engine_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_local_engine_network_gas,number_of_units),V(energy_chp_local_engine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_network_gas.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_network_gas, output_of_electricity)*2), V(energy_power_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_combined_cycle_ccs_network_gas, "number_of_units*electricity_output_capacity"),V(energy_power_combined_cycle_network_gas, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_engine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_engine_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_power_engine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_engine_network_gas, output_of_electricity)*2), V(energy_power_engine_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_engine_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_engine_network_gas,number_of_units),V(energy_power_engine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_turbine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_turbine_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_power_turbine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_turbine_network_gas, output_of_electricity)*2), V(energy_power_turbine_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_turbine_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_turbine_network_gas,number_of_units),V(energy_power_turbine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_ultra_supercritical_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_ultra_supercritical_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_power_ultra_supercritical_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_network_gas, output_of_electricity)*2), V(energy_power_ultra_supercritical_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_network_gas,number_of_units),V(energy_power_ultra_supercritical_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen2_uranium_oxide.ad
@@ -11,7 +11,7 @@
       		V(energy_power_nuclear_gen2_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_nuclear_gen2_uranium_oxide, output_of_electricity)*2), V(energy_power_nuclear_gen2_uranium_oxide,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_gen2_uranium_oxide,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_gen2_uranium_oxide,number_of_units),V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen3_uranium_oxide.ad
@@ -11,7 +11,7 @@
       		V(energy_power_nuclear_gen3_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_nuclear_gen3_uranium_oxide, output_of_electricity)*2), V(energy_power_nuclear_gen3_uranium_oxide,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_gen3_uranium_oxide,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_gen3_uranium_oxide,number_of_units),V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/oil_plants/capacity_of_energy_power_engine_diesel.ad
+++ b/inputs/supply/electricity/oil_plants/capacity_of_energy_power_engine_diesel.ad
@@ -11,7 +11,7 @@
         	V(energy_power_engine_diesel, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_engine_diesel, output_of_electricity)*2), V(energy_power_engine_diesel,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_engine_diesel,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_engine_diesel,number_of_units),V(energy_power_engine_diesel,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/oil_plants/capacity_of_energy_power_ultra_supercritical_crude_oil.ad
+++ b/inputs/supply/electricity/oil_plants/capacity_of_energy_power_ultra_supercritical_crude_oil.ad
@@ -11,7 +11,7 @@
       		V(energy_power_ultra_supercritical_crude_oil, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_crude_oil, output_of_electricity)*2), V(energy_power_ultra_supercritical_crude_oil,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_crude_oil,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_crude_oil,number_of_units),V(energy_power_ultra_supercritical_crude_oil, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_chp_combined_cycle_gas_power_fuelmix, output_of_steam_hot_water)*2), V(industry_chp_combined_cycle_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_combined_cycle_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_combined_cycle_gas_power_fuelmix,number_of_units),V(industry_chp_combined_cycle_gas_power_fuelmix,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_chp_engine_gas_power_fuelmix, output_of_steam_hot_water)*2), V(industry_chp_engine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_engine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_engine_gas_power_fuelmix,number_of_units),V(industry_chp_engine_gas_power_fuelmix,heat_output_capacity))
 - step_value = 0.1

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_chp_turbine_gas_power_fuelmix, output_of_steam_hot_water)*2), V(industry_chp_turbine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_turbine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_turbine_gas_power_fuelmix,number_of_units),V(industry_chp_turbine_gas_power_fuelmix,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_chp_ultra_supercritical_coal, output_of_steam_hot_water)*2), V(industry_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_ultra_supercritical_coal,number_of_units),V(industry_chp_ultra_supercritical_coal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_chp_wood_pellets, output_of_steam_hot_water)*2), V(industry_chp_wood_pellets,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_wood_pellets,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_chp_wood_pellets,number_of_units),V(industry_chp_wood_pellets,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_heat_burner_coal.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_heat_burner_coal.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw_output)
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_heat_burner_coal, output_of_steam_hot_water)*2), V(industry_heat_burner_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_heat_burner_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_heat_burner_coal,number_of_units),V(industry_heat_burner_coal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_heat_burner_crude_oil.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_heat_burner_crude_oil.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw_output)
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_heat_burner_crude_oil, output_of_steam_hot_water)*2), V(industry_heat_burner_crude_oil,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_heat_burner_crude_oil,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_heat_burner_crude_oil,number_of_units),V(industry_heat_burner_crude_oil,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_heat_burner_lignite.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_heat_burner_lignite.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw_output)
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_heat_burner_lignite, output_of_steam_hot_water)*2), V(industry_heat_burner_lignite,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_heat_burner_lignite,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_heat_burner_lignite,number_of_units),V(industry_heat_burner_lignite,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/industry/capacity_of_industry_heat_well_geothermal.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_heat_well_geothermal.ad
@@ -12,7 +12,7 @@
             USER_INPUT() * demand_per_mw_output)
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(heat_production_industry) * BILLIONS, V(industry_heat_well_geothermal, output_of_steam_hot_water)*2), V(industry_heat_well_geothermal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_heat_well_geothermal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(industry_heat_well_geothermal,number_of_units),V(industry_heat_well_geothermal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/biomass_plants/capacity_of_energy_chp_local_engine_biogas.ad
+++ b/inputs/supply/renewable_electricity/biomass_plants/capacity_of_energy_chp_local_engine_biogas.ad
@@ -11,7 +11,7 @@
           V(energy_chp_local_engine_biogas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_local_engine_biogas, output_of_electricity)*2), V(energy_chp_local_engine_biogas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_local_engine_biogas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_local_engine_biogas,number_of_units),V(energy_chp_local_engine_biogas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/biomass_plants/capacity_of_energy_chp_local_wood_pellets.ad
+++ b/inputs/supply/renewable_electricity/biomass_plants/capacity_of_energy_chp_local_wood_pellets.ad
@@ -11,7 +11,7 @@
           V(energy_chp_local_wood_pellets, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_local_wood_pellets, output_of_electricity)*2), V(energy_chp_local_wood_pellets,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_local_wood_pellets,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_local_wood_pellets,number_of_units),V(energy_chp_local_wood_pellets,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/geothermal/capacity_of_energy_power_geothermal.ad
+++ b/inputs/supply/renewable_electricity/geothermal/capacity_of_energy_power_geothermal.ad
@@ -11,7 +11,7 @@
         	V(energy_power_geothermal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_geothermal, output_of_electricity)*2), V(energy_power_geothermal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_geothermal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_geothermal,number_of_units),V(energy_power_geothermal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_mountain.ad
+++ b/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_mountain.ad
@@ -11,7 +11,7 @@
             V(energy_power_hydro_mountain, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_hydro_mountain, output_of_electricity)*2), V(energy_power_hydro_mountain,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed) V(energy_power_hydro_mountain,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_hydro_mountain,number_of_units),V(energy_power_hydro_mountain,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_mountain.ad
+++ b/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_mountain.ad
@@ -11,7 +11,7 @@
             V(energy_power_hydro_mountain, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed) V(energy_power_hydro_mountain,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_hydro_mountain,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_hydro_mountain,number_of_units),V(energy_power_hydro_mountain,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_river.ad
+++ b/inputs/supply/renewable_electricity/hydro_electric/capacity_of_energy_power_hydro_river.ad
@@ -12,7 +12,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_hydro_river, output_of_electricity)*2), V(energy_power_hydro_river,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_hydro_river,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_hydro_river,number_of_units),V(energy_power_hydro_river,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_combined_cycle_hydrogen.ad
+++ b/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_combined_cycle_hydrogen.ad
@@ -11,7 +11,7 @@
         	V(energy_power_combined_cycle_hydrogen, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_combined_cycle_hydrogen, output_of_electricity)*2), V(energy_power_combined_cycle_hydrogen,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_hydrogen,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_combined_cycle_hydrogen,number_of_units),V(energy_power_combined_cycle_hydrogen,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_turbine_hydrogen.ad
+++ b/inputs/supply/renewable_electricity/hydrogen_plants/capacity_of_energy_power_turbine_hydrogen.ad
@@ -11,7 +11,7 @@
       		V(energy_power_turbine_hydrogen, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_turbine_hydrogen, output_of_electricity)*2), V(energy_power_turbine_hydrogen,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_turbine_hydrogen,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_turbine_hydrogen,number_of_units),V(energy_power_turbine_hydrogen,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_energy_power_solar_csp_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_energy_power_solar_csp_solar_radiation.ad
@@ -11,7 +11,7 @@
         	V(energy_power_solar_csp_solar_radiation, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_solar_csp_solar_radiation, output_of_electricity)*2), V(energy_power_solar_csp_solar_radiation,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_solar_csp_solar_radiation,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_solar_csp_solar_radiation,number_of_units),V(energy_power_solar_csp_solar_radiation,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
+++ b/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
@@ -23,7 +23,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_chp_supercritical_waste_mix, output_of_electricity)*2), V(energy_chp_supercritical_waste_mix,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_supercritical_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_chp_supercritical_waste_mix,number_of_units),V(energy_chp_supercritical_waste_mix,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_power_supercritical_waste_mix.ad
+++ b/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_power_supercritical_waste_mix.ad
@@ -23,7 +23,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(Q(total_electricity_consumed), V(energy_power_supercritical_waste_mix, output_of_electricity)*2), V(energy_power_supercritical_waste_mix,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_supercritical_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_supercritical_waste_mix,number_of_units),V(energy_power_supercritical_waste_mix,electricity_output_capacity))
 - step_value = 1.0


### PR DESCRIPTION
For electricity plants the slider max is now equal to twice (the installed capacity required to supply) total electricity demand in the present. For heat plants the slider max equals twice the (installed capacity required to supply) total heat production in the present.