### PR TITLE
Fix spelling mistake in biomass gasification input

### DIFF
--- a/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification.ad
@@ -1,5 +1,5 @@
 - input.network_gas = 0.023057412958266084
-- input.torrified_biomass_pellets = 0.9769425870417339
+- input.torrefied_biomass_pellets = 0.9769425870417339
 - output.hydrogen = 0.461
 - output.loss = elastic
 - groups = [hydrogen_production, wacc_unproven_tech, costs_production_dedicated_hydrogen_production]

--- a/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification_ccs.ad
@@ -1,5 +1,5 @@
 - input.network_gas = 0.02419636984480177
-- input.torrified_biomass_pellets = 0.9758036301551982
+- input.torrefied_biomass_pellets = 0.9758036301551982
 - output.hydrogen = 0.44799999999999995
 - output.loss = elastic
 - groups = [hydrogen_production, wacc_unproven_tech, costs_production_dedicated_hydrogen_production]


### PR DESCRIPTION
Torrefied biomass pellets was misspelled as torrified biomass pellets, preventing negative emissions to occur for hydrogen production through biomass gasification with CCS.