### PR TITLE
Set specific edges from share to flexible to generate fallback shares

### DIFF
--- a/graphs/energy/edges/agriculture/agriculture_network_gas_hybrid_heat-agriculture_useful_demand_useable_heat@useable_heat.ad
+++ b/graphs/energy/edges/agriculture/agriculture_network_gas_hybrid_heat-agriculture_useful_demand_useable_heat@useable_heat.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/industry/industry_chemicals_other_burner_crude_oil-industry_useful_demand_for_chemical_other_useable_heat@useable_heat.ad
+++ b/graphs/energy/edges/industry/industry_chemicals_other_burner_crude_oil-industry_useful_demand_for_chemical_other_useable_heat@useable_heat.ad
@@ -1,3 +1,3 @@
-- type = share
+- type = flexible
 - reversed = false
 - groups = [chemical_industry]

--- a/graphs/energy/edges/industry/industry_other_food_network_gas_hybrid_heat-industry_useful_demand_for_other_food_useable_heat@useable_heat.ad
+++ b/graphs/energy/edges/industry/industry_other_food_network_gas_hybrid_heat-industry_useful_demand_for_other_food_useable_heat@useable_heat.ad
@@ -1,3 +1,3 @@
-- type = share
+- type = flexible
 - reversed = false
 - groups = [other_industry]

--- a/graphs/energy/edges/industry/industry_other_paper_network_gas_hybrid_heat-industry_useful_demand_for_other_paper_useable_heat@useable_heat.ad
+++ b/graphs/energy/edges/industry/industry_other_paper_network_gas_hybrid_heat-industry_useful_demand_for_other_paper_useable_heat@useable_heat.ad
@@ -1,3 +1,3 @@
-- type = share
+- type = flexible
 - reversed = false
 - groups = [other_industry]

--- a/graphs/energy/edges/industry/industry_useful_demand_for_chemical_other_crude_oil_non_energetic-industry_useful_demand_for_chemical_other_non_energetic@not_defined.ad
+++ b/graphs/energy/edges/industry/industry_useful_demand_for_chemical_other_crude_oil_non_energetic-industry_useful_demand_for_chemical_other_non_energetic@not_defined.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_bus_using_diesel_mix-transport_useful_demand_busses@passenger_kms.ad
+++ b/graphs/energy/edges/transport/transport_bus_using_diesel_mix-transport_useful_demand_busses@passenger_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_car_using_gasoline_mix-transport_useful_demand_cars@passenger_kms.ad
+++ b/graphs/energy/edges/transport/transport_car_using_gasoline_mix-transport_useful_demand_cars@passenger_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_freight_train_using_electricity-transport_useful_demand_freight_trains@freight_tonne_kms.ad
+++ b/graphs/energy/edges/transport/transport_freight_train_using_electricity-transport_useful_demand_freight_trains@freight_tonne_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_passenger_train_using_electricity-transport_useful_demand_passenger_trains@passenger_kms.ad
+++ b/graphs/energy/edges/transport/transport_passenger_train_using_electricity-transport_useful_demand_passenger_trains@passenger_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_ship_using_diesel_mix-transport_useful_demand_ships@freight_tonne_kms.ad
+++ b/graphs/energy/edges/transport/transport_ship_using_diesel_mix-transport_useful_demand_ships@freight_tonne_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_truck_using_diesel_mix-transport_useful_demand_trucks@freight_tonne_kms.ad
+++ b/graphs/energy/edges/transport/transport_truck_using_diesel_mix-transport_useful_demand_trucks@freight_tonne_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false

--- a/graphs/energy/edges/transport/transport_van_using_diesel_mix-transport_useful_demand_vans@freight_tonne_kms.ad
+++ b/graphs/energy/edges/transport/transport_van_using_diesel_mix-transport_useful_demand_vans@freight_tonne_kms.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false


### PR DESCRIPTION
**Issue**
In a number of industry sub sectors and for a number of transport applications, all edges that are set by inputs in the frontend were set to `share`. In datasets with 0.0 MJ demand for those sub sectors or transport applications these inputs would all be 0.0%. Resetting any of the inputs would cause the model to break. See screenshots below for an example.

**Solution**
For each of the affected sub sectors and transport applications, a single edge is set to `flexible`, which forces that edge to adopt a 100% share when no demand is present. The edge that has the most demand in `nl2019` is chosen.

Closes https://github.com/quintel/etmodel/issues/4107
Closes https://github.com/quintel/etlocal/issues/378

**Example of issue for Aarhus dataset**

This in the frontend:
![Screenshot 2023-05-03 at 17 04 27](https://user-images.githubusercontent.com/67338510/235957241-250da118-beef-4b61-9f29-05cddd777bcd.png)

Is caused by this in the backend:
![Screenshot 2023-05-03 at 17 05 27](https://user-images.githubusercontent.com/67338510/235957488-1d36c80c-8c2f-4ce0-afd7-97a77620d284.png)

