### PR TITLE
Co2 sankey fix

### DIFF
--- a/gqueries/output_elements/output_series/sankey_190_co2/agriculture_network_gas_total_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/agriculture_network_gas_total_in_co2_sankey.gql
@@ -3,6 +3,17 @@
 - unit = tonne
 - query =
     PRODUCT(
-        V(agriculture_final_demand_network_gas, demand),
-        V(CARRIER(natural_gas), co2_conversion_per_mj)
+            SUM(
+                V(
+                    FILTER(
+                            ALL(),
+                            "agriculture_heat && (agriculture_heat.type == :producer)"
+                            ),
+                    demand),
+                V(agriculture_final_demand_network_gas
+                ,demand
+                )
+            ),
+            V(CARRIER(natural_gas),
+            co2_conversion_per_mj)
     ) / THOUSANDS

--- a/gqueries/output_elements/output_series/sankey_190_co2/energy_biomass_total_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/energy_biomass_total_in_co2_sankey.gql
@@ -6,17 +6,10 @@
         V(CHILDREN(V(energy_power_hv_network_electricity)), input_of_torrefied_biomass_pellets).sum * V(CARRIER(torrefied_biomass_pellets), potential_co2_conversion_per_mj),
         SUM(
             V(CHILDREN(V(energy_power_hv_network_electricity)), input_of_wood_pellets).sum,
+            V(CHILDREN(V(energy_power_mv_distribution_network_electricity)), input_of_wood_pellets).sum,
             V(
                 energy_heat_burner_ht_wood_pellets,
                 energy_heat_burner_mt_wood_pellets,
-                energy_chp_local_ht_wood_pellets_must_run,
-                energy_chp_local_ht_wood_pellets_dispatchable,
-                energy_chp_local_ht_wood_pellets_ccs_must_run,
-                energy_chp_local_ht_wood_pellets_ccs_dispatchable,
-                energy_chp_local_mt_wood_pellets_must_run,
-                energy_chp_local_mt_wood_pellets_dispatchable,
-                energy_chp_local_mt_wood_pellets_ccs_must_run,
-                energy_chp_local_mt_wood_pellets_ccs_dispatchable,
                 input_of_wood_pellets
             )
         ) * V(CARRIER(wood_pellets), potential_co2_conversion_per_mj),

--- a/gqueries/output_elements/output_series/sankey_190_co2/energy_biomass_total_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/energy_biomass_total_in_co2_sankey.gql
@@ -27,6 +27,13 @@
                 input_of_biogas
             )
         ) *  V(CARRIER(biogas), potential_co2_conversion_per_mj),
+        SUM(
+            V(
+                energy_hydrogen_biomass_gasification_ccs,
+                energy_hydrogen_biomass_gasification,
+                input_of_torrefied_biomass_pellets
+            )
+        ) * V(CARRIER(torrefied_biomass_pellets), potential_co2_conversion_per_mj),
         V(energy_distribution_biogenic_waste, demand) * V(CARRIER(biogenic_waste), potential_co2_conversion_per_mj)
     ) / THOUSANDS
     + PRODUCT(

--- a/gqueries/output_elements/output_series/sankey_190_co2/energy_natural_gas_total_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/energy_natural_gas_total_in_co2_sankey.gql
@@ -15,5 +15,7 @@
             energy_hydrogen_steam_methane_reformer_ccs_must_run,
             energy_hydrogen_steam_methane_reformer_dispatchable
             energy_hydrogen_steam_methane_reformer_must_run,
+            energy_hydrogen_biomass_gasification_ccs,
+            energy_hydrogen_biomass_gasification,
             input_of_natural_gas)),
         V(CARRIER(natural_gas), co2_conversion_per_mj)) / THOUSANDS

--- a/gqueries/output_elements/output_series/sankey_190_co2/energy_natural_gas_total_in_co2_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_190_co2/energy_natural_gas_total_in_co2_sankey.gql
@@ -8,7 +8,12 @@
     )
     + PRODUCT(
         SUM(
-          V(energy_steam_methane_reformer_ccs_hydrogen,
-            energy_steam_methane_reformer_hydrogen,
+          V(
+            energy_hydrogen_autothermal_reformer_ccs_must_run,
+            energy_hydrogen_autothermal_reformer_dispatchable,
+            energy_hydrogen_autothermal_reformer_must_run,
+            energy_hydrogen_steam_methane_reformer_ccs_must_run,
+            energy_hydrogen_steam_methane_reformer_dispatchable
+            energy_hydrogen_steam_methane_reformer_must_run,
             input_of_natural_gas)),
         V(CARRIER(natural_gas), co2_conversion_per_mj)) / THOUSANDS


### PR DESCRIPTION
This PR aims to solve issue [#4203](https://github.com/quintel/etmodel/issues/4203) from ETModel.

The main issue lay in that the hydrogen co2 streams were not queried correctly due to name changes from nodes.  

