### PR TITLE
Fix typo in natural gas chart queries

### DIFF
--- a/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_bunkers.gql
+++ b/gqueries/general/final_demand/mece/final_demand_of_natural_gas_and_derivatives_in_bunkers.gql
@@ -30,7 +30,6 @@
         ),
         value
       ),
-      ,
       V(
         FILTER(
           FILTER(

--- a/gqueries/output_elements/output_series/waterfall_present_energy_exports/natural_gas_in_present_energy_exports.gql
+++ b/gqueries/output_elements/output_series/waterfall_present_energy_exports/natural_gas_in_present_energy_exports.gql
@@ -1,8 +1,8 @@
 - query = 
     present:
         SUM(
-            (export_of_natural_gas),
-            (export_of_propane)
+            Q(export_of_natural_gas),
+            Q(export_of_propane)
         )
 
 - unit = PJ


### PR DESCRIPTION
This PR fixes 2 typo's for the final energy demand mekko and the present energy exports chart.