### PR TITLE
Add useable heat to final heat demand queries

### DIFF
--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_agriculture.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_buildings.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_bunkers.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_energy.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_households.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_industry.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_other.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_fossil_heat_in_transport.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "(1 - sustainability_share) * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_agriculture.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_buildings.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_bunkers.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_energy.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_households.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_industry.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_other.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_renewable_heat_in_transport.gql
@@ -11,7 +11,7 @@
             ),
             energetic?
           ),
-          steam_hot_water?
+          "steam_hot_water? || useable_heat?"
         ),
         "sustainability_share * value"
       )


### PR DESCRIPTION
Final demand for useable_heat was missing from the heat final demand queries in the multi-year-charts. This created a difference between de final heat in the multi-year-charts and in the ETM.

This has been addressed by adding useable_heat to the queries.

Closes https://github.com/quintel/multi-year-charts/issues/21