### PR TITLE
Prevent fuel production input slider of Estonia from breaking

### DIFF
--- a/gqueries/general/primary_demand/primary_demand_of_fossil_and_fossil_from_export.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_fossil_and_fossil_from_export.gql
@@ -1,0 +1,6 @@
+- query =
+    SUM(
+      Q(primary_demand_of_fossil),
+      Q(primary_demand_of_fossil_from_export)
+    )
+- unit = MJ

--- a/gqueries/general/primary_demand/primary_demand_of_fossil_from_export.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_fossil_from_export.gql
@@ -1,0 +1,4 @@
+# Primary demand of fossil carriers. Includes uranium.
+
+- unit = MJ
+- query = V(G(energy_export), primary_demand_of_fossil).sum

--- a/inputs/supply/fuel_production/fuel_production_coal.ad
+++ b/inputs/supply/fuel_production/fuel_production_coal.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_extraction_coal), demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:Q(primary_demand_of_fossil)/BILLIONS
+- max_value_gql = present:Q(primary_demand_of_fossil_and_fossil_from_export)/BILLIONS
 - min_value = 0.0
 - start_value_gql = present:V(energy_extraction_coal, demand)/BILLIONS
 - step_value = 0.1

--- a/inputs/supply/fuel_production/fuel_production_crude_oil.ad
+++ b/inputs/supply/fuel_production/fuel_production_crude_oil.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_extraction_crude_oil), demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:Q(primary_demand_of_fossil)/BILLIONS
+- max_value_gql = present:Q(primary_demand_of_fossil_and_fossil_from_export)/BILLIONS
 - min_value = 0.0
 - start_value_gql = present:V(energy_extraction_crude_oil, demand)/BILLIONS
 - step_value = 0.1

--- a/inputs/supply/fuel_production/fuel_production_lignite.ad
+++ b/inputs/supply/fuel_production/fuel_production_lignite.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_extraction_lignite), demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:Q(primary_demand_of_fossil)/BILLIONS
+- max_value_gql = present:Q(primary_demand_of_fossil_and_fossil_from_export)/BILLIONS
 - min_value = 0.0
 - start_value_gql = present:V(energy_extraction_lignite, demand)/BILLIONS
 - step_value = 0.1

--- a/inputs/supply/fuel_production/fuel_production_natural_gas.ad
+++ b/inputs/supply/fuel_production/fuel_production_natural_gas.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_extraction_natural_gas), demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:Q(primary_demand_of_fossil)/BILLIONS
+- max_value_gql = present:Q(primary_demand_of_fossil_and_fossil_from_export)/BILLIONS
 - min_value = 0.0
 - start_value_gql = present:V(energy_extraction_natural_gas, demand)/BILLIONS
 - step_value = 0.1

--- a/inputs/supply/fuel_production/fuel_production_uranium_oxide.ad
+++ b/inputs/supply/fuel_production/fuel_production_uranium_oxide.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_extraction_uranium_oxide), demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:Q(primary_demand_of_fossil)/BILLIONS
+- max_value_gql = present:Q(primary_demand_of_fossil_and_fossil_from_export)/BILLIONS
 - min_value = 0.0
 - start_value_gql = present:V(energy_extraction_uranium_oxide, demand)/BILLIONS
 - step_value = 0.1


### PR DESCRIPTION
The maximum value of the fossil fuel production sliders was set by `primary_demand_of_fossil`, which is the primary demand of fossil fuels caused by final demand. The maximum value of the crude oil fuel production slider for Estonia was 121 PJ. Because the primary production as specified on the energy balance in 2019 was 128 PJ, inputting this value broke the model.

This has been solved by adding a new query that take the primary demand of fossil fuels caused by final demand and export. The maximum value of the fossil fuel production sliders has been set to this new query `primary_demand_of_fossil_and_fossil_from_export`.