### PR TITLE
Add reservoirs to storage forecasting merit order

### DIFF
--- a/config/forecast_storage_order.yml
+++ b/config/forecast_storage_order.yml
@@ -4,6 +4,7 @@
 - energy_flexibility_flow_batteries_electricity
 - energy_flexibility_hv_opac_electricity
 - energy_flexibility_mv_batteries_electricity
+- energy_flexibility_pumped_storage_electricity
 - households_flexibility_p2p_electricity
 - transport_bus_flexibility_p2p_electricity
 - transport_car_flexibility_p2p_electricity

--- a/gqueries/general/merit/user_sortable/forecast_storage/user_sortable_energy_flexibility_pumped_storage_electricity_capacity.gql
+++ b/gqueries/general/merit/user_sortable/forecast_storage/user_sortable_energy_flexibility_pumped_storage_electricity_capacity.gql
@@ -1,0 +1,7 @@
+- query =
+    PRODUCT(
+      V(energy_flexibility_pumped_storage_electricity, "number_of_units * input_capacity"),
+      V(energy_flexibility_pumped_storage_electricity, availability)
+    )
+
+- unit = MW

--- a/gqueries/general/merit/user_sortable/forecast_storage/user_sortable_energy_flexibility_pumped_storage_electricity_is_sortable.gql
+++ b/gqueries/general/merit/user_sortable/forecast_storage/user_sortable_energy_flexibility_pumped_storage_electricity_is_sortable.gql
@@ -1,0 +1,8 @@
+- query =
+    IF(
+      V(energy_flexibility_pumped_storage_electricity, "merit_order.subtype") == :optimizing_storage,
+      -> { true },
+      -> { false }
+    )
+
+- unit = boolean


### PR DESCRIPTION
Closes https://github.com/quintel/etsource/pull/2874
Goes with https://github.com/quintel/etmodel/pull/4095

@noracato could you check if I haven't missed anything in configuring this additional storage technology for the forecasting merit order? See Anthony's previous PRs:

- https://github.com/quintel/etengine/pull/1313
- https://github.com/quintel/etsource/pull/2837