### PR TITLE
Change annual electricity output to charge cycles in electricity storage table

### DIFF
--- a/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_flow_batteries_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_flow_batteries_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(energy_flexibility_flow_batteries_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(energy_flexibility_flow_batteries_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_hv_opac_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_hv_opac_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(energy_flexibility_hv_opac_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(energy_flexibility_hv_opac_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_mv_batteries_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_mv_batteries_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(energy_flexibility_mv_batteries_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(energy_flexibility_mv_batteries_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_pumped_storage_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/energy_flexibility_pumped_storage_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(energy_flexibility_pumped_storage_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(energy_flexibility_pumped_storage_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/households_flexibility_p2p_electricity_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/households_flexibility_p2p_electricity_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(households_flexibility_p2p_electricity_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(households_flexibility_p2p_electricity_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/transport_bus_flexibility_p2p_electricity_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/transport_bus_flexibility_p2p_electricity_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(transport_bus_flexibility_p2p_electricity_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(transport_bus_flexibility_p2p_electricity_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/transport_car_flexibility_p2p_electricity_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/transport_car_flexibility_p2p_electricity_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(transport_car_flexibility_p2p_electricity_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(transport_car_flexibility_p2p_electricity_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/transport_truck_flexibility_p2p_electricity_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/transport_truck_flexibility_p2p_electricity_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(transport_truck_flexibility_p2p_electricity_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(transport_truck_flexibility_p2p_electricity_storage_volume)
+    )
+- unit = number

--- a/gqueries/output_elements/output_series/table_storage_specifications/transport_van_flexibility_p2p_electricity_full_charge_cycles.gql
+++ b/gqueries/output_elements/output_series/table_storage_specifications/transport_van_flexibility_p2p_electricity_full_charge_cycles.gql
@@ -1,0 +1,9 @@
+- query = 
+    DIVIDE(
+      DIVIDE(
+        PRODUCT(Q(transport_van_flexibility_p2p_electricity_annual_input),BILLIONS),
+        MJ_PER_MWH
+      ),
+      Q(transport_van_flexibility_p2p_electricity_storage_volume)
+    )
+- unit = number


### PR DESCRIPTION
This PR adds queries to calculate the number of charge cycles for electricity storage technologies to be displayed in the `Electricity storage technologies specifications` [table](https://energytransitionmodel.com/scenario/flexibility/flexibility_forecast_storage_order/forecasting-storage-order), instead of the annual electricity output.

It goes with https://github.com/quintel/etmodel/pull/4079