### PR TITLE
CTM-ETM coupling deliverable 3b

### DIFF
--- a/config/energy_node_positions.yml
+++ b/config/energy_node_positions.yml
@@ -2236,22 +2236,22 @@ industry_chemicals_refineries_used_heat:
   "y": 10600
 industry_chp_combined_cycle_gas_power_fuelmix:
   x: 3920
-  "y": 8900
+  "y": 8720
 industry_chp_engine_gas_power_fuelmix:
   x: 3920
-  "y": 8720
+  "y": 8360
 industry_chp_turbine_gas_power_fuelmix:
   x: 3920
-  "y": 8780
+  "y": 8480
 industry_chp_turbine_hydrogen:
   x: 3920
-  "y": 8660
+  "y": 8240
 industry_chp_ultra_supercritical_coal:
   x: 3920
-  "y": 8840
+  "y": 8600
 industry_chp_wood_pellets:
   x: 3920
-  "y": 8960
+  "y": 8840
 industry_final_demand_ammonia_non_energetic:
   x: 2900
   "y": 10620
@@ -2746,22 +2746,40 @@ industry_final_demand_wood_pellets_non_energetic:
   "y": 10500
 industry_heat_backup_burner_network_gas:
   x: 3920
-  "y": 9260
+  "y": 9200
 industry_heat_burner_coal:
   x: 3920
-  "y": 9080
+  "y": 9020
 industry_heat_burner_crude_oil:
   x: 3920
-  "y": 9200
+  "y": 9140
 industry_heat_burner_hydrogen:
   x: 3920
-  "y": 9320
+  "y": 9260
 industry_heat_burner_lignite:
   x: 3920
-  "y": 9020
+  "y": 8960
+industry_heat_combined_cycle_gas_power_fuelmix:
+  x: 3920
+  "y": 8780
+industry_heat_engine_gas_power_fuelmix:
+  x: 3920
+  "y": 8420
+industry_heat_turbine_gas_power_fuelmix:
+  x: 3920
+  "y": 8540
+industry_heat_turbine_hydrogen:
+  x: 3920
+  "y": 8300
+industry_heat_ultra_supercritical_coal:
+  x: 3920
+  "y": 8660
 industry_heat_well_geothermal:
   x: 3920
-  "y": 9140
+  "y": 9080
+industry_heat_wood_pellets:
+  x: 3920
+  "y": 8900
 industry_locally_available_crude_oil_non_energetic_for_chemical:
   x: 2000
   "y": 11460

--- a/gqueries/general/conversion/heat/biomass_products_in_source_of_central_heat_production.gql
+++ b/gqueries/general/conversion/heat/biomass_products_in_source_of_central_heat_production.gql
@@ -3,6 +3,7 @@
 - query =
     SUM(
       Q(wood_pellets_in_source_of_central_heat_production),
-      Q(greengas_in_source_of_central_heat_production)
+      Q(greengas_in_source_of_central_heat_production),
+      Q(gas_power_fuelmix_in_source_of_central_heat_conversion) * V(energy_mixer_for_gas_power_fuel, bio_oil_input_conversion)
     )
 - unit = PJ

--- a/gqueries/general/conversion/heat/gas_power_fuelmix_in_source_of_central_heat_conversion.gql
+++ b/gqueries/general/conversion/heat/gas_power_fuelmix_in_source_of_central_heat_conversion.gql
@@ -1,0 +1,14 @@
+# Direct conversion output of steam hot water from central heating through gas power fuelmix heaters
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          Q(central_heat_producing_converters_sankey),
+          "output_of_steam_hot_water * gas_power_fuelmix_input_conversion"
+        )
+      ),
+      BILLIONS
+    )
+
+- unit = PJ

--- a/gqueries/general/conversion/heat/network_gas_in_source_of_central_heat_production.gql
+++ b/gqueries/general/conversion/heat/network_gas_in_source_of_central_heat_production.gql
@@ -1,13 +1,16 @@
 # Direct conversion output of steam hot water from central heating through network gas heaters
 
 - query =
-    DIVIDE(
-      SUM(
-        V(
-          Q(central_heat_producing_converters_sankey),
-          "output_of_steam_hot_water * network_gas_input_conversion"
-        )
+    SUM(
+      DIVIDE(
+        SUM(
+          V(
+            Q(central_heat_producing_converters_sankey),
+            "output_of_steam_hot_water * network_gas_input_conversion"
+          )
+        ),
+        BILLIONS
       ),
-      BILLIONS
+      Q(gas_power_fuelmix_in_source_of_central_heat_conversion) * V(energy_mixer_for_gas_power_fuel, network_gas_input_conversion)
     )
 - unit = PJ

--- a/gqueries/general/conversion/heat/oil_and_derivatives_in_source_of_central_heat_production.gql
+++ b/gqueries/general/conversion/heat/oil_and_derivatives_in_source_of_central_heat_production.gql
@@ -1,13 +1,16 @@
 # Direct conversion output of steam hot water from central heating through oil derivatives heaters
 
 - query =
-    DIVIDE(
-      SUM(
-        V(
-          Q(central_heat_producing_converters_sankey),
-          "output_of_steam_hot_water * crude_oil_input_conversion"
-        )
+    SUM(
+      DIVIDE(
+        SUM(
+          V(
+            Q(central_heat_producing_converters_sankey),
+            "output_of_steam_hot_water * crude_oil_input_conversion"
+          )
+        ),
+        BILLIONS
       ),
-      BILLIONS
+      Q(gas_power_fuelmix_in_source_of_central_heat_conversion) * V(energy_mixer_for_gas_power_fuel, crude_oil_input_conversion)
     )
 - unit = PJ

--- a/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_combined_cycle_gas_power_fuelmix_in_industrial_heat_network_mekko.gql
+++ b/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_combined_cycle_gas_power_fuelmix_in_industrial_heat_network_mekko.gql
@@ -1,2 +1,11 @@
+# Accounts for heat component of the CHP (industry_heat_xxx) if external coupling is activated
+
 - unit = MJ
-- query = V(industry_chp_combined_cycle_gas_power_fuelmix, output_of_steam_hot_water)
+- query =
+    SUM(
+      V(
+        industry_chp_combined_cycle_gas_power_fuelmix,
+        industry_heat_combined_cycle_gas_power_fuelmix,
+        output_of_steam_hot_water
+      )
+    )

--- a/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_engine_gas_power_fuelmix_in_industrial_heat_network_mekko.gql
+++ b/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_engine_gas_power_fuelmix_in_industrial_heat_network_mekko.gql
@@ -1,2 +1,11 @@
+# Accounts for heat component of the CHP (industry_heat_xxx) if external coupling is activated
+
 - unit = MJ
-- query = V(industry_chp_engine_gas_power_fuelmix, output_of_steam_hot_water)
+- query =
+    SUM(
+      V(
+        industry_chp_engine_gas_power_fuelmix,
+        industry_heat_engine_gas_power_fuelmix,
+        output_of_steam_hot_water
+      )
+    )

--- a/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_turbine_gas_power_fuelmix_in_industrial_heat_network_mekko.gql
+++ b/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_turbine_gas_power_fuelmix_in_industrial_heat_network_mekko.gql
@@ -1,2 +1,11 @@
+# Accounts for heat component of the CHP (industry_heat_xxx) if external coupling is activated
+
 - unit = MJ
-- query = V(industry_chp_turbine_gas_power_fuelmix, output_of_steam_hot_water)
+- query =
+    SUM(
+      V(
+        industry_chp_turbine_gas_power_fuelmix,
+        industry_heat_turbine_gas_power_fuelmix,
+        output_of_steam_hot_water
+      )
+    )

--- a/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_turbine_hydrogen_in_industrial_heat_network_mekko.gql
+++ b/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_turbine_hydrogen_in_industrial_heat_network_mekko.gql
@@ -1,2 +1,11 @@
+# Accounts for heat component of the CHP (industry_heat_xxx) if external coupling is activated
+
 - unit = MJ
-- query = V(industry_chp_turbine_hydrogen, output_of_steam_hot_water)
+- query =
+    SUM(
+      V(
+        industry_chp_turbine_hydrogen,
+        industry_heat_turbine_hydrogen,
+        output_of_steam_hot_water
+      )
+    )

--- a/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_ultra_supercritical_coal_in_industrial_heat_network_mekko.gql
+++ b/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_ultra_supercritical_coal_in_industrial_heat_network_mekko.gql
@@ -1,2 +1,11 @@
+# Accounts for heat component of the CHP (industry_heat_xxx) if external coupling is activated
+
 - unit = MJ
-- query = V(industry_chp_ultra_supercritical_coal, output_of_steam_hot_water)
+- query =
+    SUM(
+      V(
+        industry_chp_ultra_supercritical_coal,
+        industry_heat_ultra_supercritical_coal,
+        output_of_steam_hot_water
+      )
+    )

--- a/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_wood_pellets_in_industrial_heat_network_mekko.gql
+++ b/gqueries/output_elements/output_series/mekko_industrial_heat_network/industry_chp_wood_pellets_in_industrial_heat_network_mekko.gql
@@ -1,2 +1,11 @@
+# Accounts for heat component of the CHP (industry_heat_xxx) if external coupling is activated
+
 - unit = MJ
-- query = V(industry_chp_wood_pellets, output_of_steam_hot_water)
+- query =
+    SUM(
+      V(
+        industry_chp_wood_pellets,
+        industry_heat_wood_pellets,
+        output_of_steam_hot_water
+      )
+    )

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_combined_cycle_gas_power_fuelmix_electricity_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_combined_cycle_gas_power_fuelmix_electricity_production_in_chp_properties.gql
@@ -1,4 +1,4 @@
 # electricity production of industry_chp_combined_cycle_gas_power_fuelmix
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_combined_cycle_gas_power_fuelmix, output_of_electricity),billions)
+- query = future:DIVIDE(V(industry_chp_combined_cycle_gas_power_fuelmix, output_of_electricity),BILLIONS)

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_combined_cycle_gas_power_fuelmix_heat_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_combined_cycle_gas_power_fuelmix_heat_production_in_chp_properties.gql
@@ -1,4 +1,15 @@
 # heat production of industry_chp_combined_cycle_gas_power_fuelmix
+# accounts for CHP heat component (industry_heat_xxx) when external coupling is activated
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_combined_cycle_gas_power_fuelmix, "output_of_useable_heat + output_of_steam_hot_water"),billions)
+- query =
+    future:DIVIDE(
+      SUM(
+        V(
+          industry_chp_combined_cycle_gas_power_fuelmix,
+          industry_heat_combined_cycle_gas_power_fuelmix,
+          "output_of_useable_heat + output_of_steam_hot_water"
+        )
+      ),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_engine_gas_power_fuelmix_electricity_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_engine_gas_power_fuelmix_electricity_production_in_chp_properties.gql
@@ -1,4 +1,4 @@
 # electricity production of industry_chp_engine_gas_power_fuelmix
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_engine_gas_power_fuelmix, output_of_electricity),billions)
+- query = future:DIVIDE(V(industry_chp_engine_gas_power_fuelmix, output_of_electricity),BILLIONS)

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_engine_gas_power_fuelmix_heat_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_engine_gas_power_fuelmix_heat_production_in_chp_properties.gql
@@ -1,4 +1,15 @@
 # heat production of industry_chp_engine_gas_power_fuelmix
+# accounts for CHP heat component (industry_heat_xxx) when external coupling is activated
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_engine_gas_power_fuelmix, "output_of_useable_heat + output_of_steam_hot_water"),billions)
+- query =
+    future:DIVIDE(
+      SUM(
+        V(
+          industry_chp_engine_gas_power_fuelmix,
+          industry_heat_engine_gas_power_fuelmix,
+          "output_of_useable_heat + output_of_steam_hot_water"
+        )
+      ),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_gas_power_fuelmix_electricity_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_gas_power_fuelmix_electricity_production_in_chp_properties.gql
@@ -1,4 +1,4 @@
 # electricity production of industry_chp_turbine_gas_power_fuelmix
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_turbine_gas_power_fuelmix, output_of_electricity),billions)
+- query = future:DIVIDE(V(industry_chp_turbine_gas_power_fuelmix, output_of_electricity),BILLIONS)

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_gas_power_fuelmix_heat_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_gas_power_fuelmix_heat_production_in_chp_properties.gql
@@ -1,4 +1,15 @@
 # heat production of industry_chp_turbine_gas_power_fuelmix
+# accounts for CHP heat component (industry_heat_xxx) when external coupling is activated
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_turbine_gas_power_fuelmix, "output_of_useable_heat + output_of_steam_hot_water"),billions)
+- query =
+    future:DIVIDE(
+      SUM(
+        V(
+          industry_chp_turbine_gas_power_fuelmix,
+          industry_heat_turbine_gas_power_fuelmix,
+          "output_of_useable_heat + output_of_steam_hot_water"
+        )
+      ),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_hydrogen_electricity_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_hydrogen_electricity_production_in_chp_properties.gql
@@ -1,4 +1,4 @@
 # electricity production of industry_chp_turbine_hydrogen
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_turbine_hydrogen, output_of_electricity),billions)
+- query = future:DIVIDE(V(industry_chp_turbine_hydrogen, output_of_electricity),BILLIONS)

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_hydrogen_heat_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_turbine_hydrogen_heat_production_in_chp_properties.gql
@@ -1,4 +1,15 @@
 # heat production of industry_chp_turbine_hydrogen
+# accounts for CHP heat component (industry_heat_xxx) when external coupling is activated
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_turbine_hydrogen, "output_of_useable_heat + output_of_steam_hot_water"),billions)
+- query =
+    future:DIVIDE(
+      SUM(
+        V(
+          industry_chp_turbine_hydrogen,
+          industry_heat_turbine_hydrogen,
+          "output_of_useable_heat + output_of_steam_hot_water"
+        )
+      ),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_ultra_supercritical_coal_electricity_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_ultra_supercritical_coal_electricity_production_in_chp_properties.gql
@@ -1,4 +1,4 @@
 # electricity production of industry_chp_ultra_supercritical_coal
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_ultra_supercritical_coal, output_of_electricity),billions)
+- query = future:DIVIDE(V(industry_chp_ultra_supercritical_coal, output_of_electricity),BILLIONS)

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_ultra_supercritical_coal_heat_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_ultra_supercritical_coal_heat_production_in_chp_properties.gql
@@ -1,4 +1,15 @@
 # heat production of industry_chp_ultra_supercritical_coal
+# accounts for CHP heat component (industry_heat_xxx) when external coupling is activated
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_ultra_supercritical_coal, "output_of_useable_heat + output_of_steam_hot_water"),billions)
+- query =
+    future:DIVIDE(
+      SUM(
+        V(
+          industry_chp_ultra_supercritical_coal,
+          industry_heat_ultra_supercritical_coal,
+          "output_of_useable_heat + output_of_steam_hot_water"
+        )
+      ),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_wood_pellets_electricity_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_wood_pellets_electricity_production_in_chp_properties.gql
@@ -1,4 +1,4 @@
 # electricity production of industry_chp_wood_pellets
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_wood_pellets, output_of_electricity),billions)
+- query = future:DIVIDE(V(industry_chp_wood_pellets, output_of_electricity),BILLIONS)

--- a/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_wood_pellets_heat_production_in_chp_properties.gql
+++ b/gqueries/output_elements/output_series/table_141_chp_properties/industry_chp_wood_pellets_heat_production_in_chp_properties.gql
@@ -1,4 +1,15 @@
 # heat production of industry_chp_wood_pellets
+# accounts for CHP heat component (industry_heat_xxx) when external coupling is activated
 
 - unit = PJ
-- query = future:UNIT(V(industry_chp_wood_pellets, "output_of_useable_heat + output_of_steam_hot_water"),billions)
+- query =
+    future:DIVIDE(
+      SUM(
+        V(
+          industry_chp_wood_pellets,
+          industry_heat_wood_pellets,
+          "output_of_useable_heat + output_of_steam_hot_water"
+        )
+      ),
+      BILLIONS
+    )

--- a/graphs/energy/edges/industry/energy_distribution_coal-industry_heat_ultra_supercritical_coal@coal.ad
+++ b/graphs/energy/edges/industry/energy_distribution_coal-industry_heat_ultra_supercritical_coal@coal.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/energy_distribution_torrefied_biomass_pellets-industry_heat_ultra_supercritical_coal@torrefied_biomass_pellets.ad
+++ b/graphs/energy/edges/industry/energy_distribution_torrefied_biomass_pellets-industry_heat_ultra_supercritical_coal@torrefied_biomass_pellets.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/energy_distribution_wood_pellets-industry_heat_wood_pellets@wood_pellets.ad
+++ b/graphs/energy/edges/industry/energy_distribution_wood_pellets-industry_heat_wood_pellets@wood_pellets.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/energy_hydrogen_after_distribution-industry_heat_turbine_hydrogen@hydrogen.ad
+++ b/graphs/energy/edges/industry/energy_hydrogen_after_distribution-industry_heat_turbine_hydrogen@hydrogen.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/energy_mixer_for_gas_power_fuel-industry_heat_combined_cycle_gas_power_fuelmix@gas_power_fuelmix.ad
+++ b/graphs/energy/edges/industry/energy_mixer_for_gas_power_fuel-industry_heat_combined_cycle_gas_power_fuelmix@gas_power_fuelmix.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/energy_mixer_for_gas_power_fuel-industry_heat_engine_gas_power_fuelmix@gas_power_fuelmix.ad
+++ b/graphs/energy/edges/industry/energy_mixer_for_gas_power_fuel-industry_heat_engine_gas_power_fuelmix@gas_power_fuelmix.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/energy_mixer_for_gas_power_fuel-industry_heat_turbine_gas_power_fuelmix@gas_power_fuelmix.ad
+++ b/graphs/energy/edges/industry/energy_mixer_for_gas_power_fuel-industry_heat_turbine_gas_power_fuelmix@gas_power_fuelmix.ad
@@ -1,0 +1,2 @@
+- type = share
+- reversed = false

--- a/graphs/energy/edges/industry/industry_heat_combined_cycle_gas_power_fuelmix-industry_locally_available_steam_hot_water@steam_hot_water.ad
+++ b/graphs/energy/edges/industry/industry_heat_combined_cycle_gas_power_fuelmix-industry_locally_available_steam_hot_water@steam_hot_water.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/energy/edges/industry/industry_heat_engine_gas_power_fuelmix-industry_locally_available_steam_hot_water@steam_hot_water.ad
+++ b/graphs/energy/edges/industry/industry_heat_engine_gas_power_fuelmix-industry_locally_available_steam_hot_water@steam_hot_water.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/energy/edges/industry/industry_heat_turbine_gas_power_fuelmix-industry_locally_available_steam_hot_water@steam_hot_water.ad
+++ b/graphs/energy/edges/industry/industry_heat_turbine_gas_power_fuelmix-industry_locally_available_steam_hot_water@steam_hot_water.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/energy/edges/industry/industry_heat_turbine_hydrogen-industry_locally_available_steam_hot_water@steam_hot_water.ad
+++ b/graphs/energy/edges/industry/industry_heat_turbine_hydrogen-industry_locally_available_steam_hot_water@steam_hot_water.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/energy/edges/industry/industry_heat_ultra_supercritical_coal-industry_locally_available_steam_hot_water@steam_hot_water.ad
+++ b/graphs/energy/edges/industry/industry_heat_ultra_supercritical_coal-industry_locally_available_steam_hot_water@steam_hot_water.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/energy/edges/industry/industry_heat_wood_pellets-industry_locally_available_steam_hot_water@steam_hot_water.ad
+++ b/graphs/energy/edges/industry/industry_heat_wood_pellets-industry_locally_available_steam_hot_water@steam_hot_water.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/energy/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -16,24 +16,14 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 328.7
 - wacc = 0.04
-- energy_balance_group = central_chp
 - merit_order.level = mv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
 - network_gas.demand_carrier = gas_power_fuelmix
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
-- land_use_per_unit = 0.1
-- part_load_efficiency_penalty = 0.1
-- part_load_operating_point = 0.7
 - takes_part_in_ets = 1.0
-- hours_maint_nl = 534600.0
-- hours_place_nl = 2835000.0
-- hours_prep_nl = 442800.0
-- hours_prod_nl = 0.0
-- hours_remov_nl = 354600.0
 
 ~ demand = CENTRAL_PRODUCTION(industry_chp_combined_cycle_gas_power_fuelmix, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(industry_chp_combined_cycle_gas_power_fuelmix, full_load_hours)

--- a/graphs/energy/nodes/industry/industry_chp_engine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_chp_engine_gas_power_fuelmix.ad
@@ -15,24 +15,14 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 8.0
 - wacc = 0.04
-- energy_balance_group = central_chp
 - merit_order.level = mv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
 - network_gas.demand_carrier = gas_power_fuelmix
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
-- land_use_per_unit = 0.1
-- part_load_efficiency_penalty = 0.1
-- part_load_operating_point = 0.7
 - takes_part_in_ets = 0.0
-- hours_maint_nl = 1260.0
-- hours_place_nl = 2880.0
-- hours_prep_nl = 360.0
-- hours_prod_nl = 0.0
-- hours_remov_nl = 360.0
 
 ~ demand = CENTRAL_PRODUCTION(industry_chp_engine_gas_power_fuelmix, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(industry_chp_engine_gas_power_fuelmix, full_load_hours)

--- a/graphs/energy/nodes/industry/industry_chp_turbine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_chp_turbine_gas_power_fuelmix.ad
@@ -15,24 +15,14 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 157.5
 - wacc = 0.04
-- energy_balance_group = central_chp
 - merit_order.level = mv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
 - network_gas.demand_carrier = gas_power_fuelmix
 - network_gas.profile = self: electricity_output_curve
 - network_gas.type = consumer
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
-- land_use_per_unit = 0.1
-- part_load_efficiency_penalty = 0.1
-- part_load_operating_point = 0.7
 - takes_part_in_ets = 1.0
-- hours_maint_nl = 32040.0
-- hours_place_nl = 193680.0
-- hours_prep_nl = 26820.0
-- hours_prod_nl = 0.0
-- hours_remov_nl = 21600.0
 
 ~ demand = CENTRAL_PRODUCTION(industry_chp_turbine_gas_power_fuelmix, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(industry_chp_turbine_gas_power_fuelmix, full_load_hours)

--- a/graphs/energy/nodes/industry/industry_chp_turbine_hydrogen.ad
+++ b/graphs/energy/nodes/industry/industry_chp_turbine_hydrogen.ad
@@ -17,7 +17,6 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
 - wacc = 0.07
-- energy_balance_group = central_chp
 - hydrogen.group = self: electricity_output_curve
 - hydrogen.type = consumer
 - hydrogen.subtype = generic

--- a/graphs/energy/nodes/industry/industry_chp_ultra_supercritical_coal.ad
+++ b/graphs/energy/nodes/industry/industry_chp_ultra_supercritical_coal.ad
@@ -1,5 +1,3 @@
-- input.coal = 1.0
-- input.torrefied_biomass_pellets = 0.0
 - output.loss = elastic
 - groups = [preset_demand, electricity_production, dispatchable_production, heat_production, mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group]
 - use = energetic
@@ -18,21 +16,11 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 2844.44
 - wacc = 0.04
-- energy_balance_group = central_chp
 - merit_order.level = mv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
-- land_use_per_unit = 0.3
-- part_load_efficiency_penalty = 0.1
-- part_load_operating_point = 0.7
 - takes_part_in_ets = 1.0
-- hours_maint_nl = 32040.0
-- hours_place_nl = 193680.0
-- hours_prep_nl = 26820.0
-- hours_prod_nl = 0.0
-- hours_remov_nl = 21600.0
 
 ~ demand = CENTRAL_PRODUCTION(industry_chp_ultra_supercritical_coal, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(industry_chp_ultra_supercritical_coal, full_load_hours)

--- a/graphs/energy/nodes/industry/industry_chp_wood_pellets.ad
+++ b/graphs/energy/nodes/industry/industry_chp_wood_pellets.ad
@@ -16,21 +16,11 @@
 - variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
 - variable_operation_and_maintenance_costs_per_full_load_hour = 194.15
 - wacc = 0.04
-- energy_balance_group = central_chp
 - merit_order.level = mv
 - merit_order.subtype = dispatchable
 - merit_order.type = producer
-- forecasting_error = 0.0
 - free_co2_factor = 0.0
-- land_use_per_unit = 0.0662
-- part_load_efficiency_penalty = 0.1
-- part_load_operating_point = 0.7
 - takes_part_in_ets = 0.0
-- hours_maint_nl = 10800.0
-- hours_place_nl = 55800.0
-- hours_prep_nl = 4680.0
-- hours_prod_nl = 0.0
-- hours_remov_nl = 3780.0
 
 ~ demand = CENTRAL_PRODUCTION(industry_chp_wood_pellets, demand)
 ~ full_load_hours = CENTRAL_PRODUCTION(industry_chp_wood_pellets, full_load_hours)

--- a/graphs/energy/nodes/industry/industry_heat_combined_cycle_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_heat_combined_cycle_gas_power_fuelmix.ad
@@ -1,0 +1,31 @@
+# this node is activated once input for external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix is set
+# this node provides the heat output of the connected CHP
+# full_load_hours are an estimation for the must-run characteristic of heat supply from industrial CHPs
+# steam hot water efficiency is a generic value which will be updated when external coupling is activated
+# cost attributes are set to 0 since these are allocated to the connected CHP
+
+- output.loss = elastic
+- output.steam_hot_water = 0.9
+- groups = [preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group]
+- use = energetic
+- presentation_group = traditional_heat
+- availability = 0.9
+- typical_input_capacity = 260.9
+- ccs_investment = 0.0
+- construction_time = 2.5
+- cost_of_installing = 0.0
+- decommissioning_costs = 0.0
+- fixed_operation_and_maintenance_costs_per_year = 0.0
+- initial_investment = 0.0
+- technical_lifetime = 30.0
+- variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
+- variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
+- wacc = 0.04
+- network_gas.demand_carrier = gas_power_fuelmix
+- network_gas.profile = flat
+- network_gas.type = consumer
+- free_co2_factor = 0.0
+- takes_part_in_ets = 1.0
+
+~ demand = 0.0
+~ full_load_hours = 8300.0

--- a/graphs/energy/nodes/industry/industry_heat_engine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_heat_engine_gas_power_fuelmix.ad
@@ -1,0 +1,31 @@
+# this node is activated once input for external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix is set
+# this node provides the heat output of the connected CHP
+# full_load_hours are an estimation for the must-run characteristic of heat supply from industrial CHPs
+# steam hot water efficiency is a generic value which will be updated when external coupling is activated
+# cost attributes are set to 0 since these are allocated to the connected CHP
+
+- output.loss = elastic
+- output.steam_hot_water = 0.9
+- groups = [preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group]
+- use = energetic
+- presentation_group = traditional_heat
+- availability = 0.95
+- typical_input_capacity = 2.4
+- ccs_investment = 0.0
+- construction_time = 1.0
+- cost_of_installing = 0.0
+- decommissioning_costs = 0.0
+- fixed_operation_and_maintenance_costs_per_year = 0.0
+- initial_investment = 0.0
+- technical_lifetime = 20.0
+- variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
+- variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
+- wacc = 0.04
+- network_gas.demand_carrier = gas_power_fuelmix
+- network_gas.profile = flat
+- network_gas.type = consumer
+- free_co2_factor = 0.0
+- takes_part_in_ets = 0.0
+
+~ demand = 0.0
+~ full_load_hours = 8300.0

--- a/graphs/energy/nodes/industry/industry_heat_turbine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_heat_turbine_gas_power_fuelmix.ad
@@ -1,0 +1,31 @@
+# this node is activated once input for external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix is set
+# this node provides the heat output of the connected CHP
+# full_load_hours are an estimation for the must-run characteristic of heat supply from industrial CHPs
+# steam hot water efficiency is a generic value which will be updated when external coupling is activated
+# cost attributes are set to 0 since these are allocated to the connected CHP
+
+- output.loss = elastic
+- output.steam_hot_water = 0.9
+- groups = [preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group]
+- use = energetic
+- presentation_group = traditional_heat
+- availability = 0.9
+- typical_input_capacity = 118.4
+- ccs_investment = 0.0
+- construction_time = 1.5
+- cost_of_installing = 0.0
+- decommissioning_costs = 0.0
+- fixed_operation_and_maintenance_costs_per_year = 0.0
+- initial_investment = 0.0
+- technical_lifetime = 25.0
+- variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
+- variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
+- wacc = 0.04
+- network_gas.demand_carrier = gas_power_fuelmix
+- network_gas.profile = flat
+- network_gas.type = consumer
+- free_co2_factor = 0.0
+- takes_part_in_ets = 1.0
+
+~ demand = 0.0
+~ full_load_hours = 8300.0

--- a/graphs/energy/nodes/industry/industry_heat_turbine_hydrogen.ad
+++ b/graphs/energy/nodes/industry/industry_heat_turbine_hydrogen.ad
@@ -1,0 +1,31 @@
+# this node is activated once input for external_coupling_capacity_of_industry_chp_turbine_hydrogen is set
+# this node provides the heat output of the connected CHP
+# full_load_hours are an estimation for the must-run characteristic of heat supply from industrial CHPs
+# steam hot water efficiency is a generic value which will be updated when external coupling is activated
+# cost attributes are set to 0 since these are allocated to the connected CHP
+
+- output.loss = elastic
+- output.steam_hot_water = 0.9
+- groups = [preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group]
+- use = energetic
+- presentation_group = traditional_heat
+- availability = 0.9
+- typical_input_capacity = 59.8
+- ccs_investment = 0.0
+- construction_time = 1.5
+- cost_of_installing = 0.0
+- decommissioning_costs = 0.0
+- fixed_operation_and_maintenance_costs_per_year = 0.0
+- initial_investment = 0.0
+- technical_lifetime = 25.0
+- variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
+- variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
+- wacc = 0.07
+- hydrogen.group = flat
+- hydrogen.type = consumer
+- hydrogen.subtype = generic
+- free_co2_factor = 0.0
+- takes_part_in_ets = 1.0
+
+~ demand = 0.0
+~ full_load_hours = 8300.0

--- a/graphs/energy/nodes/industry/industry_heat_ultra_supercritical_coal.ad
+++ b/graphs/energy/nodes/industry/industry_heat_ultra_supercritical_coal.ad
@@ -1,0 +1,30 @@
+# this node is activated once input for external_coupling_capacity_of_industry_chp_ultra_supercritical_coal is set
+# this node provides the heat output of the connected CHP
+# full_load_hours are an estimation for the must-run characteristic of heat supply from industrial CHPs
+# steam hot water efficiency is a generic value which will be updated when external coupling is activated
+# cost attributes are set to 0 since these are allocated to the connected CHP
+
+- input.coal = 1.0
+- input.torrefied_biomass_pellets = 0.0
+- output.loss = elastic
+- output.steam_hot_water = 0.9
+- groups = [preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group]
+- use = energetic
+- presentation_group = traditional_heat
+- availability = 0.9
+- typical_input_capacity = 1500.0
+- ccs_investment = 0.0
+- construction_time = 4.0
+- cost_of_installing = 0.0
+- decommissioning_costs = 0.0
+- fixed_operation_and_maintenance_costs_per_year = 0.0
+- initial_investment = 0.0
+- technical_lifetime = 40.0
+- variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
+- variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
+- wacc = 0.04
+- free_co2_factor = 0.0
+- takes_part_in_ets = 1.0
+
+~ demand = 0.0
+~ full_load_hours = 8300.0

--- a/graphs/energy/nodes/industry/industry_heat_wood_pellets.ad
+++ b/graphs/energy/nodes/industry/industry_heat_wood_pellets.ad
@@ -1,0 +1,28 @@
+# this node is activated once input for external_coupling_capacity_of_industry_chp_wood_pellets is set
+# this node provides the heat output of the connected CHP
+# full_load_hours are an estimation for the must-run characteristic of heat supply from industrial CHPs
+# steam hot water efficiency is a generic value which will be updated when external coupling is activated
+# cost attributes are set to 0 since these are allocated to the connected CHP
+
+- output.loss = elastic
+- output.steam_hot_water = 0.9
+- groups = [preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group]
+- use = energetic
+- presentation_group = traditional_heat
+- availability = 0.9
+- typical_input_capacity = 632.6
+- ccs_investment = 0.0
+- construction_time = 1.0
+- cost_of_installing = 0.0
+- decommissioning_costs = 0.0
+- fixed_operation_and_maintenance_costs_per_year = 0.0
+- initial_investment = 0.0
+- technical_lifetime = 25.0
+- variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour = 0.0
+- variable_operation_and_maintenance_costs_per_full_load_hour = 0.0
+- wacc = 0.04
+- free_co2_factor = 0.0
+- takes_part_in_ets = 0.0
+
+~ demand = 0.0
+~ full_load_hours = 8300.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_biogas_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_biogas_electricity.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_engine_biogas), 
+        V(agriculture_chp_engine_biogas),
         electricity
-      ), 
+      ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_engine_biogas, electricity_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_engine_biogas, electricity_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_engine_biogas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_biogas_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_biogas_heat.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_engine_biogas), 
+        V(agriculture_chp_engine_biogas),
         steam_hot_water
       ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_engine_biogas, steam_hot_water_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_engine_biogas, steam_hot_water_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_engine_biogas, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_dispatchable_network_gas_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_dispatchable_network_gas_electricity.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_engine_network_gas_dispatchable), 
+        V(agriculture_chp_engine_network_gas_dispatchable),
         electricity
-      ), 
+      ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_engine_network_gas_dispatchable, electricity_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_engine_network_gas_dispatchable, electricity_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_engine_network_gas_dispatchable, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_dispatchable_network_gas_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_dispatchable_network_gas_heat.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_engine_network_gas_dispatchable), 
+        V(agriculture_chp_engine_network_gas_dispatchable),
         steam_hot_water
       ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_engine_network_gas_dispatchable, steam_hot_water_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_engine_network_gas_dispatchable, steam_hot_water_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_engine_network_gas_dispatchable, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_must_run_network_gas_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_must_run_network_gas_electricity.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_engine_network_gas_must_run), 
+        V(agriculture_chp_engine_network_gas_must_run),
         electricity
-      ), 
+      ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_engine_network_gas_must_run, electricity_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_engine_network_gas_must_run, electricity_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_engine_network_gas_must_run, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_must_run_network_gas_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_engine_must_run_network_gas_heat.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_engine_network_gas_must_run), 
+        V(agriculture_chp_engine_network_gas_must_run),
         steam_hot_water
       ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_engine_network_gas_must_run, steam_hot_water_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_engine_network_gas_must_run, steam_hot_water_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_engine_network_gas_must_run, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_wood_pellets_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_wood_pellets_electricity.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_wood_pellets), 
+        V(agriculture_chp_wood_pellets),
         electricity
-      ), 
+      ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_wood_pellets, electricity_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_wood_pellets, electricity_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_wood_pellets, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_agriculture_chp_wood_pellets_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_agriculture_chp_wood_pellets_heat.ad
@@ -1,12 +1,14 @@
-- query = 
+# Priority set to 1 to set prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
-        V(agriculture_chp_wood_pellets), 
+        V(agriculture_chp_wood_pellets),
         steam_hot_water
       ),
       conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value_gql = present:MIN(V(agriculture_chp_wood_pellets, steam_hot_water_output_conversion) * 100.0 + 10.0, 100.0)
 - min_value_gql = present:MAX(V(agriculture_chp_wood_pellets, steam_hot_water_output_conversion) * 100.0 - 10.0, 0.0)
 - start_value_gql = present:V(agriculture_chp_wood_pellets, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_combined_cycle_network_gas_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_combined_cycle_network_gas_electricity.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_combined_cycle_ht_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_combined_cycle_mt_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_combined_cycle_ht_network_gas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_combined_cycle_ht_network_gas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_combined_cycle_ht_network_gas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_combined_cycle_network_gas_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_combined_cycle_network_gas_heat.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_combined_cycle_ht_network_gas), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_combined_cycle_mt_network_gas), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_combined_cycle_ht_network_gas, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_combined_cycle_ht_network_gas, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_combined_cycle_ht_network_gas, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_biogas_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_biogas_electricity.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_ht_biogas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_mt_biogas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_local_engine_ht_biogas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_local_engine_ht_biogas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_local_engine_ht_biogas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_biogas_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_biogas_heat.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_ht_biogas), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_mt_biogas), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_local_engine_ht_biogas, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_local_engine_ht_biogas, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_local_engine_ht_biogas, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_network_gas_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_network_gas_electricity.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_ht_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_mt_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_local_engine_ht_network_gas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_local_engine_ht_network_gas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_local_engine_ht_network_gas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_network_gas_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_local_engine_network_gas_heat.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_ht_network_gas), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_engine_mt_network_gas), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_local_engine_ht_network_gas, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_local_engine_ht_network_gas, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_local_engine_ht_network_gas, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_local_wood_pellets_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_local_wood_pellets_electricity.ad
@@ -1,11 +1,13 @@
-- query = 
+# Priority set to 3 to set prior to input for share in ccs, input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_ht_wood_pellets_must_run), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_ht_wood_pellets_dispatchable), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_mt_wood_pellets_must_run), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_mt_wood_pellets_dispatchable), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 3
 - max_value_gql = present:(V(energy_chp_local_ht_wood_pellets_must_run, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_local_ht_wood_pellets_must_run, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_local_ht_wood_pellets_must_run, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_local_wood_pellets_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_local_wood_pellets_heat.ad
@@ -1,11 +1,13 @@
-- query = 
+# Priority set to 3 to set prior to input for share in ccs, input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_ht_wood_pellets_must_run), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_ht_wood_pellets_dispatchable), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_mt_wood_pellets_must_run), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_local_mt_wood_pellets_dispatchable), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 3
 - max_value_gql = present:(V(energy_chp_local_ht_wood_pellets_must_run, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_local_ht_wood_pellets_must_run, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_local_ht_wood_pellets_must_run, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_electricity.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 3 to set prior to input for share in ccs, input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ht_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_mt_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 3
 - max_value_gql = present:(V(energy_chp_supercritical_ht_waste_mix, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_supercritical_ht_waste_mix, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_supercritical_ht_waste_mix, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_heat.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 3 to set prior to input for share in ccs, input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ht_waste_mix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_mt_waste_mix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 3
 - max_value_gql = present:(V(energy_chp_supercritical_ht_waste_mix, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_supercritical_ht_waste_mix, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_supercritical_ht_waste_mix, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_coal_electricity.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_ht_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_mt_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_ultra_supercritical_ht_coal, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_ultra_supercritical_ht_coal, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_ht_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_coal_heat.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_ht_coal), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_mt_coal), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_ultra_supercritical_ht_coal, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_ultra_supercritical_ht_coal, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_ht_coal, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_cofiring_coal_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_cofiring_coal_electricity.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_cofiring_ht_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_cofiring_mt_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_ultra_supercritical_cofiring_ht_coal, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_ultra_supercritical_cofiring_ht_coal, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_cofiring_ht_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_cofiring_coal_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_ultra_supercritical_cofiring_coal_heat.ad
@@ -1,9 +1,11 @@
-- query = 
+# Priority set to 2 to set prior to input for share in ht/mt and input for capacity
+
+- query =
     EACH(
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_cofiring_ht_coal), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0)),
         UPDATE(OUTPUT_SLOTS(V(energy_chp_ultra_supercritical_cofiring_mt_coal), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
     )
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_chp_ultra_supercritical_cofiring_ht_coal, steam_hot_water_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_chp_ultra_supercritical_cofiring_ht_coal, steam_hot_water_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_chp_ultra_supercritical_cofiring_ht_coal, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_combined_cycle_coal.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_combined_cycle_coal.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to input for share in ccs and input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_combined_cycle_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_power_combined_cycle_coal, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_combined_cycle_coal, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_combined_cycle_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_combined_cycle_hydrogen.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_combined_cycle_hydrogen.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_combined_cycle_hydrogen), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_combined_cycle_hydrogen, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_combined_cycle_hydrogen, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_combined_cycle_hydrogen, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_combined_cycle_network_gas.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_combined_cycle_network_gas.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to input for share in ccs and input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_combined_cycle_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_power_combined_cycle_network_gas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_combined_cycle_network_gas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_combined_cycle_network_gas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_engine_diesel.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_engine_diesel.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_engine_diesel), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_engine_diesel, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_engine_diesel, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_engine_diesel, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_engine_network_gas.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_engine_network_gas.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_engine_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_engine_network_gas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_engine_network_gas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_engine_network_gas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_nuclear_gen2_uranium_oxide.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_nuclear_gen2_uranium_oxide), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_nuclear_gen2_uranium_oxide, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_nuclear_gen3_uranium_oxide.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_nuclear_gen3_uranium_oxide), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_nuclear_gen3_uranium_oxide, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_nuclear_small_modular_reactor_uranium_oxide.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_nuclear_small_modular_reactor_uranium_oxide.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_nuclear_small_modular_reactor_uranium_oxide), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_nuclear_small_modular_reactor_uranium_oxide, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_nuclear_small_modular_reactor_uranium_oxide, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_nuclear_small_modular_reactor_uranium_oxide, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_supercritical_coal.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_supercritical_coal.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_supercritical_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_supercritical_coal, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_supercritical_coal, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_supercritical_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_supercritical_waste_mix.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_supercritical_waste_mix.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to input for share in ccs and input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_supercritical_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_power_supercritical_waste_mix, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_supercritical_waste_mix, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_supercritical_waste_mix, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_turbine_hydrogen.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_turbine_hydrogen.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_turbine_hydrogen), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_turbine_hydrogen, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_turbine_hydrogen, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_turbine_hydrogen, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_turbine_network_gas.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_turbine_network_gas.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_turbine_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_turbine_network_gas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_turbine_network_gas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_turbine_network_gas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_coal.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_coal.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to input for share in ccs and input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_ultra_supercritical_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value_gql = present:(V(energy_power_ultra_supercritical_coal, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_ultra_supercritical_coal, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_cofiring_coal.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_ultra_supercritical_cofiring_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_ultra_supercritical_cofiring_coal, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_ultra_supercritical_cofiring_coal, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_cofiring_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_crude_oil.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_crude_oil.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_ultra_supercritical_crude_oil), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_ultra_supercritical_crude_oil, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_ultra_supercritical_crude_oil, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_crude_oil, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_network_gas.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_power_ultra_supercritical_network_gas.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_power_ultra_supercritical_network_gas), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value_gql = present:(V(energy_power_ultra_supercritical_network_gas, electricity_output_conversion) * 100.0) + 10.0
 - min_value_gql = present:(V(energy_power_ultra_supercritical_network_gas, electricity_output_conversion) * 100.0) - 10.0
 - start_value_gql = present:V(energy_power_ultra_supercritical_network_gas, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_combined_cycle_gas_power_fuelmix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_combined_cycle_gas_power_fuelmix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_engine_gas_power_fuelmix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_engine_gas_power_fuelmix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_turbine_gas_power_fuelmix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_turbine_gas_power_fuelmix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -11,3 +11,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -1,10 +1,12 @@
-- query = 
+# Priority set to 1 to set efficiency prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
         V(industry_chp_turbine_hydrogen), electricity
       ), conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_turbine_hydrogen, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -1,10 +1,12 @@
-- query = 
+# Priority set to 1 to set efficiency prior to input for capacity
+
+- query =
     UPDATE(
       OUTPUT_SLOTS(
         V(industry_chp_turbine_hydrogen), steam_hot_water
       ), conversion, DIVIDE(USER_INPUT(), 100.0)
     )
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_turbine_hydrogen, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -11,3 +11,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_turbine_hydrogen_heat

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_ultra_supercritical_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_ultra_supercritical_coal, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_ultra_supercritical_coal), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_ultra_supercritical_coal, steam_hot_water_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_wood_pellets_electricity

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_wood_pellets), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_wood_pellets, electricity_output_conversion) * 100.0

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
@@ -6,3 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
+- disabled_by = external_coupling_efficiency_industry_chp_wood_pellets_heat

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
@@ -1,5 +1,7 @@
+# Priority set to 1 to set efficiency prior to input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(industry_chp_wood_pellets), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 1
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_chp_wood_pellets, steam_hot_water_output_conversion) * 100.0

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -1,0 +1,81 @@
+# This input splits the industry CHP in a price-based electricity component and a must-run heat component
+# This input sets the:
+# 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
+# 2. typical input capacity of CHP and heater node based on corrected efficiency
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+#    (based on updated typical input capacity)
+# 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
+
+- query =
+    chp_electricity_efficiency = V(industry_chp_combined_cycle_gas_power_fuelmix, electricity_output_conversion);
+    chp_heat_efficiency = V(industry_chp_combined_cycle_gas_power_fuelmix, steam_hot_water_output_conversion);
+    chp_useful_output = chp_electricity_efficiency + chp_heat_efficiency;
+    chp_input_capacity = V(industry_chp_combined_cycle_gas_power_fuelmix, typical_input_capacity);
+
+    electricity_component_input_capacity = chp_input_capacity * chp_electricity_efficiency / chp_useful_output;
+    electricity_component_total_output_capacity = USER_INPUT();
+    electricity_component_demand_per_mw = V(industry_chp_combined_cycle_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    electricity_component_efficiency_electricity = chp_useful_output;
+    electricity_component_efficiency_heat = 0.0;
+    
+    heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
+    heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
+    heat_component_demand_per_mw = V(industry_heat_combined_cycle_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    heat_component_efficiency_heat = chp_useful_output;
+
+    EACH(
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_combined_cycle_gas_power_fuelmix), steam_hot_water),
+        conversion,
+        electricity_component_efficiency_heat
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_combined_cycle_gas_power_fuelmix), electricity),
+        conversion,
+        electricity_component_efficiency_electricity
+      ),
+      UPDATE(
+        V(industry_chp_combined_cycle_gas_power_fuelmix),
+        typical_input_capacity,
+        electricity_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_chp_combined_cycle_gas_power_fuelmix),
+        number_of_units,
+        electricity_component_total_output_capacity / V(industry_chp_combined_cycle_gas_power_fuelmix, electricity_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_chp_combined_cycle_gas_power_fuelmix),
+        preset_demand,
+        electricity_component_total_output_capacity * electricity_component_demand_per_mw
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_heat_combined_cycle_gas_power_fuelmix), steam_hot_water),
+        conversion,
+        heat_component_efficiency_heat
+      ),
+      UPDATE(
+        V(industry_heat_combined_cycle_gas_power_fuelmix),
+        typical_input_capacity,
+        heat_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_heat_combined_cycle_gas_power_fuelmix),
+        number_of_units,
+        heat_component_total_output_capacity / V(industry_heat_combined_cycle_gas_power_fuelmix, heat_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_heat_combined_cycle_gas_power_fuelmix),
+        preset_demand,
+        heat_component_total_output_capacity * heat_component_demand_per_mw
+      )
+    )
+
+- priority = 0
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_combined_cycle_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
+- min_value = 0.0
+- start_value_gql = present:PRODUCT(V(industry_chp_combined_cycle_gas_power_fuelmix,number_of_units),V(industry_chp_combined_cycle_gas_power_fuelmix,electricity_output_capacity))
+- step_value = 1.0
+- unit = MW
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -1,0 +1,81 @@
+# This input splits the industry CHP in a price-based electricity component and a must-run heat component
+# This input sets the:
+# 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
+# 2. typical input capacity of CHP and heater node based on corrected efficiency
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+#    (based on updated typical input capacity)
+# 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
+
+- query =
+    chp_electricity_efficiency = V(industry_chp_engine_gas_power_fuelmix, electricity_output_conversion);
+    chp_heat_efficiency = V(industry_chp_engine_gas_power_fuelmix, steam_hot_water_output_conversion);
+    chp_useful_output = chp_electricity_efficiency + chp_heat_efficiency;
+    chp_input_capacity = V(industry_chp_engine_gas_power_fuelmix, typical_input_capacity);
+
+    electricity_component_input_capacity = chp_input_capacity * chp_electricity_efficiency / chp_useful_output;
+    electricity_component_total_output_capacity = USER_INPUT();
+    electricity_component_demand_per_mw = V(industry_chp_engine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    electricity_component_efficiency_electricity = chp_useful_output;
+    electricity_component_efficiency_heat = 0.0;
+    
+    heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
+    heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
+    heat_component_demand_per_mw = V(industry_heat_engine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    heat_component_efficiency_heat = chp_useful_output;
+
+    EACH(
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_engine_gas_power_fuelmix), steam_hot_water),
+        conversion,
+        electricity_component_efficiency_heat
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_engine_gas_power_fuelmix), electricity),
+        conversion,
+        electricity_component_efficiency_electricity
+      ),
+      UPDATE(
+        V(industry_chp_engine_gas_power_fuelmix),
+        typical_input_capacity,
+        electricity_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_chp_engine_gas_power_fuelmix),
+        number_of_units,
+        electricity_component_total_output_capacity / V(industry_chp_engine_gas_power_fuelmix, electricity_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_chp_engine_gas_power_fuelmix),
+        preset_demand,
+        electricity_component_total_output_capacity * electricity_component_demand_per_mw
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_heat_engine_gas_power_fuelmix), steam_hot_water),
+        conversion,
+        heat_component_efficiency_heat
+      ),
+      UPDATE(
+        V(industry_heat_engine_gas_power_fuelmix),
+        typical_input_capacity,
+        heat_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_heat_engine_gas_power_fuelmix),
+        number_of_units,
+        heat_component_total_output_capacity / V(industry_heat_engine_gas_power_fuelmix, heat_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_heat_engine_gas_power_fuelmix),
+        preset_demand,
+        heat_component_total_output_capacity * heat_component_demand_per_mw
+      )
+    )
+
+- priority = 0
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_engine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
+- min_value = 0.0
+- start_value_gql = present:PRODUCT(V(industry_chp_engine_gas_power_fuelmix,number_of_units),V(industry_chp_engine_gas_power_fuelmix,electricity_output_capacity))
+- step_value = 1.0
+- unit = MW
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -1,0 +1,81 @@
+# This input splits the industry CHP in a price-based electricity component and a must-run heat component
+# This input sets the:
+# 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
+# 2. typical input capacity of CHP and heater node based on corrected efficiency
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+#    (based on updated typical input capacity)
+# 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
+
+- query =
+    chp_electricity_efficiency = V(industry_chp_turbine_gas_power_fuelmix, electricity_output_conversion);
+    chp_heat_efficiency = V(industry_chp_turbine_gas_power_fuelmix, steam_hot_water_output_conversion);
+    chp_useful_output = chp_electricity_efficiency + chp_heat_efficiency;
+    chp_input_capacity = V(industry_chp_turbine_gas_power_fuelmix, typical_input_capacity);
+
+    electricity_component_input_capacity = chp_input_capacity * chp_electricity_efficiency / chp_useful_output;
+    electricity_component_total_output_capacity = USER_INPUT();
+    electricity_component_demand_per_mw = V(industry_chp_turbine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    electricity_component_efficiency_electricity = chp_useful_output;
+    electricity_component_efficiency_heat = 0.0;
+    
+    heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
+    heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
+    heat_component_demand_per_mw = V(industry_heat_turbine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    heat_component_efficiency_heat = chp_useful_output;
+
+    EACH(
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_turbine_gas_power_fuelmix), steam_hot_water),
+        conversion,
+        electricity_component_efficiency_heat
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_turbine_gas_power_fuelmix), electricity),
+        conversion,
+        electricity_component_efficiency_electricity
+      ),
+      UPDATE(
+        V(industry_chp_turbine_gas_power_fuelmix),
+        typical_input_capacity,
+        electricity_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_chp_turbine_gas_power_fuelmix),
+        number_of_units,
+        electricity_component_total_output_capacity / V(industry_chp_turbine_gas_power_fuelmix, electricity_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_chp_turbine_gas_power_fuelmix),
+        preset_demand,
+        electricity_component_total_output_capacity * electricity_component_demand_per_mw
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_heat_turbine_gas_power_fuelmix), steam_hot_water),
+        conversion,
+        heat_component_efficiency_heat
+      ),
+      UPDATE(
+        V(industry_heat_turbine_gas_power_fuelmix),
+        typical_input_capacity,
+        heat_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_heat_turbine_gas_power_fuelmix),
+        number_of_units,
+        heat_component_total_output_capacity / V(industry_heat_turbine_gas_power_fuelmix, heat_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_heat_turbine_gas_power_fuelmix),
+        preset_demand,
+        heat_component_total_output_capacity * heat_component_demand_per_mw
+      )
+    )
+
+- priority = 0
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_turbine_gas_power_fuelmix,full_load_hours)), MJ_PER_MWH)
+- min_value = 0.0
+- start_value_gql = present:PRODUCT(V(industry_chp_turbine_gas_power_fuelmix,number_of_units),V(industry_chp_turbine_gas_power_fuelmix,electricity_output_capacity))
+- step_value = 1.0
+- unit = MW
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_hydrogen.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_hydrogen.ad
@@ -1,0 +1,81 @@
+# This input splits the industry CHP in a price-based electricity component and a must-run heat component
+# This input sets the:
+# 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
+# 2. typical input capacity of CHP and heater node based on corrected efficiency
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+#    (based on updated typical input capacity)
+# 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
+
+- query =
+    chp_electricity_efficiency = V(industry_chp_turbine_hydrogen, electricity_output_conversion);
+    chp_heat_efficiency = V(industry_chp_turbine_hydrogen, steam_hot_water_output_conversion);
+    chp_useful_output = chp_electricity_efficiency + chp_heat_efficiency;
+    chp_input_capacity = V(industry_chp_turbine_hydrogen, typical_input_capacity);
+
+    electricity_component_input_capacity = chp_input_capacity * chp_electricity_efficiency / chp_useful_output;
+    electricity_component_total_output_capacity = USER_INPUT();
+    electricity_component_demand_per_mw = V(industry_chp_turbine_hydrogen, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    electricity_component_efficiency_electricity = chp_useful_output;
+    electricity_component_efficiency_heat = 0.0;
+    
+    heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
+    heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
+    heat_component_demand_per_mw = V(industry_heat_turbine_hydrogen, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    heat_component_efficiency_heat = chp_useful_output;
+
+    EACH(
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_turbine_hydrogen), steam_hot_water),
+        conversion,
+        electricity_component_efficiency_heat
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_turbine_hydrogen), electricity),
+        conversion,
+        electricity_component_efficiency_electricity
+      ),
+      UPDATE(
+        V(industry_chp_turbine_hydrogen),
+        typical_input_capacity,
+        electricity_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_chp_turbine_hydrogen),
+        number_of_units,
+        electricity_component_total_output_capacity / V(industry_chp_turbine_hydrogen, electricity_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_chp_turbine_hydrogen),
+        preset_demand,
+        electricity_component_total_output_capacity * electricity_component_demand_per_mw
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_heat_turbine_hydrogen), steam_hot_water),
+        conversion,
+        heat_component_efficiency_heat
+      ),
+      UPDATE(
+        V(industry_heat_turbine_hydrogen),
+        typical_input_capacity,
+        heat_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_heat_turbine_hydrogen),
+        number_of_units,
+        heat_component_total_output_capacity / V(industry_heat_turbine_hydrogen, heat_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_heat_turbine_hydrogen),
+        preset_demand,
+        heat_component_total_output_capacity * heat_component_demand_per_mw
+      )
+    )
+
+- priority = 0
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_turbine_hydrogen,full_load_hours)), MJ_PER_MWH)
+- min_value = 0.0
+- start_value_gql = present:PRODUCT(V(industry_chp_turbine_hydrogen,number_of_units),V(industry_chp_turbine_hydrogen,electricity_output_capacity))
+- step_value = 1.0
+- unit = MW
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -1,0 +1,81 @@
+# This input splits the industry CHP in a price-based electricity component and a must-run heat component
+# This input sets the:
+# 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
+# 2. typical input capacity of CHP and heater node based on corrected efficiency
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+#    (based on updated typical input capacity)
+# 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
+
+- query =
+    chp_electricity_efficiency = V(industry_chp_ultra_supercritical_coal, electricity_output_conversion);
+    chp_heat_efficiency = V(industry_chp_ultra_supercritical_coal, steam_hot_water_output_conversion);
+    chp_useful_output = chp_electricity_efficiency + chp_heat_efficiency;
+    chp_input_capacity = V(industry_chp_ultra_supercritical_coal, typical_input_capacity);
+
+    electricity_component_input_capacity = chp_input_capacity * chp_electricity_efficiency / chp_useful_output;
+    electricity_component_total_output_capacity = USER_INPUT();
+    electricity_component_demand_per_mw = V(industry_chp_ultra_supercritical_coal, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    electricity_component_efficiency_electricity = chp_useful_output;
+    electricity_component_efficiency_heat = 0.0;
+    
+    heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
+    heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
+    heat_component_demand_per_mw = V(industry_heat_ultra_supercritical_coal, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    heat_component_efficiency_heat = chp_useful_output;
+
+    EACH(
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_ultra_supercritical_coal), steam_hot_water),
+        conversion,
+        electricity_component_efficiency_heat
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_ultra_supercritical_coal), electricity),
+        conversion,
+        electricity_component_efficiency_electricity
+      ),
+      UPDATE(
+        V(industry_chp_ultra_supercritical_coal),
+        typical_input_capacity,
+        electricity_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_chp_ultra_supercritical_coal),
+        number_of_units,
+        electricity_component_total_output_capacity / V(industry_chp_ultra_supercritical_coal, electricity_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_chp_ultra_supercritical_coal),
+        preset_demand,
+        electricity_component_total_output_capacity * electricity_component_demand_per_mw
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_heat_ultra_supercritical_coal), steam_hot_water),
+        conversion,
+        heat_component_efficiency_heat
+      ),
+      UPDATE(
+        V(industry_heat_ultra_supercritical_coal),
+        typical_input_capacity,
+        heat_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_heat_ultra_supercritical_coal),
+        number_of_units,
+        heat_component_total_output_capacity / V(industry_heat_ultra_supercritical_coal, heat_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_heat_ultra_supercritical_coal),
+        preset_demand,
+        heat_component_total_output_capacity * heat_component_demand_per_mw
+      )
+    )
+
+- priority = 0
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_ultra_supercritical_coal,full_load_hours)), MJ_PER_MWH)
+- min_value = 0.0
+- start_value_gql = present:PRODUCT(V(industry_chp_ultra_supercritical_coal,number_of_units),V(industry_chp_ultra_supercritical_coal,electricity_output_capacity))
+- step_value = 1.0
+- unit = MW
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_wood_pellets.ad
@@ -1,0 +1,81 @@
+# This input splits the industry CHP in a price-based electricity component and a must-run heat component
+# This input sets the:
+# 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
+# 2. typical input capacity of CHP and heater node based on corrected efficiency
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+#    (based on updated typical input capacity)
+# 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
+
+- query =
+    chp_electricity_efficiency = V(industry_chp_wood_pellets, electricity_output_conversion);
+    chp_heat_efficiency = V(industry_chp_wood_pellets, steam_hot_water_output_conversion);
+    chp_useful_output = chp_electricity_efficiency + chp_heat_efficiency;
+    chp_input_capacity = V(industry_chp_wood_pellets, typical_input_capacity);
+
+    electricity_component_input_capacity = chp_input_capacity * chp_electricity_efficiency / chp_useful_output;
+    electricity_component_total_output_capacity = USER_INPUT();
+    electricity_component_demand_per_mw = V(industry_chp_wood_pellets, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    electricity_component_efficiency_electricity = chp_useful_output;
+    electricity_component_efficiency_heat = 0.0;
+    
+    heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
+    heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
+    heat_component_demand_per_mw = V(industry_heat_wood_pellets, full_load_hours) * MJ_PER_MWH / chp_useful_output;
+    heat_component_efficiency_heat = chp_useful_output;
+
+    EACH(
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_wood_pellets), steam_hot_water),
+        conversion,
+        electricity_component_efficiency_heat
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_chp_wood_pellets), electricity),
+        conversion,
+        electricity_component_efficiency_electricity
+      ),
+      UPDATE(
+        V(industry_chp_wood_pellets),
+        typical_input_capacity,
+        electricity_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_chp_wood_pellets),
+        number_of_units,
+        electricity_component_total_output_capacity / V(industry_chp_wood_pellets, electricity_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_chp_wood_pellets),
+        preset_demand,
+        electricity_component_total_output_capacity * electricity_component_demand_per_mw
+      ),
+      UPDATE(
+        OUTPUT_SLOTS(V(industry_heat_wood_pellets), steam_hot_water),
+        conversion,
+        heat_component_efficiency_heat
+      ),
+      UPDATE(
+        V(industry_heat_wood_pellets),
+        typical_input_capacity,
+        heat_component_input_capacity
+      ),
+      UPDATE(
+        V(industry_heat_wood_pellets),
+        number_of_units,
+        heat_component_total_output_capacity / V(industry_heat_wood_pellets, heat_output_capacity)
+      ),  
+      UPDATE(
+        L(industry_heat_wood_pellets),
+        preset_demand,
+        heat_component_total_output_capacity * heat_component_demand_per_mw
+      )
+    )
+
+- priority = 0
+- max_value_gql = present:2*DIVIDE(DIVIDE(Q(heat_production_industry) * BILLIONS, V(industry_chp_wood_pellets,full_load_hours)), MJ_PER_MWH)
+- min_value = 0.0
+- start_value_gql = present:PRODUCT(V(industry_chp_wood_pellets,number_of_units),V(industry_chp_wood_pellets,electricity_output_capacity))
+- step_value = 1.0
+- unit = MW
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_combined_cycle_gas_power_fuelmix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix, electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_combined_cycle_gas_power_fuelmix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_combined_cycle_gas_power_fuelmix, steam_hot_water_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_engine_gas_power_fuelmix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix, electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_engine_gas_power_fuelmix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_engine_gas_power_fuelmix, steam_hot_water_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_turbine_gas_power_fuelmix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix, electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_turbine_gas_power_fuelmix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_turbine_gas_power_fuelmix, steam_hot_water_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_turbine_hydrogen
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_turbine_hydrogen), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_turbine_hydrogen, electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_turbine_hydrogen
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_turbine_hydrogen), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_turbine_hydrogen, steam_hot_water_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_ultra_supercritical_coal
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_ultra_supercritical_coal), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_ultra_supercritical_coal, electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_ultra_supercritical_coal
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_ultra_supercritical_coal), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_ultra_supercritical_coal, steam_hot_water_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_electricity.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_wood_pellets
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_wood_pellets), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_wood_pellets, electricity_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_heat.ad
@@ -1,0 +1,12 @@
+# Priority set to 1 to set efficiency before setting capacity
+# with external_coupling_capacity_of_industry_chp_wood_pellets
+
+- query = UPDATE(OUTPUT_SLOTS(V(industry_chp_wood_pellets), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
+- priority = 1
+- max_value = 90.0
+- min_value = 10.0
+- start_value_gql = present:V(industry_chp_wood_pellets, steam_hot_water_output_conversion) * 100.0
+- step_value = 1.0
+- unit = %
+- update_period = future
+- coupling_groups = [ctm]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to external coupling input for share in ccs and external coupling input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ccs_ht_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_supercritical_ccs_ht_waste_mix, electricity_output_conversion) * 100.0

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_heat_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_heat_efficiency.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to external coupling input for share in ccs and external coupling input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ccs_ht_waste_mix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_supercritical_ccs_ht_waste_mix, steam_hot_water_output_conversion) * 100.0

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to external coupling input for share in ccs and external coupling input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ht_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_supercritical_ht_waste_mix, electricity_output_conversion) * 100.0

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency.ad
@@ -1,5 +1,7 @@
+# Priority set to 2 to set prior to external coupling input for share in ccs and external coupling input for capacity
+
 - query = UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ht_waste_mix), steam_hot_water), conversion, DIVIDE(USER_INPUT(), 100.0))
-- priority = 0
+- priority = 2
 - max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(energy_chp_supercritical_ht_waste_mix, steam_hot_water_output_conversion) * 100.0

--- a/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_ultra_supercritical_cofiring_ht_coal.ad
+++ b/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_ultra_supercritical_cofiring_ht_coal.ad
@@ -1,14 +1,14 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_ultra_supercritical_ht_coal),
+            V(energy_chp_ultra_supercritical_cofiring_ht_coal),
             number_of_units,
-            DIVIDE(USER_INPUT(),100.0) * INPUT_VALUE(capacity_of_energy_chp_ultra_supercritical_coal) / V(energy_chp_ultra_supercritical_ht_coal, electricity_output_capacity)
+            DIVIDE(USER_INPUT(),100.0) * INPUT_VALUE(capacity_of_energy_chp_ultra_supercritical_coal) / V(energy_chp_ultra_supercritical_cofiring_ht_coal, electricity_output_capacity)
         ),
         UPDATE(
-            L(energy_chp_ultra_supercritical_ht_coal),
+            L(energy_chp_ultra_supercritical_cofiring_ht_coal),
             preset_demand_by_electricity_production,
-            V(energy_chp_ultra_supercritical_ht_coal, production_based_on_number_of_units)
+            V(energy_chp_ultra_supercritical_cofiring_ht_coal, production_based_on_number_of_units)
         )
     )
 
@@ -16,14 +16,14 @@
 - priority = 1
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:PRODUCT(
       (1 -
         DIVIDE(
-          V(energy_chp_ultra_supercritical_mt_coal,"number_of_units * electricity_output_capacity"),
+          V(energy_chp_ultra_supercritical_cofiring_mt_coal,"number_of_units * electricity_output_capacity"),
           SUM(
-            V(energy_chp_ultra_supercritical_mt_coal,"number_of_units * electricity_output_capacity"),
-            V(energy_chp_ultra_supercritical_ht_coal,"number_of_units * electricity_output_capacity")
+            V(energy_chp_ultra_supercritical_cofiring_mt_coal,"number_of_units * electricity_output_capacity"),
+            V(energy_chp_ultra_supercritical_cofiring_ht_coal,"number_of_units * electricity_output_capacity")
           )
         )
       ),

--- a/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_ultra_supercritical_cofiring_mt_coal.ad
+++ b/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_ultra_supercritical_cofiring_mt_coal.ad
@@ -1,14 +1,14 @@
 - query =
     EACH(
         UPDATE(
-            V(energy_chp_ultra_supercritical_mt_coal),
+            V(energy_chp_ultra_supercritical_cofiring_mt_coal),
             number_of_units,
-            DIVIDE(USER_INPUT(),100.0) * INPUT_VALUE(capacity_of_energy_chp_ultra_supercritical_coal) / V(energy_chp_ultra_supercritical_mt_coal, electricity_output_capacity)
+            DIVIDE(USER_INPUT(),100.0) * INPUT_VALUE(capacity_of_energy_chp_ultra_supercritical_coal) / V(energy_chp_ultra_supercritical_cofiring_mt_coal, electricity_output_capacity)
         ),
         UPDATE(
-            L(energy_chp_ultra_supercritical_mt_coal),
+            L(energy_chp_ultra_supercritical_cofiring_mt_coal),
             preset_demand_by_electricity_production,
-            V(energy_chp_ultra_supercritical_mt_coal, production_based_on_number_of_units)
+            V(energy_chp_ultra_supercritical_cofiring_mt_coal, production_based_on_number_of_units)
         )
     )
 
@@ -16,13 +16,13 @@
 - priority = 1
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:PRODUCT(
       DIVIDE(
-        V(energy_chp_ultra_supercritical_mt_coal,"number_of_units * electricity_output_capacity"),
+        V(energy_chp_ultra_supercritical_cofiring_mt_coal,"number_of_units * electricity_output_capacity"),
         SUM(
-          V(energy_chp_ultra_supercritical_ht_coal,"number_of_units * electricity_output_capacity"),
-          V(energy_chp_ultra_supercritical_mt_coal,"number_of_units * electricity_output_capacity")
+          V(energy_chp_ultra_supercritical_cofiring_ht_coal,"number_of_units * electricity_output_capacity"),
+          V(energy_chp_ultra_supercritical_cofiring_mt_coal,"number_of_units * electricity_output_capacity")
         )
       ),
       100.0

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -18,3 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
+- disabled_by = external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = #
 - update_period = future
+- disabled_by = external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -18,3 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
+- disabled_by = external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_hydrogen.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_hydrogen.ad
@@ -18,3 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
+- disabled_by = external_coupling_capacity_of_industry_chp_turbine_hydrogen

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -18,3 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
+- disabled_by = external_coupling_capacity_of_industry_chp_ultra_supercritical_coal

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
@@ -18,3 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
+- disabled_by = external_coupling_capacity_of_industry_chp_wood_pellets


### PR DESCRIPTION
This PR implements the heat burner solution as part of deliverable 3b from the CTM-ETM coupling project. This PR comes with the following features:

- Heat nodes are added for all six industry CHP node
- External coupling inputs are added to set electricity and heat efficiency of the industry CHP
- External coupling inputs are added to set industry CHP electricity output capacity, which will 'activate' the related heat nodes for the heat provision part
- Queries are updated to rectify fallout