### PR TITLE
Fix division by zero in some sparse graph queries

### DIFF
--- a/sparse_graph_queries/energy/energy_blastfurnace_transformation_cokes+input.ad
+++ b/sparse_graph_queries/energy/energy_blastfurnace_transformation_cokes+input.ad
@@ -3,8 +3,18 @@
 - query =
     total_input = DATASET_INPUT(input_energy_blastfurnace_transformation_coal_input_demand) + DATASET_INPUT(input_energy_blastfurnace_transformation_cokes_input_demand);
 
-    IF(total_input > 0.0,
-        {coal: DATASET_INPUT(input_energy_blastfurnace_transformation_coal_input_demand) / total_input,
-        cokes: DATASET_INPUT(input_energy_blastfurnace_transformation_cokes_input_demand) / total_input},
-        {coal: 0.44,
-        cokes: 0.56})
+    IF(
+      total_input > 0.0,
+      -> {
+        {
+          coal: DATASET_INPUT(input_energy_blastfurnace_transformation_coal_input_demand) / total_input,
+          cokes: DATASET_INPUT(input_energy_blastfurnace_transformation_cokes_input_demand) / total_input
+        }
+      },
+      -> {
+        {
+          coal: 0.44,
+          cokes: 0.56
+        }
+      }
+    )

--- a/sparse_graph_queries/energy/energy_blastfurnace_transformation_cokes-energy_distribution_coal_gas@coal_gas+child_share.ad
+++ b/sparse_graph_queries/energy/energy_blastfurnace_transformation_cokes-energy_distribution_coal_gas@coal_gas+child_share.ad
@@ -3,4 +3,8 @@
     cokesoven_coal_gas_output = DATASET_INPUT(input_energy_cokesoven_transformation_coal_input_demand) * DATASET_INPUT(input_energy_cokesoven_transformation_coal_gas_output_conversion);
     total_coal_gas_demand = blastfurnace_coal_gas_output + cokesoven_coal_gas_output;
 
-    IF(total_coal_gas_demand > 0.0, blastfurnace_coal_gas_output / total_coal_gas_demand, 0.6907)
+    IF(
+      total_coal_gas_demand > 0.0,
+      -> { blastfurnace_coal_gas_output / total_coal_gas_demand },
+      -> { 0.6907 }
+    ).call

--- a/sparse_graph_queries/energy/energy_distribution_coal_gas-energy_chp_coal_gas@coal_gas+parent_share.ad
+++ b/sparse_graph_queries/energy/energy_distribution_coal_gas-energy_chp_coal_gas@coal_gas+parent_share.ad
@@ -5,4 +5,8 @@
     chp_demand = DATASET_INPUT(input_energy_chp_coal_gas_coal_gas_input_demand);
     total_coal_gas_demand = industry_final_demand + power_plant_demand + chp_demand;
 
-    IF(total_coal_gas_demand > 0.0, chp_demand / total_coal_gas_demand, 0.16)
+    IF(
+      total_coal_gas_demand > 0.0,
+      -> { chp_demand / total_coal_gas_demand },
+      -> { 0.16 }
+    ).call

--- a/sparse_graph_queries/energy/energy_distribution_coal_gas-energy_power_combined_cycle_coal_gas@coal_gas+parent_share.ad
+++ b/sparse_graph_queries/energy/energy_distribution_coal_gas-energy_power_combined_cycle_coal_gas@coal_gas+parent_share.ad
@@ -6,4 +6,8 @@
     total_coal_gas_demand = industry_final_demand + power_plant_demand + chp_demand;
     total_coal_gas_demand = IF(total_coal_gas_demand > 0.0, total_coal_gas_demand, 1.0);
 
-    IF(total_coal_gas_demand > 0.0, power_plant_demand / total_coal_gas_demand, 0.326)
+    IF(
+      total_coal_gas_demand > 0.0,
+      -> { power_plant_demand / total_coal_gas_demand },
+      -> { 0.326 }
+    ).call

--- a/sparse_graph_queries/industry/metal/industry_other_metals_burner_network_gas+input.ad
+++ b/sparse_graph_queries/industry/metal/industry_other_metals_burner_network_gas+input.ad
@@ -7,11 +7,20 @@
     other_metals_burner_network_gas_network_gas = DATASET_INPUT(input_industry_metal_other_network_gas_demand);
     other_metals_burner_network_gas_total = other_metals_burner_network_gas_coal + other_metals_burner_network_gas_crude_oil + other_metals_burner_network_gas_network_gas;
 
-    IF(other_metals_burner_network_gas_total > 0.0, {
-        coal: other_metals_burner_network_gas_coal / other_metals_burner_network_gas_total,
-        crude_oil: other_metals_burner_network_gas_crude_oil / other_metals_burner_network_gas_total,
-        network_gas: other_metals_burner_network_gas_network_gas / other_metals_burner_network_gas_total }, {
-        coal: 1.0,
-        crude_oil: 0.0,
-        network_gas: 0.0}
-        )
+    IF(
+      other_metals_burner_network_gas_total > 0.0,
+      -> {
+        {
+          coal: other_metals_burner_network_gas_coal / other_metals_burner_network_gas_total,
+          crude_oil: other_metals_burner_network_gas_crude_oil / other_metals_burner_network_gas_total,
+          network_gas: other_metals_burner_network_gas_network_gas / other_metals_burner_network_gas_total
+        }
+      },
+      -> {
+        {
+          coal: 1.0,
+          crude_oil: 0.0,
+          network_gas: 0.0
+        }
+      }
+    )

--- a/sparse_graph_queries/industry/metal/industry_steel_blastfurnace_bof+input.ad
+++ b/sparse_graph_queries/industry/metal/industry_steel_blastfurnace_bof+input.ad
@@ -11,21 +11,30 @@
     blastfurnace_bof_crude_oil = DATASET_INPUT(input_industry_metal_steel_crude_oil_demand) * DATASET_INPUT(industry_final_demand_for_metal_steel_crude_oil_industry_steel_blastfurnace_bof_parent_share);
     blastfurnace_bof_total = blastfurnace_bof_coal + blastfurnace_bof_electricity + blastfurnace_bof_network_gas + blastfurnace_bof_wood_pellets + blastfurnace_bof_coal_gas + blastfurnace_bof_cokes + blastfurnace_bof_steam_hot_water + blastfurnace_bof_crude_oil;
 
-    IF(blastfurnace_bof_total > 0.0, {
-        coal: blastfurnace_bof_coal / blastfurnace_bof_total,
-        electricity: blastfurnace_bof_electricity / blastfurnace_bof_total,
-        network_gas: blastfurnace_bof_network_gas / blastfurnace_bof_total,
-        wood_pellets: blastfurnace_bof_wood_pellets / blastfurnace_bof_total,
-        coal_gas: blastfurnace_bof_coal_gas / blastfurnace_bof_total,
-        cokes: blastfurnace_bof_cokes / blastfurnace_bof_total,
-        steam_hot_water: blastfurnace_bof_steam_hot_water / blastfurnace_bof_total,
-        crude_oil: blastfurnace_bof_crude_oil / blastfurnace_bof_total}, {
-        coal: 0.0455,
-        electricity: 0.1809,
-        network_gas: 0.1956,
-        wood_pellets: 0.0,
-        coal_gas: 0.5097,
-        cokes: 0.0651,
-        steam_hot_water: 0.0,
-        crude_oil: 0.0032}
-        )
+    IF(
+      blastfurnace_bof_total > 0.0,
+      -> {
+        {
+          coal: blastfurnace_bof_coal / blastfurnace_bof_total,
+          electricity: blastfurnace_bof_electricity / blastfurnace_bof_total,
+          network_gas: blastfurnace_bof_network_gas / blastfurnace_bof_total,
+          wood_pellets: blastfurnace_bof_wood_pellets / blastfurnace_bof_total,
+          coal_gas: blastfurnace_bof_coal_gas / blastfurnace_bof_total,
+          cokes: blastfurnace_bof_cokes / blastfurnace_bof_total,
+          steam_hot_water: blastfurnace_bof_steam_hot_water / blastfurnace_bof_total,
+          crude_oil: blastfurnace_bof_crude_oil / blastfurnace_bof_total
+        }
+      },
+      -> {
+        {
+          coal: 0.0455,
+          electricity: 0.1809,
+          network_gas: 0.1956,
+          wood_pellets: 0.0,
+          coal_gas: 0.5097,
+          cokes: 0.0651,
+          steam_hot_water: 0.0,
+          crude_oil: 0.0032
+        }
+      }
+    )

--- a/sparse_graph_queries/industry/metal/industry_steel_blastfurnace_bof+output.ad
+++ b/sparse_graph_queries/industry/metal/industry_steel_blastfurnace_bof+output.ad
@@ -13,7 +13,12 @@
     blastfurnace_bof_total = blastfurnace_bof_coal + blastfurnace_bof_electricity + blastfurnace_bof_network_gas + blastfurnace_bof_wood_pellets + blastfurnace_bof_coal_gas + blastfurnace_bof_cokes + blastfurnace_bof_steam_hot_water + blastfurnace_bof_crude_oil;
     steel_output = DATASET_INPUT(input_industry_metal_steel_production) * DATASET_INPUT(input_industry_steel_blastfurnace_bof_share);
 
-    IF(blastfurnace_bof_total > 0.0, {
-        not_defined: steel_output * 1000.0 / blastfurnace_bof_total}, {
-        not_defined: 0.129012}
-        )
+    IF(
+      blastfurnace_bof_total > 0.0,
+      -> {
+        { not_defined: steel_output * 1000.0 / blastfurnace_bof_total }
+      },
+      -> {
+        { not_defined: 0.129012 }
+      }
+    )

--- a/sparse_graph_queries/industry/metal/industry_steel_scrap_hbi_eaf+input.ad
+++ b/sparse_graph_queries/industry/metal/industry_steel_scrap_hbi_eaf+input.ad
@@ -10,19 +10,28 @@
     scrap_hbi_wood_pellets = DATASET_INPUT(input_industry_metal_steel_wood_pellets_demand) * (1 - DATASET_INPUT(industry_final_demand_for_metal_steel_wood_pellets_industry_steel_blastfurnace_bof_parent_share));
     scrap_hbi_total = scrap_hbi_coal + scrap_hbi_electricity + scrap_hbi_network_gas + scrap_hbi_cokes + scrap_hbi_crude_oil + scrap_hbi_steam_hot_water + scrap_hbi_wood_pellets;
 
-    IF(scrap_hbi_total > 0.0, {
-        coal: scrap_hbi_coal / scrap_hbi_total,
-        electricity: scrap_hbi_electricity / scrap_hbi_total,
-        network_gas: scrap_hbi_network_gas / scrap_hbi_total,
-        cokes: scrap_hbi_cokes / scrap_hbi_total,
-        crude_oil: scrap_hbi_crude_oil / scrap_hbi_total,
-        steam_hot_water: scrap_hbi_steam_hot_water / scrap_hbi_total,
-        wood_pellets: scrap_hbi_wood_pellets / scrap_hbi_total, }, {
-        coal: 0.17635,
-        electricity: 0.24449,
-        network_gas: 0.57916,
-        cokes: 0.0,
-        crude_oil: 0.0,
-        steam_hot_water: 0.0,
-        wood_pellets: 0.0}
-        )
+    IF(
+      scrap_hbi_total > 0.0,
+      -> {
+        {
+          coal: scrap_hbi_coal / scrap_hbi_total,
+          electricity: scrap_hbi_electricity / scrap_hbi_total,
+          network_gas: scrap_hbi_network_gas / scrap_hbi_total,
+          cokes: scrap_hbi_cokes / scrap_hbi_total,
+          crude_oil: scrap_hbi_crude_oil / scrap_hbi_total,
+          steam_hot_water: scrap_hbi_steam_hot_water / scrap_hbi_total,
+          wood_pellets: scrap_hbi_wood_pellets / scrap_hbi_total
+        }
+      },
+      -> {
+        {
+          coal: 0.17635,
+          electricity: 0.24449,
+          network_gas: 0.57916,
+          cokes: 0.0,
+          crude_oil: 0.0,
+          steam_hot_water: 0.0,
+          wood_pellets: 0.0
+        }
+      }
+    )

--- a/sparse_graph_queries/industry/metal/industry_steel_scrap_hbi_eaf+output.ad
+++ b/sparse_graph_queries/industry/metal/industry_steel_scrap_hbi_eaf+output.ad
@@ -12,7 +12,8 @@
     scrap_hbi_total = scrap_hbi_coal + scrap_hbi_electricity + scrap_hbi_network_gas + scrap_hbi_cokes + scrap_hbi_crude_oil + scrap_hbi_steam_hot_water + scrap_hbi_wood_pellets;
     steel_output = DATASET_INPUT(input_industry_metal_steel_production) * (1 - DATASET_INPUT(input_industry_steel_blastfurnace_bof_share));
 
-    IF(scrap_hbi_total > 0.0, {
-        not_defined: steel_output * 1000.0 / scrap_hbi_total}, {
-        not_defined: 0.2004}
-        )
+    IF(
+      scrap_hbi_total > 0.0,
+      -> { { not_defined: steel_output * 1000.0 / scrap_hbi_total } },
+      -> { { not_defined: 0.2004 } }
+    )

--- a/sparse_graph_queries/transport/transport_rail_mixer_diesel+input.ad
+++ b/sparse_graph_queries/transport/transport_rail_mixer_diesel+input.ad
@@ -4,9 +4,18 @@
 - query =
   total_rail_mixer_diesel_demand = DATASET_INPUT(input_transport_rail_diesel_demand) + DATASET_INPUT(input_transport_rail_biodiesel_demand);
 
-  IF(total_rail_mixer_diesel_demand > 0.0, {
-    diesel: DATASET_INPUT(input_transport_rail_diesel_demand) / total_rail_mixer_diesel_demand,
-    biodiesel: DATASET_INPUT(input_transport_rail_biodiesel_demand) / total_rail_mixer_diesel_demand }, {
-    diesel: 1.0,
-    biodiesel: 0.0}
+  IF(
+    total_rail_mixer_diesel_demand > 0.0,
+    -> {
+      {
+        diesel: DATASET_INPUT(input_transport_rail_diesel_demand) / total_rail_mixer_diesel_demand,
+        biodiesel: DATASET_INPUT(input_transport_rail_biodiesel_demand) / total_rail_mixer_diesel_demand
+      }
+    },
+    -> {
+      {
+        diesel: 1.0,
+        biodiesel: 0.0
+      }
+    }
   )

--- a/sparse_graph_queries/transport/transport_road_mixer_diesel+input.ad
+++ b/sparse_graph_queries/transport/transport_road_mixer_diesel+input.ad
@@ -4,9 +4,18 @@
 - query =
   total_road_mixer_diesel_demand = DATASET_INPUT(input_transport_road_diesel_demand) + DATASET_INPUT(input_transport_road_biodiesel_demand);
 
-  IF(total_road_mixer_diesel_demand > 0.0, {
-    diesel: DATASET_INPUT(input_transport_road_diesel_demand) / total_road_mixer_diesel_demand,
-    biodiesel: DATASET_INPUT(input_transport_road_biodiesel_demand) / total_road_mixer_diesel_demand }, {
-    diesel: 1.0,
-    biodiesel: 0.0}
+  IF(
+    total_road_mixer_diesel_demand > 0.0,
+    -> {
+      {
+        diesel: DATASET_INPUT(input_transport_road_diesel_demand) / total_road_mixer_diesel_demand,
+        biodiesel: DATASET_INPUT(input_transport_road_biodiesel_demand) / total_road_mixer_diesel_demand
+      }
+    },
+    -> {
+      {
+        diesel: 1.0,
+        biodiesel: 0.0
+      }
+    }
   )

--- a/sparse_graph_queries/transport/transport_road_mixer_gasoline+input.ad
+++ b/sparse_graph_queries/transport/transport_road_mixer_gasoline+input.ad
@@ -4,9 +4,18 @@
 - query =
   total_road_mixer_gasoline_demand = DATASET_INPUT(input_transport_road_gasoline_demand) + DATASET_INPUT(input_transport_road_bio_ethanol_demand);
 
-  IF(total_road_mixer_gasoline_demand > 0.0, {
-    gasoline: DATASET_INPUT(input_transport_road_gasoline_demand) / total_road_mixer_gasoline_demand,
-    bio_ethanol: DATASET_INPUT(input_transport_road_bio_ethanol_demand) / total_road_mixer_gasoline_demand }, {
-    gasoline: 1.0,
-    bio_ethanol: 0.0}
+  IF(
+    total_road_mixer_gasoline_demand > 0.0,
+    -> {
+      {
+        gasoline: DATASET_INPUT(input_transport_road_gasoline_demand) / total_road_mixer_gasoline_demand,
+        bio_ethanol: DATASET_INPUT(input_transport_road_bio_ethanol_demand) / total_road_mixer_gasoline_demand
+      }
+    },
+    -> {
+      {
+        gasoline: 1.0,
+        bio_ethanol: 0.0
+      }
+    }
   )

--- a/sparse_graph_queries/transport/transport_road_mixer_lng+input.ad
+++ b/sparse_graph_queries/transport/transport_road_mixer_lng+input.ad
@@ -4,9 +4,18 @@
 - query =
   total_road_mixer_lng_demand = DATASET_INPUT(transport_final_demand_for_road_lng_demand) + DATASET_INPUT(transport_final_demand_for_road_bio_lng_demand);
 
-  IF(total_road_mixer_lng_demand > 0.0, {
-    lng: DATASET_INPUT(transport_final_demand_for_road_lng_demand) / total_road_mixer_lng_demand,
-    bio_lng: DATASET_INPUT(transport_final_demand_for_road_bio_lng_demand) / total_road_mixer_lng_demand }, {
-    lng: SHARE("energy/transport_road_mixer_lng_child_share", transport_final_demand_for_road_lng),
-    bio_lng: SHARE("energy/transport_road_mixer_lng_child_share", transport_final_demand_for_road_bio_lng)}
+  IF(
+    total_road_mixer_lng_demand > 0.0,
+    -> {
+      {
+        lng: DATASET_INPUT(transport_final_demand_for_road_lng_demand) / total_road_mixer_lng_demand,
+        bio_lng: DATASET_INPUT(transport_final_demand_for_road_bio_lng_demand) / total_road_mixer_lng_demand
+      }
+    },
+    -> {
+      {
+        lng: SHARE("energy/transport_road_mixer_lng_child_share", transport_final_demand_for_road_lng),
+        bio_lng: SHARE("energy/transport_road_mixer_lng_child_share", transport_final_demand_for_road_bio_lng)
+      }
+    }
   )

--- a/sparse_graph_queries/transport/transport_shipping_mixer_diesel+input.ad
+++ b/sparse_graph_queries/transport/transport_shipping_mixer_diesel+input.ad
@@ -4,15 +4,24 @@
 - query =
     total_shipping_mixer_diesel_demand = DATASET_INPUT(input_transport_ship_diesel_demand) + DATASET_INPUT(input_transport_ship_biodiesel_demand) + DATASET_INPUT(transport_final_demand_heavy_fuel_oil_demand);
 
-    IF(total_shipping_mixer_diesel_demand > 0.0, {
-        lng: 0.0,
-        bio_lng: 0.0,
-        diesel: DATASET_INPUT(input_transport_ship_diesel_demand) / total_shipping_mixer_diesel_demand,
-        biodiesel: DATASET_INPUT(input_transport_ship_biodiesel_demand) / total_shipping_mixer_diesel_demand,
-        heavy_fuel_oil: DATASET_INPUT(transport_final_demand_heavy_fuel_oil_demand) / total_shipping_mixer_diesel_demand }, {
-        lng: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_lng),
-        bio_lng: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_bio_lng),
-        diesel: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_diesel),
-        biodiesel: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_biodiesel),
-        heavy_fuel_oil: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_heavy_fuel_oil)}
-        )
+    IF(
+      total_shipping_mixer_diesel_demand > 0.0,
+      -> {
+        {
+          lng: 0.0,
+          bio_lng: 0.0,
+          diesel: DATASET_INPUT(input_transport_ship_diesel_demand) / total_shipping_mixer_diesel_demand,
+          biodiesel: DATASET_INPUT(input_transport_ship_biodiesel_demand) / total_shipping_mixer_diesel_demand,
+          heavy_fuel_oil: DATASET_INPUT(transport_final_demand_heavy_fuel_oil_demand) / total_shipping_mixer_diesel_demand
+        }
+      },
+      -> {
+        {
+          lng: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_lng),
+          bio_lng: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_bio_lng),
+          diesel: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_diesel),
+          biodiesel: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_biodiesel),
+          heavy_fuel_oil: SHARE("energy/transport_shipping_mixer_diesel_child_share", transport_final_demand_for_shipping_heavy_fuel_oil)
+        }
+      }
+    )

--- a/sparse_graph_queries/transport/transport_shipping_mixer_lng+input.ad
+++ b/sparse_graph_queries/transport/transport_shipping_mixer_lng+input.ad
@@ -4,9 +4,18 @@
 - query =
     total_shipping_mixer_lng_demand = DATASET_INPUT(transport_final_demand_for_shipping_lng_demand) + DATASET_INPUT(transport_final_demand_for_shipping_bio_lng_demand);
 
-    IF(total_shipping_mixer_lng_demand > 0.0, {
-      lng: DATASET_INPUT(transport_final_demand_for_shipping_lng_demand) / total_shipping_mixer_lng_demand,
-      bio_lng: DATASET_INPUT(transport_final_demand_for_shipping_bio_lng_demand) / total_shipping_mixer_lng_demand }, {
-      lng: SHARE("energy/transport_shipping_mixer_lng_child_share", transport_final_demand_for_shipping_lng),
-      bio_lng: SHARE("energy/transport_shipping_mixer_lng_child_share", transport_final_demand_for_shipping_bio_lng)}
+    IF(
+      total_shipping_mixer_lng_demand > 0.0,
+      ->{
+        {
+          lng: DATASET_INPUT(transport_final_demand_for_shipping_lng_demand) / total_shipping_mixer_lng_demand,
+          bio_lng: DATASET_INPUT(transport_final_demand_for_shipping_bio_lng_demand) / total_shipping_mixer_lng_demand
+        }
+      },
+      -> {
+        {
+          lng: SHARE("energy/transport_shipping_mixer_lng_child_share", transport_final_demand_for_shipping_lng),
+          bio_lng: SHARE("energy/transport_shipping_mixer_lng_child_share", transport_final_demand_for_shipping_bio_lng)
+        }
+      }
     )


### PR DESCRIPTION
Sparse graph queries were using `IF` without surrounding each branch in a lambda. This resulted in both branches always being executed, which causes errors when the divisor was actually zero.

It looks like the queries have been this way for a while; I guess it hasn't been a problem before since the divisor was always non-zero.

There may be other queries with the same mistake, but I found and fixes all those that prevent exporting the Singapore dataset.

For example:

### Bad:

```ruby
IF(value > 0, something / value, 0)
```

### Good

```ruby
IF(value > 0, -> { something / value }, -> { 0 })
```