### PR TITLE
Add LOHC and LH2 to carriers.csv for the Efate dataset

### DIFF
--- a/datasets/NH5_efate/carriers.csv
+++ b/datasets/NH5_efate/carriers.csv
@@ -51,3 +51,7 @@ wind,0.0,0.0,
 wood_pellets,0.0,0.008321111,0.112
 imported_ammonia,0.0,0.012004032,
 ammonia,0.0,0.012004032,
+liquid_hydrogen,0.0,0.02089,
+imported_liquid_hydrogen,0.0975,0.02089,
+imported_lohc,0.08211,0.01759,
+lohc,0.0,0.01759,


### PR DESCRIPTION
In addition to https://github.com/quintel/etsource/pull/2978, extend the `carriers.csv` file with (imported) liquid hydrogen and LOHC for the Efate dataset