### PR TITLE
Include non energetic demand in final demand per carrier chart of multi year charts tool

### DIFF
--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_coal_and_derivatives.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_coal_and_derivatives.gql
@@ -3,6 +3,7 @@
 - unit = MJ
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_coal),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_coal_gas)
+      V(G(final_demand_group), input_of_coal),
+      V(G(final_demand_group), input_of_coal_gas),
+      V(G(final_demand_group), input_of_cokes)
     )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_fossil_electricity.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_fossil_electricity.gql
@@ -1,4 +1,4 @@
 # Final demand of fossil electricity
 
 - unit = MJ
-- query = V(INTERSECTION(G(final_demand_group),USE(energetic)), "(1.0 - sustainability_share) * supply_of_electricity").sum
+- query = V(G(final_demand_group), "(1.0 - sustainability_share) * supply_of_electricity").sum

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_fossil_heat.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_fossil_heat.gql
@@ -1,4 +1,4 @@
 # Final demand of fossil heat
 
 - unit = MJ
-- query = SUM(V(INTERSECTION(G(final_demand_group),USE(energetic)), "(1.0 - sustainability_share) * supply_of_steam_hot_water"))
+- query = SUM(V(G(final_demand_group), "(1.0 - sustainability_share) * supply_of_steam_hot_water"))

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_green_gas.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_green_gas.gql
@@ -3,6 +3,6 @@
 - unit = MJ
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_network_gas).sum * V(energy_national_gas_network_natural_gas,greengas_input_conversion),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_compressed_network_gas).sum * V(energy_national_gas_network_natural_gas,greengas_input_conversion)
+      V(G(final_demand_group), input_of_network_gas).sum * V(energy_national_gas_network_natural_gas,greengas_input_conversion),
+      V(G(final_demand_group), input_of_compressed_network_gas).sum * V(energy_national_gas_network_natural_gas,greengas_input_conversion)
     )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_hydrogen.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_hydrogen.gql
@@ -1,4 +1,4 @@
 # Final demand of the hydrogen carrier group
 
 - unit = MJ
-- query = V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_hydrogen).sum
+- query = SUM(V(G(final_demand_group), input_of_hydrogen))

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_liquid_biofuels.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_liquid_biofuels.gql
@@ -3,9 +3,9 @@
 - unit = MJ
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_bio_kerosene),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_bio_lng),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_bio_ethanol),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_biodiesel),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_bio_oil)
+      V(G(final_demand_group), input_of_bio_kerosene),
+      V(G(final_demand_group), input_of_bio_lng),
+      V(G(final_demand_group), input_of_bio_ethanol),
+      V(G(final_demand_group), input_of_biodiesel),
+      V(G(final_demand_group), input_of_bio_oil)
     )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_natural_gas_and_derivatives.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_natural_gas_and_derivatives.gql
@@ -2,8 +2,10 @@
 
 - unit = MJ
 - query =
-    SUM( V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_network_gas).sum *
-    V(energy_national_gas_network_natural_gas,natural_gas_input_conversion),
-    V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_compressed_network_gas).sum *
-    V(energy_national_gas_network_natural_gas,natural_gas_input_conversion),
-    V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_lng).sum )
+    SUM(
+      SUM(V(G(final_demand_group), input_of_network_gas)) *
+      V(energy_national_gas_network_natural_gas,natural_gas_input_conversion),
+      SUM(V(G(final_demand_group), input_of_compressed_network_gas)) *
+      V(energy_national_gas_network_natural_gas,natural_gas_input_conversion),
+      SUM(V(G(final_demand_group), input_of_lng))
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_oil_and_derivatives.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_oil_and_derivatives.gql
@@ -3,10 +3,10 @@
 - unit = MJ
 - query =
     SUM(
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_heavy_fuel_oil),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_kerosene),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_lpg),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_diesel),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_gasoline),
-      V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_crude_oil)
+      V(G(final_demand_group), input_of_heavy_fuel_oil),
+      V(G(final_demand_group), input_of_kerosene),
+      V(G(final_demand_group), input_of_lpg),
+      V(G(final_demand_group), input_of_diesel),
+      V(G(final_demand_group), input_of_gasoline),
+      V(G(final_demand_group), input_of_crude_oil)
     )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_renewable_electricity.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_renewable_electricity.gql
@@ -1,4 +1,4 @@
 # Final demand of sustainable electricity
 
 - unit = MJ
-- query = V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_electricity").sum
+- query = SUM(V(G(final_demand_group), "sustainability_share * supply_of_electricity"))

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_renewable_heat.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_renewable_heat.gql
@@ -2,5 +2,5 @@
 
 - unit = MJ
 - query =
-    SUM(V(INTERSECTION(G(final_demand_group),USE(energetic)), "sustainability_share * supply_of_steam_hot_water")) +
+    SUM(V(G(final_demand_group), "sustainability_share * supply_of_steam_hot_water")) +
       SUM(V(FILTER(EG(final_demand),geothermal?),value))

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_solar_thermal.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_solar_thermal.gql
@@ -1,4 +1,4 @@
 # Final demand of solar solar_thermal
 
 - unit = MJ
-- query = V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_solar_thermal).sum
+- query = SUM(V(G(final_demand_group), input_of_solar_thermal))

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_solid_biofuels.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_solid_biofuels.gql
@@ -1,4 +1,4 @@
 # Final demand of solid biomass products
 
 - unit = MJ
-- query = V(INTERSECTION(G(final_demand_group),USE(energetic)), input_of_wood_pellets).sum
+- query = SUM(V(G(final_demand_group), input_of_wood_pellets))


### PR DESCRIPTION
This PR closes https://github.com/quintel/multi-year-charts/issues/11

It also includes minor improvements to final demand per carrier queries and the addition of cokes final demand to the aggregate coal product group.