### PR TITLE
Remove redundant sustainable attribute from network_gas carrier file

### DIFF
--- a/carriers/network_gas.ad
+++ b/carriers/network_gas.ad
@@ -1,2 +1,2 @@
-- sustainable = 0.0
 - infinite = false
+- graphviz_color = grey


### PR DESCRIPTION
The carrier `network_gas` only exists as a blend of `greengas` and `natural_gas`. Nowhere in the graph is supplied as a form of primary demand. Therefore, its sustainability is always determined by the blended components and the `sustainable` attribute is redundant.

I have removed attribute, and tested it for a blank nl2019 scenario and for II3050 National governance. I both cases, the engine computes normally and there is no difference in dashboard parameters between local and beta.

Closes #2897 