### PR TITLE
Add air temperature and agriculture heat user curves

### DIFF
--- a/config/user_curves.yml
+++ b/config/user_curves.yml
@@ -102,6 +102,10 @@
 #       - flh_of_technology_2
 #       - flh_of_technology_3
 
+agriculture_heating:
+  type: profile
+  display_group: agriculture
+
 interconnector_1_price:
   type: price
   display_group: interconnectors
@@ -442,6 +446,10 @@ river:
     as: full_load_hours
     sets:
       - flh_of_hydro_river
+
+weather/air_temperature:
+  type: temperature
+  display_group: weather
 
 weather/wind_offshore_baseline:
   type: capacity_profile


### PR DESCRIPTION
Allows users to upload custom curves for air temperature and agriculture heat.

Goes with https://github.com/quintel/etmodel/pull/4005