### PR TITLE
Remove duplicate costs query in heat infrastructure

### DIFF
--- a/gqueries/general/costs/heat_infrastructure/annualised_costs/heat_infrastructure_total_annualised_costs.gql
+++ b/gqueries/general/costs/heat_infrastructure/annualised_costs/heat_infrastructure_total_annualised_costs.gql
@@ -4,7 +4,6 @@
       Q(heat_infrastructure_primary_pipelines_annualised_costs),
       Q(heat_infrastructure_distribution_stations_annualised_costs),
       Q(heat_infrastructure_indoor_annualised_costs),
-      Q(heat_infrastructure_distribution_stations_annualised_costs),
       Q(heat_infrastructure_storage_annualised_costs)
       )
 - unit = euro

--- a/gqueries/general/costs/mece_costs/5_infrastructure/costs_infrastructure_heat.gql
+++ b/gqueries/general/costs/mece_costs/5_infrastructure/costs_infrastructure_heat.gql
@@ -3,7 +3,6 @@
       Q(heat_infrastructure_distribution_pipelines_annualised_costs),
       Q(heat_infrastructure_primary_pipelines_annualised_costs),
       Q(heat_infrastructure_distribution_stations_annualised_costs),
-      Q(heat_infrastructure_indoor_annualised_costs),
-      Q(heat_infrastructure_distribution_stations_annualised_costs)
+      Q(heat_infrastructure_indoor_annualised_costs)
     )
 - unit = euro


### PR DESCRIPTION
The query [costs_infrastructure_heat](https://github.com/quintel/etsource/blob/master/gqueries/general/costs/mece_costs/5_infrastructure/costs_infrastructure_heat.gql)  and [heat_infrastructure_total_annualised_costs](https://github.com/quintel/etsource/blob/master/gqueries/general/costs/heat_infrastructure/annualised_costs/heat_infrastructure_total_annualised_costs.gql) (see respective queries below) seem to contain a duplicate query: `heat_infrastructure_distribution_stations_annualised_costs`

```ruby
- query =
    SUM(
      Q(heat_infrastructure_distribution_pipelines_annualised_costs),
      Q(heat_infrastructure_primary_pipelines_annualised_costs),
      Q(heat_infrastructure_distribution_stations_annualised_costs), # <-- DUPLICATE
      Q(heat_infrastructure_indoor_annualised_costs),
      Q(heat_infrastructure_distribution_stations_annualised_costs) # <-- DUPLICATE
    )
- unit = euro
```

```ruby
- query =
    SUM(
      Q(heat_infrastructure_distribution_pipelines_annualised_costs),
      Q(heat_infrastructure_primary_pipelines_annualised_costs),
      Q(heat_infrastructure_distribution_stations_annualised_costs), # <-- DUPLICATE
      Q(heat_infrastructure_indoor_annualised_costs),
      Q(heat_infrastructure_distribution_stations_annualised_costs), # <-- DUPLICATE
      Q(heat_infrastructure_storage_annualised_costs)
      )
- unit = euro
```

@DorinevanderVlies I don't see any reason why the duplicate should be maintained or another costs component that should be included instead (based on the [documentation](https://docs.energytransitionmodel.com/main/heat-infrastructure-costs/#households-and-buildings-costs)). This PR therefore removes the duplicate from the SUM in both queries.