### PR TITLE
Increase max input values for capacity sliders

### DIFF
--- a/inputs/demand/industry/capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_fertilizers_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
+- max_value_gql = present:MAX(10000.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_fertilizers_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_other_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
+- max_value_gql = present:MAX(10000.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_other_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_refineries_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
+- max_value_gql = present:MAX(10000.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_chemical_refineries_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_food_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
+- max_value_gql = present:MAX(10000.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_food_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_paper_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
+- max_value_gql = present:MAX(25.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_paper_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -15,7 +15,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(25.0,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_paper_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
+- max_value_gql = present:MAX(10000,PRODUCT(DIVIDE(V(industry_useful_demand_for_other_paper_useable_heat,demand),(8760 * MJ_PER_MWH)),2.0))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/flexibility/energy/capacity_of_energy_flexibility_mv_batteries_electricity.ad
+++ b/inputs/flexibility/energy/capacity_of_energy_flexibility_mv_batteries_electricity.ad
@@ -5,7 +5,7 @@
       USER_INPUT() / V(energy_flexibility_mv_batteries_electricity, typical_input_capacity)
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0, PRODUCT(DIVIDE(Q(total_electricity_consumed), SECS_PER_YEAR), 6))
+- max_value_gql = present:MAX(10000.0, PRODUCT(DIVIDE(Q(total_electricity_consumed), SECS_PER_YEAR), 6))
 - min_value = 0.0
 - start_value = 0.0
 - step_value = 1.0

--- a/inputs/flexibility/energy/capacity_of_energy_heat_flexibility_p2h_boiler_electricity.ad
+++ b/inputs/flexibility/energy/capacity_of_energy_heat_flexibility_p2h_boiler_electricity.ad
@@ -12,7 +12,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_flexibility_p2h_boiler_ht_electricity, output_of_steam_hot_water)*2), V(energy_heat_flexibility_p2h_boiler_ht_electricity,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(3 * Q(heat_production_total) * BILLIONS, V(energy_heat_flexibility_p2h_boiler_ht_electricity, output_of_steam_hot_water)*12), V(energy_heat_flexibility_p2h_boiler_ht_electricity,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/flexibility/energy/capacity_of_energy_heat_flexibility_p2h_heatpump_electricity.ad
+++ b/inputs/flexibility/energy/capacity_of_energy_heat_flexibility_p2h_heatpump_electricity.ad
@@ -12,7 +12,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:DIVIDE(DIVIDE(MAX(0.5 * Q(heat_production_total) * BILLIONS, V(energy_heat_flexibility_p2h_heatpump_ht_electricity, output_of_steam_hot_water)*2), V(energy_heat_flexibility_p2h_heatpump_ht_electricity,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:DIVIDE(DIVIDE(MAX(3 * Q(heat_production_total) * BILLIONS, V(energy_heat_flexibility_p2h_heatpump_ht_electricity, output_of_steam_hot_water)*12), V(energy_heat_flexibility_p2h_heatpump_ht_electricity,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_coal.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_ht_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_ht_coal,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_cofiring_coal.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_cofiring_ht_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_cofiring_ht_coal,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_chp_ultra_supercritical_lignite.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_ht_lignite,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_ultra_supercritical_ht_lignite,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_combined_cycle_coal.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_coal,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_combined_cycle_ccs_coal, "number_of_units*electricity_output_capacity"),V(energy_power_combined_cycle_coal, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_supercritical_coal.ad
@@ -11,7 +11,7 @@
         	V(energy_power_supercritical_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_supercritical_coal,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_supercritical_coal ,number_of_units),V(energy_power_supercritical_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_coal.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_ultra_supercritical_ccs_coal, "number_of_units*electricity_output_capacity"),V(energy_power_ultra_supercritical_coal, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_cofiring_coal.ad
@@ -11,7 +11,7 @@
         	V(energy_power_ultra_supercritical_cofiring_coal, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_cofiring_coal,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_cofiring_coal,number_of_units),V(energy_power_ultra_supercritical_cofiring_coal,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_lignite.ad
+++ b/inputs/supply/electricity/coal_plants/capacity_of_energy_power_ultra_supercritical_lignite.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_lignite,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_ultra_supercritical_oxyfuel_ccs_lignite, "number_of_units*electricity_output_capacity"),V(energy_power_ultra_supercritical_lignite, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_combined_cycle_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_combined_cycle_network_gas.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_combined_cycle_ht_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_combined_cycle_ht_network_gas,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_local_engine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_chp_local_engine_network_gas.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_local_engine_ht_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_local_engine_ht_network_gas,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = 
     present:SUM(

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_combined_cycle_network_gas.ad
@@ -22,7 +22,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_combined_cycle_network_gas,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_power_combined_cycle_ccs_network_gas, "number_of_units*electricity_output_capacity"),V(energy_power_combined_cycle_network_gas, "number_of_units*electricity_output_capacity"))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_engine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_engine_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_power_engine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_engine_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_engine_network_gas,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_engine_network_gas,number_of_units),V(energy_power_engine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_turbine_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_turbine_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_power_turbine_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_turbine_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_turbine_network_gas,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_turbine_network_gas,number_of_units),V(energy_power_turbine_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/gas_plants/capacity_of_energy_power_ultra_supercritical_network_gas.ad
+++ b/inputs/supply/electricity/gas_plants/capacity_of_energy_power_ultra_supercritical_network_gas.ad
@@ -11,7 +11,7 @@
         	V(energy_power_ultra_supercritical_network_gas, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_network_gas,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_network_gas,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_network_gas,number_of_units),V(energy_power_ultra_supercritical_network_gas,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen2_uranium_oxide.ad
@@ -11,7 +11,7 @@
       		V(energy_power_nuclear_gen2_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_gen2_uranium_oxide,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000.0,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_gen2_uranium_oxide,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_gen2_uranium_oxide,number_of_units),V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_gen3_uranium_oxide.ad
@@ -11,7 +11,7 @@
       		V(energy_power_nuclear_gen3_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_gen3_uranium_oxide,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000.0,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_gen3_uranium_oxide,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_gen3_uranium_oxide,number_of_units),V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_small_modular_reactor_uranium_oxide.ad
+++ b/inputs/supply/electricity/nuclear_plants/capacity_of_energy_power_nuclear_small_modular_reactor_uranium_oxide.ad
@@ -11,7 +11,7 @@
       		V(energy_power_nuclear_small_modular_reactor_uranium_oxide, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_small_modular_reactor_uranium_oxide,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_nuclear_small_modular_reactor_uranium_oxide,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_nuclear_small_modular_reactor_uranium_oxide,number_of_units),V(energy_power_nuclear_small_modular_reactor_uranium_oxide, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/oil_plants/capacity_of_energy_power_engine_diesel.ad
+++ b/inputs/supply/electricity/oil_plants/capacity_of_energy_power_engine_diesel.ad
@@ -11,7 +11,7 @@
         	V(energy_power_engine_diesel, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_engine_diesel,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_engine_diesel,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_engine_diesel,number_of_units),V(energy_power_engine_diesel,electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/electricity/oil_plants/capacity_of_energy_power_ultra_supercritical_crude_oil.ad
+++ b/inputs/supply/electricity/oil_plants/capacity_of_energy_power_ultra_supercritical_crude_oil.ad
@@ -11,7 +11,7 @@
       		V(energy_power_ultra_supercritical_crude_oil, production_based_on_number_of_units)
     ))
 - priority = 0
-- max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_crude_oil,full_load_hours)), MJ_PER_MWH)
+- max_value_gql = present:MAX(10000,2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_power_ultra_supercritical_crude_oil,full_load_hours)), MJ_PER_MWH))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(energy_power_ultra_supercritical_crude_oil,number_of_units),V(energy_power_ultra_supercritical_crude_oil, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_ammonia_reformer_dispatchable.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_ammonia_reformer_dispatchable.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_ammonia_reformer_dispatchable,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_ammonia_reformer_dispatchable,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_hydrogen_ammonia_reformer_dispatchable, "number_of_units * hydrogen_output_capacity")
 - step_value = 0.1

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_ammonia_reformer_must_run.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_ammonia_reformer_must_run.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_ammonia_reformer_must_run,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_ammonia_reformer_must_run,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_hydrogen_ammonia_reformer_must_run, "number_of_units * hydrogen_output_capacity")
 - step_value = 0.1

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_autothermal_reformer_dispatchable.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_autothermal_reformer_dispatchable.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(5000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_autothermal_reformer_dispatchable,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_autothermal_reformer_dispatchable,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_hydrogen_autothermal_reformer_dispatchable, "number_of_units * hydrogen_output_capacity")
 - unit = MW

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_autothermal_reformer_must_run.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_autothermal_reformer_must_run.ad
@@ -23,7 +23,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(5000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_autothermal_reformer_must_run,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_autothermal_reformer_must_run,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = 
     present:

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_biomass_gasification.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_biomass_gasification.ad
@@ -23,7 +23,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_biomass_gasification,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_biomass_gasification,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_hydrogen_biomass_gasification,"number_of_units * hydrogen_output_capacity"),V(energy_hydrogen_biomass_gasification_ccs,"number_of_units * hydrogen_output_capacity"))
 - unit = MW

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_liquid_hydrogen_regasifier.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_liquid_hydrogen_regasifier.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_liquid_hydrogen_regasifier,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_liquid_hydrogen_regasifier,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_hydrogen_liquid_hydrogen_regasifier, "number_of_units * hydrogen_output_capacity")
 - step_value = 0.1

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_lohc_reformer.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_lohc_reformer.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_lohc_reformer,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_lohc_reformer,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_hydrogen_lohc_reformer, "number_of_units * hydrogen_output_capacity")
 - step_value = 0.1

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_steam_methane_reformer_dispatchable.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_steam_methane_reformer_dispatchable.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_steam_methane_reformer_dispatchable,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_steam_methane_reformer_dispatchable,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_hydrogen_steam_methane_reformer_dispatchable, "number_of_units * hydrogen_output_capacity")
 - unit = MW

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_steam_methane_reformer_must_run.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_hydrogen_steam_methane_reformer_must_run.ad
@@ -23,7 +23,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_steam_methane_reformer_must_run,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_hydrogen_steam_methane_reformer_must_run,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:SUM(V(energy_hydrogen_steam_methane_reformer_must_run,"number_of_units * hydrogen_output_capacity"),V(energy_hydrogen_steam_methane_reformer_ccs_must_run,"number_of_units * hydrogen_output_capacity"))
 - unit = MW

--- a/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_imported_hydrogen_baseload.ad
+++ b/inputs/supply/hydrogen/hydrogen_production/capacity_of_energy_imported_hydrogen_baseload.ad
@@ -13,7 +13,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_imported_hydrogen_baseload,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(10000,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_imported_hydrogen_baseload,full_load_hours),MJ_PER_MWH)))
 - min_value = 0.0
 - start_value_gql = present:V(energy_imported_hydrogen_baseload, "number_of_units * hydrogen_output_capacity")
 - step_value = 0.1

--- a/inputs/supply/hydrogen/hydrogen_storage/volume_of_energy_hydrogen_storage_depleted_gas_field.ad
+++ b/inputs/supply/hydrogen/hydrogen_storage/volume_of_energy_hydrogen_storage_depleted_gas_field.ad
@@ -12,7 +12,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:DIVIDE(Q(total_electricity_consumed), PRODUCT(MJ_PER_KWH, 10**9))
+- max_value_gql = present:MAX(1000.0, DIVIDE(Q(total_electricity_consumed), PRODUCT(MJ_PER_KWH, 10**9)))
 - min_value = 0.0
 - start_value_gql = present:DIVIDE(V(energy_hydrogen_storage_depleted_gas_field,"storage.volume * number_of_units"),MILLIONS)
 - step_value = 0.01

--- a/inputs/supply/hydrogen/hydrogen_storage/volume_of_energy_hydrogen_storage_salt_cavern.ad
+++ b/inputs/supply/hydrogen/hydrogen_storage/volume_of_energy_hydrogen_storage_salt_cavern.ad
@@ -12,7 +12,7 @@
     )
 
 - priority = 0
-- max_value_gql = present:MAX(1.0, DIVIDE(Q(total_electricity_consumed), PRODUCT(MJ_PER_KWH, 10**9)))
+- max_value_gql = present:MAX(1000.0, DIVIDE(Q(total_electricity_consumed), PRODUCT(MJ_PER_KWH, 10**9)))
 - min_value = 0.0
 - start_value_gql = present:DIVIDE(V(energy_hydrogen_storage_salt_cavern,"storage.volume * number_of_units" ),MILLIONS)
 - step_value = 0.01

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_buildings_solar_pv_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_buildings_solar_pv_solar_radiation.ad
@@ -14,7 +14,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(AREA(buildings_roof_surface_available_for_pv)*2,V(buildings_solar_pv_solar_radiation, land_use_per_unit)),V(buildings_solar_pv_solar_radiation, electricity_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(AREA(buildings_roof_surface_available_for_pv)*8,V(buildings_solar_pv_solar_radiation, land_use_per_unit)),V(buildings_solar_pv_solar_radiation, electricity_output_capacity)))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(buildings_solar_pv_solar_radiation, number_of_units), V(buildings_solar_pv_solar_radiation, electricity_output_capacity))
 - step_value = 1.0

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_households_solar_pv_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_households_solar_pv_solar_radiation.ad
@@ -14,7 +14,7 @@
       )
     )
 - priority = 0
-- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(AREA(residences_roof_surface_available_for_pv)*2,V(households_solar_pv_solar_radiation, land_use_per_unit)),V(households_solar_pv_solar_radiation, electricity_output_capacity)))
+- max_value_gql = present:MAX(1.0,PRODUCT(DIVIDE(AREA(residences_roof_surface_available_for_pv)*8,V(households_solar_pv_solar_radiation, land_use_per_unit)),V(households_solar_pv_solar_radiation, electricity_output_capacity)))
 - min_value = 0.0
 - start_value_gql = present:PRODUCT(V(households_solar_pv_solar_radiation, number_of_units), V(households_solar_pv_solar_radiation, electricity_output_capacity))
 - step_value = 1.0


### PR DESCRIPTION
This PR increases the maximum input value for several capacity sliders. The current values do not suffice e.g. in the case of provinces where one province hosts the production capacity for the entire country. Also, some max values are based on restrictions in the present (e.g. rooftop surface area available) which do not scale well with related changes in the future.

This PR makes the following increases to slider max values:

- rooftop solar pv capacities to 8x maximum roof surface area;
- nuclear plant, SMR plants, refinery p2h and flex mv batteries to at least 10000 MW;
- p2h heatpump by factor of 6;
- paper industry p2h to at least 25 MW;
- hydrogen salt cavern storage to at least 1000 TWh.

