### PR TITLE
Fixing gas flows in Sankey energy overview

### DIFF
--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_agriculture_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_agriculture_energetic.gql
@@ -50,5 +50,21 @@
           bio_lng?
         ),
         value
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :agriculture"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_buildings_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_buildings_energetic.gql
@@ -50,5 +50,21 @@
           bio_lng?
         ),
         value
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :buildings"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_bunkers_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_bunkers_energetic.gql
@@ -62,5 +62,22 @@
           bio_lng?
         ),
         value
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :bunkers"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
+
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_energy_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_energy_energetic.gql
@@ -50,5 +50,22 @@
           bio_lng?
         ),
         value
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :energy"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
+
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_households_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_households_energetic.gql
@@ -50,5 +50,21 @@
           bio_lng?
         ),
         value
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :households"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_industry_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_industry_energetic.gql
@@ -50,5 +50,22 @@
           bio_lng?
         ),
         value
+      ),
+            PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :industry"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
+
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_other_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_other_energetic.gql
@@ -50,5 +50,21 @@
           bio_lng?
         ),
         value
-      )
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :industry"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
+      )      
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_transport_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_biomass_products_in_transport_energetic.gql
@@ -50,5 +50,21 @@
           bio_lng?
         ),
         value
+      ),
+      PRODUCT(
+        SUM(
+          V(
+            FILTER(
+              FILTER(
+                FILTER(
+                  EG(final_demand),"sector == :transport"),"network_gas? || compressed_network_gas?"
+                ),
+              "energetic?"
+              ),
+            "value"
+            )
+          ) 
+            ,
+          Q(share_of_sustainable_gas_in_gas_network)
       )
     ) / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_agriculture_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_agriculture_energetic.gql
@@ -1,17 +1,36 @@
 # Final demand of the 'natural_gas_and_derivatives' carrier group
-
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(  
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :agriculture"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :agriculture"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
-      )
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :agriculture"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
+      ),
+      BILLIONS
     )
-     / BILLIONS
+    

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_buildings_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_buildings_energetic.gql
@@ -1,16 +1,39 @@
 # Final demand of the 'natural_gas_and_derivatives' carrier group
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+# Final demand of the 'natural_gas_and_derivatives' carrier group
+
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :buildings"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :buildings"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :buildings"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_bunkers_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_bunkers_energetic.gql
@@ -2,16 +2,35 @@
 
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :bunkers"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :bunkers"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :bunkers"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_energy_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_energy_energetic.gql
@@ -2,16 +2,35 @@
 
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :energy"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :households"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :households"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_households_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_households_energetic.gql
@@ -2,16 +2,35 @@
 
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :households"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :households"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :households"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_industry_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_industry_energetic.gql
@@ -2,16 +2,35 @@
 
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :industry"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :industry"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :industry"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_other_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_other_energetic.gql
@@ -2,16 +2,35 @@
 
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :other"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :other"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :other"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS

--- a/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_transport_energetic.gql
+++ b/gqueries/general/final_demand/mece_energetic/final_demand_of_natural_gas_and_derivatives_in_transport_energetic.gql
@@ -2,16 +2,35 @@
 
 - unit = PJ
 - query =
-    SUM(
-      V(
-          FILTER(
-            FILTER(
+    DIVIDE(
+      SUM(
+        SUM(
+          V(
               FILTER(
-            EG(final_demand),"sector == :transport"), "network_gas? || compressed_network_gas? || natural_gas? || lng? || propane?"
-          ),
-          "energetic?"
+                FILTER(
+                  FILTER(
+                EG(final_demand),"sector == :households"), "natural_gas? || lng? || propane?"
+              ),
+              "energetic?"
+            ),
+            value
+          )
         ),
-        value
+        PRODUCT(
+          SUM(
+            V(
+              FILTER(
+                FILTER(
+                  FILTER(
+                    EG(final_demand),"sector == :households"),"network_gas? || compressed_network_gas?"
+                  ),
+                "energetic?"
+                ),
+              "value"
+              )
+            ) 
+              ,
+            (1 - Q(share_of_sustainable_gas_in_gas_network))
+        )
       )
     )
-     / BILLIONS


### PR DESCRIPTION
This PR aims to fix the gas flows in the energy overview as described in [Issue #2999](https://github.com/quintel/etsource/issues/2999)
It does this by altering the final_demand_of_natural_gas_in__sector_ queries and the final_demand_of_biomass_products_in__sector_ queries. 

The altered queries are also used in the graph final_demand_mekko_energetic. 
In this graph the old queries did make some sense since they were placed under the label 'network_gas' and not 'natural_gas'.
This means that we either need to create different queries for the sankey overview or that we need to change the label 'network_gas' to 'natural_gas' in the final_demand_mekko_energetic. 
What do you think @mabijkerk ?