### PR TITLE
Close issue #2979. Changing cost calculation queries of import and export.

### DIFF
--- a/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_biomass.gql
+++ b/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_biomass.gql
@@ -1,16 +1,7 @@
+# Carrier costs based on net flows (imports - baseload export)
+
 - query =
-    SUM(
-      PRODUCT(V(CARRIER(torrefied_biomass_pellets), cost_per_mj), V(energy_torrefaction_wood, demand)),
-      PRODUCT(V(CARRIER(wood_pellets), cost_per_mj), V(energy_production_wood_pellets, demand)),
-      PRODUCT(V(CARRIER(bio_kerosene), cost_per_mj), V(energy_production_bio_kerosene, demand)),
-      PRODUCT(V(CARRIER(bio_ethanol), cost_per_mj), V(energy_production_bio_ethanol, demand)),
-      PRODUCT(V(CARRIER(bio_lng), cost_per_mj), V(energy_production_bio_lng, demand)),
-      PRODUCT(V(CARRIER(biodiesel), cost_per_mj), V(energy_production_biodiesel, demand)),
-      PRODUCT(V(CARRIER(bio_oil), cost_per_mj), V(energy_production_bio_oil, demand)),
-      PRODUCT(V(CARRIER(biogas), cost_per_mj), V(energy_biogas_fermentation_wet_biomass, demand)),
-      PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_greengas_gasification_wet_biomass, demand)),
-      PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_greengas_gasification_dry_biomass, demand))
-    )
+      PRODUCT(V(CARRIER(dry_biomass), cost_per_mj), V(energy_import_dry_biomass, demand))
     - PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_export_greengas_baseload, demand))
 
 - unit = euro

--- a/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_biomass.gql
+++ b/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_biomass.gql
@@ -1,16 +1,16 @@
 - query =
     SUM(
-      PRODUCT(V(CARRIER(torrefied_biomass_pellets), cost_per_mj), V(energy_torrefaction_wood, primary_demand_of_torrefied_biomass_pellets)),
-      PRODUCT(V(CARRIER(wood_pellets), cost_per_mj), V(energy_production_wood_pellets, primary_demand_of_wood_pellets)),
-      PRODUCT(V(CARRIER(bio_kerosene), cost_per_mj), V(energy_production_bio_kerosene, primary_demand_of_bio_kerosene)),
-      PRODUCT(V(CARRIER(bio_ethanol), cost_per_mj), V(energy_production_bio_ethanol, primary_demand_of_bio_ethanol)),
-      PRODUCT(V(CARRIER(bio_lng), cost_per_mj), V(energy_production_bio_lng, primary_demand_of_bio_lng)),
-      PRODUCT(V(CARRIER(biodiesel), cost_per_mj), V(energy_production_biodiesel, primary_demand_of_biodiesel)),
-      PRODUCT(V(CARRIER(bio_oil), cost_per_mj), V(energy_production_bio_oil, primary_demand_of_bio_oil)),
-      PRODUCT(V(CARRIER(biogas), cost_per_mj), V(energy_biogas_fermentation_wet_biomass, primary_demand_of_biogas)),
-      PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_greengas_gasification_wet_biomass, primary_demand_of_greengas)),
-      PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_greengas_gasification_dry_biomass, primary_demand_of_greengas))
+      PRODUCT(V(CARRIER(torrefied_biomass_pellets), cost_per_mj), V(energy_torrefaction_wood, demand)),
+      PRODUCT(V(CARRIER(wood_pellets), cost_per_mj), V(energy_production_wood_pellets, demand)),
+      PRODUCT(V(CARRIER(bio_kerosene), cost_per_mj), V(energy_production_bio_kerosene, demand)),
+      PRODUCT(V(CARRIER(bio_ethanol), cost_per_mj), V(energy_production_bio_ethanol, demand)),
+      PRODUCT(V(CARRIER(bio_lng), cost_per_mj), V(energy_production_bio_lng, demand)),
+      PRODUCT(V(CARRIER(biodiesel), cost_per_mj), V(energy_production_biodiesel, demand)),
+      PRODUCT(V(CARRIER(bio_oil), cost_per_mj), V(energy_production_bio_oil, demand)),
+      PRODUCT(V(CARRIER(biogas), cost_per_mj), V(energy_biogas_fermentation_wet_biomass, demand)),
+      PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_greengas_gasification_wet_biomass, demand)),
+      PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_greengas_gasification_dry_biomass, demand))
     )
-    - PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_export_greengas_baseload, primary_demand_of_greengas))
+    - PRODUCT(V(CARRIER(greengas), cost_per_mj), V(energy_export_greengas_baseload, demand))
 
 - unit = euro

--- a/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_oil_and_products.gql
+++ b/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_oil_and_products.gql
@@ -11,22 +11,22 @@
     )
     - 
     SUM(
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_crude_oil_backup, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_kerosene_backup, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_oil_products, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_gasoline_backup, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_diesel_backup, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_lpg_backup, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_heavy_fuel_oil_backup, primary_demand_of_crude_oil))
+        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_crude_oil_backup, demand)),
+        PRODUCT(V(CARRIER(kerosene), cost_per_mj),V(energy_export_kerosene_backup, demand)),
+        PRODUCT(V(CARRIER(oil_products), cost_per_mj),V(energy_export_oil_products, demand)),
+        PRODUCT(V(CARRIER(gasoline), cost_per_mj),V(energy_export_gasoline_backup, demand)),
+        PRODUCT(V(CARRIER(diesel), cost_per_mj),V(energy_export_diesel_backup, demand)),
+        PRODUCT(V(CARRIER(lpg), cost_per_mj),V(energy_export_lpg_backup, demand)),
+        PRODUCT(V(CARRIER(heavy_fuel_oil), cost_per_mj),V(energy_export_heavy_fuel_oil_backup, demand))
     )
     -
     SUM(
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_crude_oil_baseload, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_kerosene_baseload, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_gasoline_baseload, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_diesel_baseload, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_lpg_baseload, primary_demand_of_crude_oil)),
-        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_heavy_fuel_oil_baseload, primary_demand_of_crude_oil))
+        PRODUCT(V(CARRIER(crude_oil), cost_per_mj),V(energy_export_crude_oil_baseload, demand)),
+        PRODUCT(V(CARRIER(kerosene), cost_per_mj),V(energy_export_kerosene_baseload, demand)),
+        PRODUCT(V(CARRIER(gasoline), cost_per_mj),V(energy_export_gasoline_baseload, demand)),
+        PRODUCT(V(CARRIER(diesel), cost_per_mj),V(energy_export_diesel_baseload, demand)),
+        PRODUCT(V(CARRIER(lpg), cost_per_mj),V(energy_export_lpg_baseload, demand)),
+        PRODUCT(V(CARRIER(heavy_fuel_oil), cost_per_mj),V(energy_export_heavy_fuel_oil_baseload, demand))
     )
 
 - unit = euro


### PR DESCRIPTION
I researched the way the oil and biomass query was set up.

- For biomass the cost calculation method was not coherent with the other cost calculations. 
The cost calculation standard in the other queries is : Import - export (baseload) - export (backup). 
Since there is only import of dry biomass in the model, it would not be coherent to calculate all the production costs of all carriers as it was done before. I changed this.

- For oil see the screenshot from a blank scenario underneath:

<img width="728" alt="Screenshot 2024-01-04 at 09 39 41" src="https://github.com/quintel/etsource/assets/150331345/df5bc789-18ed-4060-a563-572f3065170f">

<img width="720" alt="Screenshot 2024-01-04 at 09 40 30" src="https://github.com/quintel/etsource/assets/150331345/e1f6ff7d-71a9-4c44-a119-0b49f256abc2">

When calculating the costs with the final_demand_of_crude_oil, not the whole energy export would be taken into account. For this reason I changed the oil query to the 'demand' variant.
