### PR TITLE
Fix issue: remove CO2 emissions uranium oxide

### DIFF
--- a/datasets/AT_austria/carriers.csv
+++ b/datasets/AT_austria/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/BE_belgium/carriers.csv
+++ b/datasets/BE_belgium/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/BG_bulgaria/carriers.csv
+++ b/datasets/BG_bulgaria/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/CY_cyprus/carriers.csv
+++ b/datasets/CY_cyprus/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/CZ_czechia/carriers.csv
+++ b/datasets/CZ_czechia/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/DE_germany/carriers.csv
+++ b/datasets/DE_germany/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/DK_denmark/carriers.csv
+++ b/datasets/DK_denmark/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/EE_estonia/carriers.csv
+++ b/datasets/EE_estonia/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/EL_greece/carriers.csv
+++ b/datasets/EL_greece/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/ES_spain/carriers.csv
+++ b/datasets/ES_spain/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/EU27_european_union_27_countries/carriers.csv
+++ b/datasets/EU27_european_union_27_countries/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/FI_finland/carriers.csv
+++ b/datasets/FI_finland/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/FR_france/carriers.csv
+++ b/datasets/FR_france/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/HR_croatia/carriers.csv
+++ b/datasets/HR_croatia/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/HU_hungary/carriers.csv
+++ b/datasets/HU_hungary/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/IE_ireland/carriers.csv
+++ b/datasets/IE_ireland/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/IT_italy/carriers.csv
+++ b/datasets/IT_italy/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/LT_lithuania/carriers.csv
+++ b/datasets/LT_lithuania/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/LU_luxembourg/carriers.csv
+++ b/datasets/LU_luxembourg/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/LV_latvia/carriers.csv
+++ b/datasets/LV_latvia/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/MT_malta/carriers.csv
+++ b/datasets/MT_malta/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/PL_poland/carriers.csv
+++ b/datasets/PL_poland/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/PT_portugal/carriers.csv
+++ b/datasets/PT_portugal/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/RO_romania/carriers.csv
+++ b/datasets/RO_romania/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/SE_sweden/carriers.csv
+++ b/datasets/SE_sweden/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/SI_slovenia/carriers.csv
+++ b/datasets/SI_slovenia/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/SK_slovakia/carriers.csv
+++ b/datasets/SK_slovakia/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/UKNI01_northern_ireland/carriers.csv
+++ b/datasets/UKNI01_northern_ireland/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/UK_united_kingdom/carriers.csv
+++ b/datasets/UK_united_kingdom/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0.0,0.0,
 solar_thermal,0.0,0.0,
 steam_hot_water,0.0,0.0,
 torrefied_biomass_pellets,0.0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0.0,0.0,
 water,0.0,0.0,
 wet_biomass,0.0,0.0,

--- a/datasets/eu/carriers.csv
+++ b/datasets/eu/carriers.csv
@@ -43,7 +43,7 @@ solar_radiation,0,0,
 solar_thermal,0,0,
 steam_hot_water,0,0,
 torrefied_biomass_pellets,0,0.0062587,0.112
-uranium_oxide,0.000155982,0.000155982,
+uranium_oxide,0.0,0.000155982,
 useable_heat,0,0,
 water,0,0,
 wet_biomass,0,0,


### PR DESCRIPTION
In [this old commit ](https://github.com/quintel/etsource/commit/d5dc5e60f75f8f6d9b018d50e98b13328a36be0a) CO2 emissions were accidentally added to uranium oxide. This new commit removes the CO2 emissions for all EU countries