### PR TITLE
Fix imported liquid hydrogen query

### DIFF
--- a/gqueries/general/primary_demand/primary_demand_of_imported_liquid_hydrogen_from_curtailment.gql
+++ b/gqueries/general/primary_demand/primary_demand_of_imported_liquid_hydrogen_from_curtailment.gql
@@ -1,5 +1,5 @@
 - unit = PJ
 - query =
     SUM(
-       V(energy_flexibility_curtailment_electricity, primary_demand_of_imported_hydrogen)
+       V(energy_flexibility_curtailment_electricity, primary_demand_of_imported_liquid_hydrogen)
     ) / BILLIONS


### PR DESCRIPTION
Minor error in primary demand query caused the [primary_demand](https://github.com/quintel/mechanical_turk/blob/master/spec/demand/primary_demand_spec.rb) MT spec to fail. This query fixes that.