### PR TITLE
Remove duplicate series in hourly greengas curves

### DIFF
--- a/gqueries/general/network_gas/production/greengas_gasification_dry_biomass_output_curve.gql
+++ b/gqueries/general/network_gas/production/greengas_gasification_dry_biomass_output_curve.gql
@@ -1,0 +1,2 @@
+- query = V(energy_greengas_gasification_dry_biomass, network_gas_output_curve)
+- unit = curve

--- a/gqueries/general/network_gas/production/greengas_gasification_wet_biomass_output_curve.gql
+++ b/gqueries/general/network_gas/production/greengas_gasification_wet_biomass_output_curve.gql
@@ -1,0 +1,2 @@
+- query = V(energy_greengas_gasification_wet_biomass, network_gas_output_curve)
+- unit = curve

--- a/gqueries/general/network_gas/production/greengas_network_gas_output_curve.gql
+++ b/gqueries/general/network_gas/production/greengas_network_gas_output_curve.gql
@@ -1,2 +1,9 @@
-- query = V(energy_distribution_greengas, network_gas_output_curve)
+- query = 
+    SUM_CURVES(
+      V(energy_greengas_gasification_dry_biomass,
+        energy_greengas_gasification_wet_biomass,
+        energy_greengas_upgrade_biogas,
+        network_gas_output_curve
+      )
+    )
 - unit = curve

--- a/gqueries/general/network_gas/production/greengas_upgrade_biogas_output_curve.gql
+++ b/gqueries/general/network_gas/production/greengas_upgrade_biogas_output_curve.gql
@@ -1,0 +1,2 @@
+- query = V(energy_greengas_upgrade_biogas, network_gas_output_curve)
+- unit = curve

--- a/graphs/energy/nodes/energy/energy_distribution_greengas.ad
+++ b/graphs/energy/nodes/energy/energy_distribution_greengas.ad
@@ -3,9 +3,6 @@
 - use = undefined
 - graph_methods = [demand]
 - energy_balance_group = distribution primary carriers
-- network_gas.demand_carrier = greengas
-- network_gas.profile = flat
-- network_gas.type = producer
 - free_co2_factor = 0.0
 
 ~ demand = PRIMARY_PRODUCTION(energy_distribution_greengas, demand)

--- a/graphs/energy/nodes/energy/energy_greengas_gasification_dry_biomass.ad
+++ b/graphs/energy/nodes/energy/energy_greengas_gasification_dry_biomass.ad
@@ -15,9 +15,11 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
 - wacc = 0.04
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
+- network_gas.demand_carrier = greengas
+- network_gas.profile = flat
+- network_gas.type = producer
 
 ~ full_load_hours = 8000

--- a/graphs/energy/nodes/energy/energy_greengas_gasification_wet_biomass.ad
+++ b/graphs/energy/nodes/energy/energy_greengas_gasification_wet_biomass.ad
@@ -15,9 +15,11 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
 - wacc = 0.07
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 1.0
+- network_gas.demand_carrier = greengas
+- network_gas.profile = flat
+- network_gas.type = producer
 
 ~ full_load_hours = 8000

--- a/graphs/energy/nodes/energy/energy_greengas_upgrade_biogas.converter.ad
+++ b/graphs/energy/nodes/energy/energy_greengas_upgrade_biogas.converter.ad
@@ -16,9 +16,11 @@
 - variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
 - wacc = 0.04
 - energy_balance_group = biomass conversion
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
+- network_gas.demand_carrier = greengas
+- network_gas.profile = flat
+- network_gas.type = producer
 
 ~ full_load_hours = 8000


### PR DESCRIPTION
Both the `industry_residual_greengas` node and the `energy_distribution_greengas` node were specified as producers in the balancing of hourly network gas curves (which includes balancing of greengas). This led to a double-counting of the industry residual greengas curve.

![Screenshot 2023-04-03 at 11 41 39](https://user-images.githubusercontent.com/67338510/229473498-f4fc5c23-5e7d-4744-9fa2-8e32850dae5d.png)

To solve this issue, the `energy_distribution_greengas` node has been removed as a producer, and the nodes on its right are all aligned as producers. Affected queries have been updated accordingly.

Closes https://github.com/quintel/etsource/issues/2852
Goes with