### PR TITLE
Input and chart curve for residential forecasting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',    ref: 'e8da927', github: 'quintel/atlas'
+  gem 'atlas',    ref: '3c1f70f', github: 'quintel/atlas'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: e8da92725b252fe1396d56ddf6d58d51c29d4775
-  ref: e8da927
+  revision: 3c1f70f1b001cecef89340e20857574fff781dd0
+  ref: 3c1f70f
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/gqueries/output_elements/output_series/line_flexibility_hourly_carriers_inflexible_imbalance/electricity_local_households_imbalance_inflexible_curve.gql
+++ b/gqueries/output_elements/output_series/line_flexibility_hourly_carriers_inflexible_imbalance/electricity_local_households_imbalance_inflexible_curve.gql
@@ -1,0 +1,12 @@
+- query =
+    SUM_CURVES(
+      SUM_CURVES(
+        V(FILTER(SECTOR(households),"merit_order && (merit_order.type == :consumer)"),electricity_input_curve)
+      ),
+      INVERT_CURVE(
+        SUM_CURVES(
+          V(FILTER(SECTOR(households),"merit_order && (merit_order.type == :producer)"),electricity_output_curve)
+        )
+      )
+    )
+- unit = curve

--- a/inputs/flexibility/households/settings_enable_storage_optimisation_households_flexibility_p2p_electricity.ad
+++ b/inputs/flexibility/households/settings_enable_storage_optimisation_households_flexibility_p2p_electricity.ad
@@ -1,16 +1,14 @@
 - query =
   IF(
-    EQUALS(USER_INPUT(), 1.0),
+    EQUALS(USER_INPUT(), "default"),
+    -> {},
     -> {
       UPDATE(V(households_flexibility_p2p_electricity, storage), decay, 0.0);
-      UPDATE(V(households_flexibility_p2p_electricity, merit_order), subtype, optimizing_storage);
-    },
-    -> {}
+      UPDATE(V(households_flexibility_p2p_electricity, merit_order), subtype, USER_INPUT());
+    }
   )
 - priority = 0
-- max_value = 1.0
-- min_value = 0.0
-- start_value = 0.0
-- step_value = 1.0
-- unit = bool
+- min_value = [default, optimizing_storage, optimizing_storage_households]
+- start_value = default
+- unit = enum
 - update_period = future


### PR DESCRIPTION
Changes the old boolean toggle for storage optimization for households for setting the `merit_order.subtype` to `optimizing_storage`, to a radio button input that can set the subtype to:
- `default`: uses the nodes default subtype (usually `storage`)
- `optimizing_storage`: enables the battery to join in the forecasting algorithm for the full systems residual load curve
- `optimizing_storage_households`: enables the battery to join in the forecasting algorithm for the households sector residual load curve


And adds a query to show the households residual load curve in charts.