### PR TITLE
Add output of useable heat queries for hybrid heat pumps

### DIFF
--- a/gqueries/general/heat/output_of_useable_heat_per_heat_technology/buildings_space_heater_hybrid_heatpump_air_water_electricity_output_of_useable_heat.gql
+++ b/gqueries/general/heat/output_of_useable_heat_per_heat_technology/buildings_space_heater_hybrid_heatpump_air_water_electricity_output_of_useable_heat.gql
@@ -1,0 +1,2 @@
+- query = V(buildings_space_heater_hybrid_heatpump_air_water_electricity,output_of_useable_heat)
+- unit = MJ

--- a/gqueries/general/heat/output_of_useable_heat_per_heat_technology/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_output_of_useable_heat.gql
+++ b/gqueries/general/heat/output_of_useable_heat_per_heat_technology/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_output_of_useable_heat.gql
@@ -1,0 +1,2 @@
+- query = V(buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,output_of_useable_heat)
+- unit = MJ

--- a/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_space_heater_hybrid_heatpump_air_water_electricity_output_of_useable_heat.gql
+++ b/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_space_heater_hybrid_heatpump_air_water_electricity_output_of_useable_heat.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_heatpump_air_water_electricity,output_of_useable_heat)
+- unit = MJ

--- a/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_output_of_useable_heat.gql
+++ b/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_output_of_useable_heat.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,output_of_useable_heat)
+- unit = MJ

--- a/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_water_heater_hybrid_heatpump_air_water_electricity_output_of_useable_heat.gql
+++ b/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_water_heater_hybrid_heatpump_air_water_electricity_output_of_useable_heat.gql
@@ -1,0 +1,2 @@
+- query = V(households_water_heater_hybrid_heatpump_air_water_electricity,output_of_useable_heat)
+- unit = MJ

--- a/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_output_of_useable_heat.gql
+++ b/gqueries/general/heat/output_of_useable_heat_per_heat_technology/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_output_of_useable_heat.gql
@@ -1,0 +1,2 @@
+- query = V(households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity,output_of_useable_heat)
+- unit = MJ


### PR DESCRIPTION
Client request:
> we are talking about querying the annual heat demand covered by hybrid heat pumps

This PR adds queries that produce the annual output of heat for hybrid heat pumps:

- Buildings (space heating): hybrid air heat pump (gas)
- Buildings (space heating): hybrid air heat pump (hydrogen)
- Households (space heating & hot water): hybrid air heat pump (gas)
- Households (space heating & hot water): hybrid air heat pump (hydrogen)