### PR TITLE
Remove costs group from electricity network nodes

### DIFF
--- a/graphs/energy/nodes/energy/energy_power_hv_network_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_power_hv_network_electricity.ad
@@ -1,6 +1,6 @@
 - output.electricity = etengine_dynamic
 - output.loss = elastic
-- groups = [wacc_public_infra, costs_production_power_plants, sankey_conversion_group]
+- groups = [wacc_public_infra, sankey_conversion_group]
 - use = undefined
 - availability = 0.0
 - full_load_hours = 8760.0

--- a/graphs/energy/nodes/energy/energy_power_lv_network_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_power_lv_network_electricity.ad
@@ -1,4 +1,4 @@
-- groups = [wacc_public_infra, costs_production_power_plants, sankey_conversion_group]
+- groups = [wacc_public_infra, sankey_conversion_group]
 - use = energetic
 - availability = 0.0
 - full_load_hours = 8760.0

--- a/graphs/energy/nodes/energy/energy_power_mv_distribution_network_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_power_mv_distribution_network_electricity.ad
@@ -1,4 +1,4 @@
-- groups = [wacc_public_infra, costs_production_power_plants, sankey_conversion_group]
+- groups = [wacc_public_infra, sankey_conversion_group]
 - use = energetic
 - availability = 0.0
 - full_load_hours = 8760.0

--- a/graphs/energy/nodes/energy/energy_power_mv_transport_network_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_power_mv_transport_network_electricity.ad
@@ -1,4 +1,4 @@
-- groups = [wacc_public_infra, costs_production_power_plants, sankey_conversion_group]
+- groups = [wacc_public_infra, sankey_conversion_group]
 - use = undefined
 - availability = 0.0
 - full_load_hours = 8760.0

--- a/graphs/energy/nodes/energy/energy_power_transformer_lv_mv_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_power_transformer_lv_mv_electricity.ad
@@ -1,4 +1,4 @@
-- groups = [wacc_public_infra, costs_production_power_plants, sankey_conversion_group]
+- groups = [wacc_public_infra, sankey_conversion_group]
 - use = undefined
 - availability = 0.0
 - full_load_hours = 8760.0

--- a/graphs/energy/nodes/energy/energy_power_transformer_mv_hv_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_power_transformer_mv_hv_electricity.ad
@@ -1,4 +1,4 @@
-- groups = [wacc_public_infra, costs_production_power_plants, sankey_conversion_group]
+- groups = [wacc_public_infra, sankey_conversion_group]
 - use = undefined
 - availability = 0.0
 - full_load_hours = 8760.0


### PR DESCRIPTION
These nodes have their own costs calculation in the query [total_costs_of_electricity_network_calculation](https://github.com/quintel/etsource/blob/master/gqueries/modules/network_calculation/total_costs_of_electricity_network_calculation.gql), so also including them in the power plant costs was redundant.

Closes #2905