### PR TITLE
Revert flexible edge in agriculture

### DIFF
--- a/graphs/energy/edges/agriculture/agriculture_final_demand_electricity-agriculture_flexibility_p2h_hydrogen_electricity@electricity.ad
+++ b/graphs/energy/edges/agriculture/agriculture_final_demand_electricity-agriculture_flexibility_p2h_hydrogen_electricity@electricity.ad
@@ -1,3 +1,3 @@
-- type = flexible
+- type = share
 - reversed = false
 - groups = [final_demand]

--- a/graphs/energy/edges/agriculture/agriculture_final_demand_electricity-agriculture_flexibility_p2h_network_gas_electricity@electricity.ad
+++ b/graphs/energy/edges/agriculture/agriculture_final_demand_electricity-agriculture_flexibility_p2h_network_gas_electricity@electricity.ad
@@ -1,3 +1,3 @@
-- type = flexible
+- type = share
 - reversed = false
 - groups = [final_demand]

--- a/graphs/energy/edges/agriculture/agriculture_network_gas_hybrid_heat-agriculture_useful_demand_useable_heat@useable_heat.ad
+++ b/graphs/energy/edges/agriculture/agriculture_network_gas_hybrid_heat-agriculture_useful_demand_useable_heat@useable_heat.ad
@@ -1,2 +1,2 @@
-- type = share
+- type = flexible
 - reversed = false


### PR DESCRIPTION
66417e11ad024f6f0d053c69488ccfdd0c80e460 set a flexible edge in agriculture for https://github.com/quintel/etlocal/issues/378. This passed locally, but produced a caching error on beta. 05f97a741fc5fbd5d896d17290a439dd5644d711 then was implemented as a potential fix, but did not solve the caching error. Given the Deploy to production next week the changes were reverted in ffc1a67cc20a3326ea57c7cc4f9aeabaae7512f6.

This PR resets both changes, to be merged after the Deploy, when there is time for @noracato to investigate the caching error on beta.