### PR TITLE
changed subtype to pseudo for heat pumps

### DIFF
--- a/graphs/energy/nodes/energy/energy_heat_boiler_ht_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_boiler_ht_electricity.ad
@@ -20,7 +20,7 @@
 - heat_network_ht.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_boiler_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_boiler_lt_electricity.ad
@@ -20,7 +20,7 @@
 - heat_network_lt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_boiler_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_boiler_mt_electricity.ad
@@ -20,7 +20,7 @@
 - heat_network_mt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_lt_electricity.ad
@@ -21,7 +21,7 @@
 - heat_network_lt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_mt_electricity.ad
@@ -21,7 +21,7 @@
 - heat_network_mt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_lt_electricity.ad
@@ -21,7 +21,7 @@
 - heat_network_lt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_mt_electricity.ad
@@ -21,7 +21,7 @@
 - heat_network_mt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_lt_electricity.ad
@@ -21,7 +21,7 @@
 - heat_network_lt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_mt_electricity.ad
@@ -21,7 +21,7 @@
 - heat_network_mt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_ht_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_ht_electricity.ad
@@ -22,7 +22,7 @@
 - heat_network_ht.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_lt_electricity.ad
@@ -22,7 +22,7 @@
 - heat_network_lt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_mt_electricity.ad
@@ -22,7 +22,7 @@
 - heat_network_mt.type = producer
 - merit_order.group = self: steam_hot_water_output_curve
 - merit_order.level = mv
-- merit_order.subtype = generic
+- merit_order.subtype = pseudo
 - merit_order.type = consumer
 - electricity_output_capacity = 0.0
 - free_co2_factor = 0.0


### PR DESCRIPTION
This should close [this heatpump issue.](https://github.com/quintel/etengine/issues/1337) 
With the help of Nora's investigation powers, I changed the merit_order subtype to _pseudo_. Based on my initial checks, the input curve is now calculating appropriately.