### PR TITLE
Update interconnector maximum value

### DIFF
--- a/gqueries/input_elements/max_value/electricity_interconnector_max_capacity.gql
+++ b/gqueries/input_elements/max_value/electricity_interconnector_max_capacity.gql
@@ -1,0 +1,13 @@
+# If there is no interconnection capacity in the start year, the max value is set to the installed electricity production  capacity, else it is set to ten times the start capacity
+
+- query =
+  IF(AREA(interconnector_capacity) == 0,
+    SUM(
+      V(
+        Q(electricity_producing_converters),
+        "input_capacity * electricity_output_conversion * number_of_units"
+      )
+    ),
+    AREA(interconnector_capacity) * 10
+  )
+- unit = MW

--- a/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_1_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:AREA(interconnector_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_10_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_10_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_11_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_11_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_12_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_12_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_2_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_2_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_3_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_3_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_4_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_4_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_5_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_5_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_6_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_6_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_7_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_7_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_8_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_8_imported_electricity, electricity_output_capacity)
 - step_value = 0.1

--- a/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_capacity.ad
@@ -4,7 +4,7 @@
       UPDATE(V(energy_interconnector_9_exported_electricity), typical_input_capacity, USER_INPUT())
     )
 - priority = 0
-- max_value_gql = present:AREA(interconnector_capacity) * 10
+- max_value_gql = present:Q(electricity_interconnector_max_capacity)
 - min_value = 0.0
 - start_value_gql = present:V(energy_interconnector_9_imported_electricity, electricity_output_capacity)
 - step_value = 0.1


### PR DESCRIPTION
Adds IF statement for maximum value of input installed capacity of interconnectors. Maximum value for regions with 0 MW interconnector capacity in start year is set to the total installed electricity production capacity.

Closes https://github.com/quintel/etengine/issues/1270
