### PR TITLE
Don't set el. input curve on battery park outputs

### DIFF
--- a/graphs/energy/nodes/energy/energy_battery_solar_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_battery_solar_electricity.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - energy_balance_group = distribution
-- groups = [electricity_production, always_on_battery_park_production]
+- groups = [electricity_production, always_on_battery_park_production, merit_order_csv_include]
 - free_co2_factor = 0.0
 - electricity_output_capacity = 0.0

--- a/graphs/energy/nodes/energy/energy_battery_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_battery_solar_pv_solar_radiation.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.electricity = 0.17
 - output.loss = elastic
-- groups = [preset_demand, primary_energy_demand, sustainable_production, volatile_production, wacc_proven_tech, costs_production_power_plants]
+- groups = [preset_demand, primary_energy_demand, sustainable_production, volatile_production, wacc_proven_tech, costs_production_power_plants, merit_order_csv_exclude]
 - presentation_group = solar_pv_plant
 - merit_order.group = dynamic: solar_pv
 - merit_order.level = hv

--- a/graphs/energy/nodes/energy/energy_battery_wind_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_battery_wind_electricity.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - energy_balance_group = distribution
-- groups = [electricity_production, always_on_battery_park_production]
+- groups = [electricity_production, always_on_battery_park_production, merit_order_csv_include]
 - free_co2_factor = 0.0
 - electricity_output_capacity = 0.0

--- a/graphs/energy/nodes/energy/energy_battery_wind_turbine_inland.ad
+++ b/graphs/energy/nodes/energy/energy_battery_wind_turbine_inland.ad
@@ -1,7 +1,7 @@
 - use = undefined
 - output.electricity = 0.97
 - output.loss = elastic
-- groups = [preset_demand, primary_energy_demand, sustainable_production, volatile_production, wacc_proven_tech, costs_production_power_plants]
+- groups = [preset_demand, primary_energy_demand, sustainable_production, volatile_production, wacc_proven_tech, costs_production_power_plants, merit_order_csv_exclude]
 - presentation_group = wind_turbine
 - merit_order.group = dynamic: wind_inland
 - merit_order.level = hv


### PR DESCRIPTION
Prevents the node from being included twice in the merit_order.csv file.

Ref quintel/etengine#1283