### PR TITLE
Add electric planes & ships to merit order and fix issue vans (#2769)

### DIFF
--- a/gqueries/general/merit/mv/mv_transport_load_curve.gql
+++ b/gqueries/general/merit/mv/mv_transport_load_curve.gql
@@ -7,6 +7,9 @@
       transport_passenger_train_using_electricity,
       transport_tram_using_electricity,
       transport_truck_using_electricity,
+      transport_plane_using_electricity,
+      transport_van_using_electricity,
+      transport_ship_using_electricity,
       electricity_input_curve
     ))
 - unit = curve

--- a/graphs/energy/nodes/transport/transport_plane_using_electricity.ad
+++ b/graphs/energy/nodes/transport/transport_plane_using_electricity.ad
@@ -2,5 +2,8 @@
 - energy_balance_group = technologies
 - output.loss = elastic
 - output.passenger_kms = 0.58005218
-- groups = [application_group, passenger_transport]
+- merit_order.group = flat
+- merit_order.level = mv
+- merit_order.type = consumer
+- groups = [application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_ship_using_electricity.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_electricity.ad
@@ -2,6 +2,9 @@
 - energy_balance_group = technologies
 - output.freight_tonne_kms = 6.25718253968254
 - output.loss = elastic
-- groups = [application_group, freight_transport]
+- merit_order.group = flat
+- merit_order.level = mv
+- merit_order.type = consumer
+- groups = [application_group, freight_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0


### PR DESCRIPTION
* Add electric planes & ships to merit order calculation
* Add electric planes, vans & ships to hourly electriciy demand query transport quintel/etmodel#4007
* Add network groups to electric transport nodes

Co-authored-by: Mathijs Bijkerk <mathijs.bijkerk@quintel.com>