### PR TITLE
Add agriculture to p2h costs slider

### DIFF
--- a/inputs/costs_efficiencies/investment_costs_flexibility_p2h_electricity.ad
+++ b/inputs/costs_efficiencies/investment_costs_flexibility_p2h_electricity.ad
@@ -10,7 +10,9 @@
         industry_other_food_flexibility_p2h_network_gas_electricity,
         industry_other_food_flexibility_p2h_hydrogen_electricity,
         industry_other_paper_flexibility_p2h_network_gas_electricity,
-        industry_other_paper_flexibility_p2h_hydrogen_electricity),
+        industry_other_paper_flexibility_p2h_hydrogen_electricity,
+        agriculture_flexibility_p2h_hydrogen_electricity,
+        agriculture_flexibility_p2h_network_gas_electricity),
         initial_investment, USER_INPUT())
 - priority = 0
 - max_value = 300.0


### PR DESCRIPTION
Agriculture p2h boilers were missing from the investment costs of p2h boilers. This PR adds them.

Goes with https://github.com/quintel/etmodel/pull/4127