### PR TITLE
Align heat producers maximum value with power producers logic

### DIFF
--- a/inputs/supply/heat/energy/capacity_of_energy_heat_boiler_electricity.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_boiler_electricity.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_boiler_electricity, output_of_steam_hot_water)*2), V(energy_heat_boiler_electricity,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_boiler_electricity,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_boiler_electricity,number_of_units),V(energy_heat_boiler_electricity,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_coal.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_coal.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_coal, output_of_steam_hot_water)*2), V(energy_heat_burner_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_burner_coal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_burner_coal,number_of_units),V(energy_heat_burner_coal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_crude_oil.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_crude_oil.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_crude_oil, output_of_steam_hot_water)*2), V(energy_heat_burner_crude_oil,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_burner_crude_oil,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_burner_crude_oil,number_of_units),V(energy_heat_burner_crude_oil,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_hydrogen.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_hydrogen.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_hydrogen, output_of_steam_hot_water)*2), V(energy_heat_burner_hydrogen,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_burner_hydrogen,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_burner_hydrogen,number_of_units),V(energy_heat_burner_hydrogen,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_network_gas.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_network_gas.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_network_gas, output_of_steam_hot_water)*2), V(energy_heat_burner_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_burner_network_gas,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_burner_network_gas,number_of_units),V(energy_heat_burner_network_gas,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_waste_mix.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_waste_mix.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_waste_mix, output_of_steam_hot_water)*2), V(energy_heat_burner_waste_mix,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_burner_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_burner_waste_mix,number_of_units),V(energy_heat_burner_waste_mix,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_burner_wood_pellets.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_burner_wood_pellets.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_burner_wood_pellets, output_of_steam_hot_water)*2), V(energy_heat_burner_wood_pellets,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_burner_wood_pellets,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_burner_wood_pellets,number_of_units),V(energy_heat_burner_wood_pellets,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_heatpump_water_water_electricity.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_heatpump_water_water_electricity.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_heatpump_water_water_electricity, output_of_steam_hot_water)*2), V(energy_heat_heatpump_water_water_electricity,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_heatpump_water_water_electricity,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_heatpump_water_water_electricity,number_of_units),V(energy_heat_heatpump_water_water_electricity,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_solar_thermal.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_solar_thermal.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_solar_thermal, output_of_steam_hot_water)*2), V(energy_heat_solar_thermal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_solar_thermal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_solar_thermal,number_of_units),V(energy_heat_solar_thermal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/capacity_of_energy_heat_well_geothermal.ad
+++ b/inputs/supply/heat/energy/capacity_of_energy_heat_well_geothermal.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_well_geothermal, output_of_steam_hot_water)*2), V(energy_heat_well_geothermal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:2*DIVIDE(DIVIDE(PRODUCT(Q(heat_production_total),BILLIONS), V(energy_heat_well_geothermal,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_heat_well_geothermal,number_of_units),V(energy_heat_well_geothermal,heat_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/heat/energy/volume_of_imported_heat.ad
+++ b/inputs/supply/heat/energy/volume_of_imported_heat.ad
@@ -1,6 +1,6 @@
 - query = UPDATE(V(energy_distribution_imported_heat), preset_demand, (USER_INPUT() * BILLIONS))
 - priority = 0
-- max_value_gql = present:DIVIDE(Q(heat_production_total), 2)
+- max_value_gql = present:2*Q(heat_production_total)
 - min_value = 0.0
 - start_value_gql = present:DIVIDE(V(energy_distribution_imported_heat, demand),BILLIONS)
 - step_value = 0.1


### PR DESCRIPTION
Closes https://github.com/quintel/etmodel/issues/4134

This PR changes the maximum slider value for the capacity of heat producers.

- The previous logic is that any heat producer in the district heating network takes the maximum of: half of the total heat production (including the heat production in the demand sectors) in the base year or twice its own heat production in the base year
- The new logic is that each heat producer should be able to produce in the future, at maximum, twice the amount of heat produced in the present year
- This aligns with the generic approach for power producers, which can, at maximum, produce twice the amount of electricity consumed in the present year