### PR TITLE
Updates to the costs data-export

### DIFF
--- a/gqueries/general/costs/costs_hydrogen_storage.gql
+++ b/gqueries/general/costs/costs_hydrogen_storage.gql
@@ -1,0 +1,6 @@
+- query = 
+    PRODUCT(
+          V(energy_hydrogen_storage, "storage.cost_per_mwh"),
+          V(energy_hydrogen_storage, "storage.volume")
+    )
+- unit = euro


### PR DESCRIPTION
There are a number of issues with the costs data-export, as described in https://github.com/quintel/etsource/issues/2859:

Goes with https://github.com/quintel/etengine/pull/1323

Fixes include the following:

- Structure of totals is changed slightly so that Group totals are clearly defined
- Hydrogen storage costs is now assigned the right query, so that a value is displayed
- CO2 costs are now assigned the right queries, so that values are displayed
- Heat infrastructure costs query is now assigned the right query, so that double-counting with the heat storage costs is avoided
- Hydrogen infrastructure costs total query is now removed from the data-export, so that double-counting with the two underlying queries that are also in the data-export is avoided
- Ammonia carrier costs has been added to the data-export

Fixes do **not** include the following:

- All CCS costs are included in the CO2 costs queries in the row "Total ex ccs". Conceptually this does not make sense and it should be addressed