### PR TITLE
Include additional nodes in curtailment

### DIFF
--- a/gqueries/general/primary_demand/primary_demand_of_biofuels_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biofuels_from_curtailment.gql
@@ -3,9 +3,9 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_biodiesel),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_bio_ethanol),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_bio_kerosene),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_bio_lng),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_bio_oil)
+       V(G(curtailment_group), primary_demand_of_biodiesel),
+       V(G(curtailment_group), primary_demand_of_bio_ethanol),
+       V(G(curtailment_group), primary_demand_of_bio_kerosene),
+       V(G(curtailment_group), primary_demand_of_bio_lng),
+       V(G(curtailment_group), primary_demand_of_bio_oil)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_biogas_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biogas_from_curtailment.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_biogas)
+       V(G(curtailment_group), primary_demand_of_biogas)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_biogenic_waste_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biogenic_waste_from_curtailment.gql
@@ -1,3 +1,3 @@
 - unit = MJ
 - query =
-    V(G(energy_flexibility_curtailment_electricity),primary_demand_of_biogenic_waste)
+    V(G(curtailment_group),primary_demand_of_biogenic_waste)

--- a/gqueries/general/primary_demand/primary_demand_of_biomass_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_biomass_from_curtailment.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_torrefied_biomass_pellets),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_wood_pellets)
+       V(G(curtailment_group), primary_demand_of_torrefied_biomass_pellets),
+       V(G(curtailment_group), primary_demand_of_wood_pellets)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_coal_and_derivatives_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_coal_and_derivatives_from_curtailment.gql
@@ -3,7 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_coal),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_coal_gas),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_cokes)
+       V(G(curtailment_group), primary_demand_of_coal),
+       V(G(curtailment_group), primary_demand_of_coal_gas),
+       V(G(curtailment_group), primary_demand_of_cokes)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_electricity_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_electricity_from_curtailment.gql
@@ -3,8 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_electricity),
-       V(energy_battery_curtailed_solar_electricity, primary_demand_of_electricity),
-       V(energy_battery_curtailed_wind_electricity, primary_demand_of_electricity),
-       V(energy_hydrogen_curtailed_electricity, primary_demand_of_electricity)
+       V(G(curtailment_group), primary_demand_of_electricity)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_greengas_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_greengas_from_curtailment.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_greengas)
+       V(G(curtailment_group), primary_demand_of_greengas)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_imported_ammonia_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_imported_ammonia_from_curtailment.gql
@@ -1,5 +1,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_imported_ammonia)
+       V(G(curtailment_group), primary_demand_of_imported_ammonia)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_imported_electricity_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_imported_electricity_from_curtailment.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_imported_electricity)
+       V(G(curtailment_group), primary_demand_of_imported_electricity)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_imported_heat_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_imported_heat_from_curtailment.gql
@@ -1,5 +1,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_imported_heat)
+       V(G(curtailment_group), primary_demand_of_imported_heat)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_imported_hydrogen_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_imported_hydrogen_from_curtailment.gql
@@ -1,5 +1,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_imported_hydrogen)
+       V(G(curtailment_group), primary_demand_of_imported_hydrogen)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_lignite_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_lignite_from_curtailment.gql
@@ -1,5 +1,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_lignite)
+       V(G(curtailment_group), primary_demand_of_lignite)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_lng_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_lng_from_curtailment.gql
@@ -1,5 +1,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_lng)
+       V(G(curtailment_group), primary_demand_of_lng)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_natural_gas_and_derivatives_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_natural_gas_and_derivatives_from_curtailment.gql
@@ -3,7 +3,7 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_natural_gas),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_compressed_network_gas),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_lng)
+       V(G(curtailment_group), primary_demand_of_natural_gas),
+       V(G(curtailment_group), primary_demand_of_compressed_network_gas),
+       V(G(curtailment_group), primary_demand_of_lng)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_non_biogenic_waste_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_non_biogenic_waste_from_curtailment.gql
@@ -1,3 +1,3 @@
 - unit = MJ
 - query =
-    V(energy_flexibility_curtailment_electricity,primary_demand_of_non_biogenic_waste)
+    V(G(curtailment_group),primary_demand_of_non_biogenic_waste)

--- a/gqueries/general/primary_demand/primary_demand_of_nuclear_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_nuclear_from_curtailment.gql
@@ -3,5 +3,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_uranium_oxide)
+       V(G(curtailment_group), primary_demand_of_uranium_oxide)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_oil_and_derivatives_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_oil_and_derivatives_from_curtailment.gql
@@ -1,10 +1,10 @@
 - unit = PJ
 - query =
     SUM(
-      V(energy_flexibility_curtailment_electricity, primary_demand_of_crude_oil),
-      V(energy_flexibility_curtailment_electricity, primary_demand_of_gasoline),
-      V(energy_flexibility_curtailment_electricity, primary_demand_of_diesel),
-      V(energy_flexibility_curtailment_electricity, primary_demand_of_kerosene),
-      V(energy_flexibility_curtailment_electricity, primary_demand_of_lpg),
-      V(energy_flexibility_curtailment_electricity, primary_demand_of_heavy_fuel_oil)
+      V(G(curtailment_group), primary_demand_of_crude_oil),
+      V(G(curtailment_group), primary_demand_of_gasoline),
+      V(G(curtailment_group), primary_demand_of_diesel),
+      V(G(curtailment_group), primary_demand_of_kerosene),
+      V(G(curtailment_group), primary_demand_of_lpg),
+      V(G(curtailment_group), primary_demand_of_heavy_fuel_oil)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_renewable_heat_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_renewable_heat_from_curtailment.gql
@@ -1,6 +1,6 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_solar_thermal),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_steam_hot_water)
+       V(G(curtailment_group), primary_demand_of_solar_thermal),
+       V(G(curtailment_group), primary_demand_of_steam_hot_water)
     ) / BILLIONS

--- a/gqueries/general/primary_demand/primary_demand_of_waste_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_waste_from_curtailment.gql
@@ -3,6 +3,6 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_non_biogenic_waste),
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_biogenic_waste)
+       V(G(curtailment_group), primary_demand_of_non_biogenic_waste),
+       V(G(curtailment_group), primary_demand_of_biogenic_waste)
     ) / BILLIONS

--- a/gqueries/mechanical_turk/demand/primary_demand/primary_demand_of_curtailment.gql
+++ b/gqueries/mechanical_turk/demand/primary_demand/primary_demand_of_curtailment.gql
@@ -1,2 +1,5 @@
-- query = V(energy_flexibility_curtailment_electricity, primary_demand)
+- query = 
+    SUM(
+      V(G(curtailment_group),primary_demand)
+    )
 - unit = MJ

--- a/graphs/energy/nodes/energy/energy_battery_curtailed_solar_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_battery_curtailed_solar_electricity.ad
@@ -1,3 +1,3 @@
-- groups = [sankey_conversion_group]
+- groups = [sankey_conversion_group, curtailment_group]
 - use = energetic
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_battery_curtailed_wind_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_battery_curtailed_wind_electricity.ad
@@ -1,3 +1,3 @@
-- groups = [sankey_conversion_group]
+- groups = [sankey_conversion_group, curtailment_group]
 - use = energetic
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_flexibility_curtailment_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_flexibility_curtailment_electricity.ad
@@ -1,4 +1,4 @@
-- groups = [sankey_conversion_group]
+- groups = [sankey_conversion_group, curtailment_group]
 - use = energetic
 - availability = 1.0
 - energy_balance_group = flexibility

--- a/graphs/energy/nodes/energy/energy_hydrogen_curtailed_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_curtailed_electricity.ad
@@ -1,3 +1,3 @@
-- groups = [sankey_conversion_group]
+- groups = [sankey_conversion_group, curtailment_group]
 - use = energetic
 - free_co2_factor = 0.0


### PR DESCRIPTION
Apart from the 'main' curtailment node, `energy_flexibility_curtailment_electricity`, additional curtailment nodes have been added over the past few years: `energy_battery_curtailed_solar_electricity`, `energy_battery_curtailed_wind_electricity`, and `energy_hydrogen_curtailed_electricity`.

In our primary demand queries however, we still regularly only query the main curtailment node. This PR addresses that by adding a `curtailment_group` to these nodes and querying that group instead of only the main node.

Questions to discuss:

- [x] Is it desirable to query all the curtailment nodes, or was querying the single node intentional?
- [x] How does curtailment work for direct electrolysis? In principle all electricity should be converted to hydrogen, so why is curtailment applied?
- [x] How does **last resort** curtailment work for the battery systems? They have their own curtailment which is activated when the battery is full and the capacity to the grid is reached. So what happens, if their total production exceeds total demand in a scenario? Last resort curtailment needs to be applied. How is this handled?
- [ ] If we choose to use the node group and query all curtailment nodes, are there more queries that should be updated than the ones I have tackled so far?

Notifying @noracato and @ChaelKruip

I will discuss this with @redekok and decide on next steps