### PR TITLE
Minor fixes for the energy flows (overview) data export

### DIFF
--- a/config/sankey_csv.yml
+++ b/config/sankey_csv.yml
@@ -1,4 +1,4 @@
-# The configuration should have two keys:
+  # The configuration should have two keys:
 #
 # - schema: An array of hashes describing each column in the CSV. Each hash should contain a `name`
 #           key and optionally a `type` key.
@@ -1170,7 +1170,7 @@ rows:
     Type: Input
     Value: biomass_products_to_central_heat_prod_in_sankey
   - Group: Conversion
-    Carrier: Green gas
+    Carrier: Biomass
     Category: Residual green gas from industry
     Type: Output
     Value: conversion_industry_residual_greengas

--- a/gqueries/general/conversion/hydrogen/direct_electrolysis_solar_in_source_of_hydrogen_production.gql
+++ b/gqueries/general/conversion/hydrogen/direct_electrolysis_solar_in_source_of_hydrogen_production.gql
@@ -3,7 +3,7 @@
 - query =
     DIVIDE(
       V(
-        energy_hydrogen_solar_pv_solar_radiation,
+        energy_hydrogen_electrolysis_solar_electricity,
         output_of_hydrogen
       ),
       BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_electricity_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_electricity_from_curtailment.gql
@@ -5,5 +5,6 @@
     SUM(
        V(energy_flexibility_curtailment_electricity, primary_demand_of_electricity),
        V(energy_battery_curtailed_solar_electricity, primary_demand_of_electricity),
-       V(energy_battery_curtailed_wind_electricity, primary_demand_of_electricity)
+       V(energy_battery_curtailed_wind_electricity, primary_demand_of_electricity),
+       V(energy_hydrogen_curtailed_electricity, primary_demand_of_electricity)
     ) / BILLIONS


### PR DESCRIPTION
This PR includes two fixes:

- Direct electrolysis of solar electricity referred to the wrong node
- Curtailment of solar and wind electricity for direct electrolysis was not included in curtailment query and therefore not included in electricity to electricity losses. @redekok what is you assessment, am I right to include it?