### PR TITLE
Fix interconnector query

### DIFF
--- a/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_electricity_future.gql
+++ b/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_electricity_future.gql
@@ -23,11 +23,34 @@
       PRODUCT_CURVES(
         V(energy_interconnector_6_imported_electricity, electricity_output_curve),
         Q(interconnector_6_marginal_cost_curve)
+      ),
+      PRODUCT_CURVES(
+        V(energy_interconnector_7_imported_electricity, electricity_output_curve),
+        Q(interconnector_7_marginal_cost_curve)
+      ),
+      PRODUCT_CURVES(
+        V(energy_interconnector_8_imported_electricity, electricity_output_curve),
+        Q(interconnector_8_marginal_cost_curve)
+      ),
+      PRODUCT_CURVES(
+        V(energy_interconnector_9_imported_electricity, electricity_output_curve),
+        Q(interconnector_9_marginal_cost_curve)
+      ),
+      PRODUCT_CURVES(
+        V(energy_interconnector_10_imported_electricity, electricity_output_curve),
+        Q(interconnector_10_marginal_cost_curve)
+      ),
+      PRODUCT_CURVES(
+        V(energy_interconnector_11_imported_electricity, electricity_output_curve),
+        Q(interconnector_11_marginal_cost_curve)
+      ),
+      PRODUCT_CURVES(
+        V(energy_interconnector_12_imported_electricity, electricity_output_curve),
+        Q(interconnector_12_marginal_cost_curve)
       )
-    )-
+    ) -
     PRODUCT(
       V(energy_export_electricity, weighted_carrier_cost_per_mj),
       V(energy_export_electricity, demand)
     )
-
 - unit = euro


### PR DESCRIPTION
This PR adds interconnectors 7-12 to the `costs_carriers_electricity_future` query. 

**Discussion**
Should the ETM use the domestic electricity price for exporting electricity, rather than the weighted carrier costs?

According to the [documentation](https://docs.energytransitionmodel.com/main/cost-methods) the ETM only takes into account the primary carrier costs when exporting electricity:

> For export the ETM charges the costs of the primary carrier that is needed for that export. The export of electricity and transit of oil is cost neutral and independent of the market price. A country does not "earn" money from processing oil. And for electricity the ETM deducts the costs of the primary carriers needed to produce that electricity. 

Consequently, however, the import costs are calculated on an hourly basis whereas the export costs are aggregated on an annual basis. 

The difference between using the hourly market price (marginal costs curve) and the weighted carrier costs is significant; see [this example](https://github.com/quintel/etsource/issues/2991#issuecomment-1911641626).

Closes #2991 .