### PR TITLE
Change unit type for inputs with boolean values

### DIFF
--- a/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_flow_batteries_electricity.ad
+++ b/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_flow_batteries_electricity.ad
@@ -12,5 +12,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_hv_opac_electricity.ad
+++ b/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_hv_opac_electricity.ad
@@ -12,5 +12,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_mv_batteries_electricity.ad
+++ b/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_mv_batteries_electricity.ad
@@ -12,5 +12,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_pumped_storage_electricity.ad
+++ b/inputs/flexibility/energy/settings_enable_storage_optimisation_energy_flexibility_pumped_storage_electricity.ad
@@ -12,5 +12,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/flexibility/households/settings_enable_storage_optimisation_households_flexibility_p2p_electricity.ad
+++ b/inputs/flexibility/households/settings_enable_storage_optimisation_households_flexibility_p2p_electricity.ad
@@ -12,5 +12,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/flexibility/transport/settings_enable_storage_optimisation_transport_car_flexibility_p2p_electricity.ad
+++ b/inputs/flexibility/transport/settings_enable_storage_optimisation_transport_car_flexibility_p2p_electricity.ad
@@ -18,5 +18,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/misc/settings_enable_merit_order.ad
+++ b/inputs/misc/settings_enable_merit_order.ad
@@ -4,5 +4,5 @@
 - min_value = 0.0
 - start_value_gql = present:AREA(use_merit_order_demands) ? 1.0 : 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = both

--- a/inputs/supply/electricity/nuclear_plants/merit_order_subtype_of_energy_power_nuclear_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/merit_order_subtype_of_energy_power_nuclear_uranium_oxide.ad
@@ -14,5 +14,5 @@
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = future

--- a/inputs/supply/heat/energy/heat_storage_enabled.ad
+++ b/inputs/supply/heat/energy/heat_storage_enabled.ad
@@ -11,5 +11,5 @@
 - min_value = 0.0
 - start_value_gql = present:0.0
 - step_value = 1.0
-- unit = x
+- unit = bool
 - update_period = both


### PR DESCRIPTION
## What?
This PR changes the unit type for inputs with boolean values from `x` to `bool` so they can be properly recognized and acted upon by the rest of the application stack (i.e. `etengine`).

## Why?
As described in [this](https://github.com/quintel/multi-year-charts/issues/31) and [this](https://github.com/quintel/etengine/issues/1321) issue boolean values are currently not handled properly: they were not validated properly and their value was interpolated and recalculated for scenarios in transition paths. Both of these issues are fixed through PR https://github.com/quintel/etengine/pull/1358. That PR depends on the changes in this PR to work properly.

## How?
The `unit` value are simply changed from `x` to `bool` in the input definitions for the following inputs:
```
heat_storage_enabled
merit_order_subtype_of_energy_power_nuclear_uranium_oxide
settings_enable_merit_order
settings_enable_storage_optimisation_energy_flexibility_flow_batteries_electricity
settings_enable_storage_optimisation_energy_flexibility_hv_opac_electricity
settings_enable_storage_optimisation_energy_flexibility_mv_batteries_electricity
settings_enable_storage_optimisation_energy_flexibility_pumped_storage_electricity
settings_enable_storage_optimisation_households_flexibility_p2p_electricity
settings_enable_storage_optimisation_transport_car_flexibility_p2p_electricity
```

Closes #1321
Closes quintel/multi-year-charts#31