### PR TITLE
Fix link flh slider offshore wind turbine for H2

### DIFF
--- a/config/user_curves.yml
+++ b/config/user_curves.yml
@@ -499,6 +499,7 @@ weather/wind_offshore_baseline:
     sets:
       - flh_of_energy_power_wind_turbine_offshore
       - flh_of_energy_power_wind_turbine_offshore_user_curve
+      - flh_of_energy_hydrogen_wind_turbine_offshore
 
 weather/wind_coastal_baseline:
   type: capacity_profile


### PR DESCRIPTION
Now the newly uploaded user curve for offshore wind also updates the flh of  offshore wind turbines for H2. Afterwards it disables the slider.