### PR TITLE
Add missing geothermal flow to Sankey

### DIFF
--- a/gqueries/output_elements/output_series/sankey_energy_overview/sankey_0_to_1_geothermal_to_electricity.gql
+++ b/gqueries/output_elements/output_series/sankey_energy_overview/sankey_0_to_1_geothermal_to_electricity.gql
@@ -1,0 +1,2 @@
+- query = Q(conversion_from_geothermal_to_electricity)
+- unit = PJ


### PR DESCRIPTION
This PR cherry-picks be1b12c to `production`.