### PR TITLE
Removed duplicate entry from hydrogen levelised costs export

### DIFF
--- a/config/hydrogen_integral_cost_csv.yml
+++ b/config/hydrogen_integral_cost_csv.yml
@@ -61,12 +61,6 @@
 - name: Production cost curve wind electrolysis (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_offshore_wind_turbine
 
-- name: Production curve wind electrolysis (MWh)
-  query: energy_hydrogen_electrolysis_wind_electricity_hydrogen_output_curve
-
-- name: Production cost curve wind electrolysis (Eur/MWh)
-  query: production_costs_per_mwh_curve_hydrogen_offshore_wind_turbine
-
 - name: Production curve power to gas (MWh)
   query: energy_hydrogen_flexibility_p2g_electricity_hydrogen_output_curve
 


### PR DESCRIPTION
The following keys were listed twice in this export, and therefore these duplicates are removed:
- Production curve wind electrolysis (MWh)
- Production cost curve wind electrolysis (Eur/MWh)
