### PR TITLE
Add hybrid oil heat pumps to heatpump costs slider

### DIFF
--- a/inputs/costs_efficiencies/investment_costs_electric_heat_pumps.ad
+++ b/inputs/costs_efficiencies/investment_costs_electric_heat_pumps.ad
@@ -9,6 +9,7 @@
         buildings_space_heater_heatpump_air_water_electricity,
         buildings_space_heater_hybrid_heatpump_air_water_electricity,
         buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,
+        buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
         households_cooling_heatpump_air_water_electricity,
         households_cooling_heatpump_ground_water_electricity,
         households_space_heater_heatpump_air_water_electricity,
@@ -21,6 +22,8 @@
         households_water_heater_hybrid_heatpump_air_water_electricity,
         households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,
         households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity,
+        households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity,
+        households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity,
         energy_heat_heatpump_water_water_ht_electricity,
         energy_heat_heatpump_water_water_mt_electricity,
         energy_heat_heatpump_water_water_lt_electricity

--- a/inputs/costs_efficiencies/investment_costs_electric_heat_pumps.ad
+++ b/inputs/costs_efficiencies/investment_costs_electric_heat_pumps.ad
@@ -9,7 +9,7 @@
         buildings_space_heater_heatpump_air_water_electricity,
         buildings_space_heater_hybrid_heatpump_air_water_electricity,
         buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,
-        buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity
+        buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity,
         households_cooling_heatpump_air_water_electricity,
         households_cooling_heatpump_ground_water_electricity,
         households_space_heater_heatpump_air_water_electricity,


### PR DESCRIPTION
This PR adds the hybrid oil heat pumps to the heat pump costs update slider under Costs & efficiencies.

Replaces #3038 because of git issues.
