### PR TITLE
Updates to Hengelo dataset as requested by municipality

### DIFF
--- a/datasets/GM0164_hengelo/graph_values.yml
+++ b/datasets/GM0164_hengelo/graph_values.yml
@@ -85,7 +85,7 @@ buildings_final_demand_other_oil:
 buildings_final_demand_solar_thermal:
   demand: 0.0
 buildings_final_demand_steam_hot_water:
-  demand: 2513.74760317867
+  demand: 15.776
 buildings_final_demand_wood_pellets:
   demand: 87.0
 buildings_local_production_electricity:
@@ -206,12 +206,12 @@ energy_heat_burner_waste_mix:
   demand: 1675.0
   output:
     :steam_hot_water: 0.72
-  full_load_hours: 2190.0
+  full_load_hours: 3045.0
 energy_heat_burner_wood_pellets:
   demand: 1596.25
   output:
     :steam_hot_water: 0.8
-  full_load_hours: 2190.0
+  full_load_hours: 4434.0
 energy_heat_distribution_loss:
   demand: 0.0
 energy_heat_heatpump_water_water_electricity:


### PR DESCRIPTION
Adjust final steam hot water demand in buildings sector, adjust full load hours of waste and biomass heater.

- Steam hot water demand is adjusted because the steam hot water final demand is determined by subtracting the steam hot water final demand from households from the total steam hot water production on the district heat network. This doesn't account for the fact that heat can be exported to neighbouring regions - which is the case for a significant amount of steam hot water production in Hengelo.
- Steam hot water final demand in buildings has been changed, to fill 2% of the useful buildings heat demand.
- Full load hours of waste and biomass heater for district heating have been adjusted to match the respective 110 MW and 80 MW heat output capacity as specified by the municipality.

**Note**
All the changes have been made on ETSource alone and are not reflected on ETLocal, because the 2017 version of the dataset lives on ETLocal, while the 2019 version lives on ETSource.