### PR TITLE
CTM-ETM coupling: external input groups

### DIFF
--- a/inputs/costs_efficiencies/costs_industry_residual_heat.ad
+++ b/inputs/costs_efficiencies/costs_industry_residual_heat.ad
@@ -23,4 +23,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_energy_heat_production_ht_residual_heat_investment_costs
+- disabled_by_couplings = [ctm, residual_heat]

--- a/inputs/costs_efficiencies/costs_industry_residual_heat.ad
+++ b/inputs/costs_efficiencies/costs_industry_residual_heat.ad
@@ -23,4 +23,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, residual_heat]
+- disabled_by_couplings = [external_model_industry, residual_heat]

--- a/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_electricity.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_electricity.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_heat.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_energy_chp_supercritical_waste_mix_heat.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -13,4 +13,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -13,4 +13,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -13,4 +13,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_turbine_hydrogen_heat
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -13,4 +13,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_wood_pellets_electricity
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_electricity.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_efficiency_industry_chp_wood_pellets_heat
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/costs_efficiencies/efficiency_industry_chp_wood_pellets_heat.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/demand/agriculture/capacity_of_agriculture_flexibility_p2h_electricity.ad
+++ b/inputs/demand/agriculture/capacity_of_agriculture_flexibility_p2h_electricity.ad
@@ -21,4 +21,3 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-#- disabled_by = external_coupling_agriculture_p2h_capacity

--- a/inputs/demand/industry/capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_p2h_capacity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_p2h_capacity
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_other_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_p2h_capacity
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_p2h_capacity
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_food_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/demand/industry/capacity_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_p2h_capacity
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_aggregated_other_industry_coal_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_coal_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_coal_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_coal_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_coal_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_coal_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_coal_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_coal_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_coal_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_coal_share_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_cokes_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_cokes_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_cokes_share_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_crude_oil_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_crude_oil_share_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_crude_oil_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_electricity_share.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_electricity_share.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_electricity_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_electricity_share.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_electricity_share.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_hydrogen_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_hydrogen_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_hydrogen_share_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_network_gas_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_network_gas_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_network_gas_share_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_useable_heat_share.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_useable_heat_share.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_useable_heat_share.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_useable_heat_share.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_useable_heat_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_wood_pellets_share_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_non_specified_industry_wood_pellets_share_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_non_energetic.ad
+++ b/inputs/demand/industry/industry_aggregated_other_industry_wood_pellets_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_aluminium_carbothermalreduction_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_carbothermalreduction_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_aluminium_carbothermalreduction_electricity_share
+- disabled_by_couplings = [ctm, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_carbothermalreduction_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_carbothermalreduction_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_aluminium]
+- disabled_by_couplings = [external_model_industry, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_electrolysis_bat_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_electrolysis_bat_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_aluminium_electrolysis_bat_electricity_share
+- disabled_by_couplings = [ctm, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_electrolysis_bat_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_electrolysis_bat_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_aluminium]
+- disabled_by_couplings = [external_model_industry, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_electrolysis_current_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_electrolysis_current_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_aluminium_electrolysis_current_electricity_share
+- disabled_by_couplings = [ctm, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_electrolysis_current_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_electrolysis_current_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_aluminium]
+- disabled_by_couplings = [external_model_industry, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_production.ad
+++ b/inputs/demand/industry/industry_aluminium_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_metal_aluminium_production
+- disabled_by_couplings = [ctm, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_production.ad
+++ b/inputs/demand/industry/industry_aluminium_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_metal_aluminium]
+- disabled_by_couplings = [external_model_industry, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_smeltoven_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_smeltoven_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_aluminium_smeltoven_electricity_share
+- disabled_by_couplings = [ctm, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_aluminium_smeltoven_electricity_share.ad
+++ b/inputs/demand/industry/industry_aluminium_smeltoven_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_aluminium]
+- disabled_by_couplings = [external_model_industry, industry_metal_aluminium]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_central_ammonia_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_central_ammonia_share.ad
@@ -19,4 +19,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_central_ammonia_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_central_ammonia_share.ad
@@ -19,4 +19,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_hydrogen_network_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_hydrogen_network_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_hydrogen_network_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_hydrogen_network_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_central_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_central_hydrogen_share.ad
@@ -32,4 +32,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_central_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_central_hydrogen_share.ad
@@ -8,13 +8,13 @@
 - query =
     x = DIVIDE(INPUT_VALUE(industry_chemicals_fertilizers_local_ammonia_local_hydrogen_share),100);
     y = DIVIDE(USER_INPUT(),100);
-    
+
     beta = IF(
       INPUT_VALUE(industry_chemicals_fertilizers_central_ammonia_share) == 100.0,
       -> { 0.0 },
       -> { DIVIDE(y, x + y) }
     );
-    
+
     UPDATE(
       EDGE(industry_chemicals_fertilizers_locally_available_hydrogen, industry_final_demand_for_chemical_fertilizers_hydrogen_non_energetic),
       share,
@@ -24,7 +24,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:(
       V(industry_chemicals_fertilizers_haber_bosch_process_hydrogen,share_of_industry_chemicals_fertilizers_locally_available_ammonia) *
       V(industry_final_demand_for_chemical_fertilizers_hydrogen_non_energetic,share_of_industry_chemicals_fertilizers_locally_available_hydrogen) * 100
@@ -32,4 +32,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_local_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_local_hydrogen_share.ad
@@ -8,13 +8,13 @@
 - query =
     x = DIVIDE(USER_INPUT(),100);
     y = DIVIDE(INPUT_VALUE(industry_chemicals_fertilizers_local_ammonia_central_hydrogen_share),100);
-    
+
     alpha = IF(
       INPUT_VALUE(industry_chemicals_fertilizers_central_ammonia_share) == 100.0,
       -> { 1.0 },
       -> { DIVIDE(x, x + y) }
     );
-    
+
     UPDATE(
       EDGE(industry_chemicals_fertilizers_locally_available_hydrogen, industry_chemicals_fertilizers_steam_methane_reformer_hydrogen),
       share,
@@ -24,7 +24,7 @@
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:(
       V(industry_chemicals_fertilizers_haber_bosch_process_hydrogen,share_of_industry_chemicals_fertilizers_locally_available_ammonia) *
       V(industry_chemicals_fertilizers_steam_methane_reformer_hydrogen,share_of_industry_chemicals_fertilizers_locally_available_hydrogen) * 100
@@ -32,4 +32,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_local_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_local_ammonia_local_hydrogen_share.ad
@@ -32,4 +32,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_steam_methane_reformer_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_steam_methane_reformer_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_fertilizers_steam_methane_reformer_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_fertilizers_steam_methane_reformer_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_chemicals_other_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_crude_oil_share.ad
@@ -12,5 +12,5 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]
 

--- a/inputs/demand/industry/industry_chemicals_other_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_crude_oil_share.ad
@@ -12,5 +12,5 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]
 

--- a/inputs/demand/industry/industry_chemicals_other_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_coal_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_coal_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_total_non_energetic
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_coal_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_coal_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_crude_oil_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_crude_oil_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_total_non_energetic
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_crude_oil_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_crude_oil_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_heater_electricity_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_heater_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_heater_electricity_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_heater_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_heatpump_water_water_electricity_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_heatpump_water_water_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_heatpump_water_water_electricity_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_heatpump_water_water_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_hydrogen_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_hydrogen_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_total_non_energetic
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_hydrogen_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_hydrogen_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_network_gas_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_network_gas_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_total_non_energetic
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_network_gas_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_network_gas_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_steam_recompression_electricity_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_steam_recompression_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_steam_recompression_electricity_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_steam_recompression_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_wood_pellets_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_wood_pellets_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_total_non_energetic
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_other_wood_pellets_non_energetic_share.ad
+++ b/inputs/demand/industry/industry_chemicals_other_wood_pellets_non_energetic_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_chemicals_refineries_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_chemicals_refineries_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_final_demand_for_chemical_fertilizers_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_fertilizers_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_final_demand_for_chemical_fertilizers_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_fertilizers_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_final_demand_for_chemical_other_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_other_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_final_demand_for_chemical_other_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_other_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_final_demand_for_chemical_refineries_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_refineries_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_final_demand_for_chemical_refineries_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_chemical_refineries_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_final_demand_for_other_food_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_other_food_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_final_demand_for_other_food_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_other_food_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_final_demand_for_other_paper_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_other_paper_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_final_demand_for_other_paper_steam_hot_water_share.ad
+++ b/inputs/demand/industry/industry_final_demand_for_other_paper_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_other_food_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_other_food_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_heater_electricity_share.ad
+++ b/inputs/demand/industry/industry_other_food_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_other_food_heater_electricity_share.ad
+++ b/inputs/demand/industry/industry_other_food_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_other_metals_process_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_other_metals_process_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_metal_other]
+- disabled_by_couplings = [external_model_industry, industry_metal_other]

--- a/inputs/demand/industry/industry_other_metals_process_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_other_metals_process_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_metals_external_coupling_share
+- disabled_by_couplings = [ctm, industry_metal_other]

--- a/inputs/demand/industry/industry_other_metals_process_heat_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_other_metals_process_heat_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_metal_other]
+- disabled_by_couplings = [external_model_industry, industry_metal_other]

--- a/inputs/demand/industry/industry_other_metals_process_heat_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_other_metals_process_heat_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_metals_external_coupling_share
+- disabled_by_couplings = [ctm, industry_metal_other]

--- a/inputs/demand/industry/industry_other_metals_production.ad
+++ b/inputs/demand/industry/industry_other_metals_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_metal_other]
+- disabled_by_couplings = [external_model_industry, industry_metal_other]

--- a/inputs/demand/industry/industry_other_metals_production.ad
+++ b/inputs/demand/industry/industry_other_metals_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_metals_external_coupling_share
+- disabled_by_couplings = [ctm, industry_metal_other]

--- a/inputs/demand/industry/industry_other_paper_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_coal_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_crude_oil_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_network_gas_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_burner_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_other_paper_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_heater_electricity_share.ad
+++ b/inputs/demand/industry/industry_other_paper_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_other_paper_heater_electricity_share.ad
+++ b/inputs/demand/industry/industry_other_paper_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_steel_blastfurnace_bof_share.ad
+++ b/inputs/demand/industry/industry_steel_blastfurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_blastfurnace_bof_share.ad
+++ b/inputs/demand/industry/industry_steel_blastfurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_cyclonefurnace_bof_share.ad
+++ b/inputs/demand/industry/industry_steel_cyclonefurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_cyclonefurnace_bof_share.ad
+++ b/inputs/demand/industry/industry_steel_cyclonefurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_cyclonefurnace_bof_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_steel_cyclonefurnace_bof_wood_pellets_share.ad
@@ -13,4 +13,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_cyclonefurnace_bof_wood_pellets_share.ad
+++ b/inputs/demand/industry/industry_steel_cyclonefurnace_bof_wood_pellets_share.ad
@@ -13,4 +13,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_dri_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_steel_dri_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_dri_hydrogen_share.ad
+++ b/inputs/demand/industry/industry_steel_dri_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_dri_network_gas_share.ad
+++ b/inputs/demand/industry/industry_steel_dri_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_dri_network_gas_share.ad
+++ b/inputs/demand/industry/industry_steel_dri_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_production.ad
+++ b/inputs/demand/industry/industry_steel_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_production.ad
+++ b/inputs/demand/industry/industry_steel_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_scrap_hbi_eaf_share.ad
+++ b/inputs/demand/industry/industry_steel_scrap_hbi_eaf_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_total_demand
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/demand/industry/industry_steel_scrap_hbi_eaf_share.ad
+++ b/inputs/demand/industry/industry_steel_scrap_hbi_eaf_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_electricity_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_electricity_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_useful_demand_for_other_non_specified_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_useful_demand_for_other_non_specified_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_non_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_non_energetic.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_non_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_useful_demand_for_other_non_specified_non_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_useable_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_non_specified]
+- disabled_by_couplings = [external_model_industry, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_aggregated_other_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_aggregated_other_useable_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_useful_demand_for_other_non_specified_energetic
+- disabled_by_couplings = [ctm, industry_other_non_specified]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers.ad
@@ -13,4 +13,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers.ad
@@ -13,4 +13,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_fertilizers_total_excluding_electricity
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_fertilizers_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other.ad
@@ -12,4 +12,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other.ad
@@ -12,4 +12,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_other_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_other_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_other_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_refineries.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_refineries.ad
@@ -14,4 +14,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_refineries.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_refineries.ad
@@ -14,4 +14,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_electricity_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_chemical_refineries_useable_heat
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_chemical_refineries_useable_heat_efficiency.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/demand/industry/industry_useful_demand_for_other_food.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_food.ad
@@ -10,4 +10,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_useful_demand_for_other_food.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_food.ad
@@ -10,4 +10,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_useful_demand_for_other_food_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_food_electricity_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_useful_demand_for_other_food_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_food_electricity_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_useful_demand_for_other_food_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_food_useable_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_food_useable_heat
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/demand/industry/industry_useful_demand_for_other_food_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_food_useable_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/demand/industry/industry_useful_demand_for_other_paper.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_paper.ad
@@ -10,4 +10,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_useful_demand_for_other_paper.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_paper.ad
@@ -10,4 +10,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_useful_demand_for_other_paper_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_paper_electricity_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_useful_demand_for_other_paper_electricity_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_paper_electricity_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/demand/industry/industry_useful_demand_for_other_paper_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_paper_useable_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/demand/industry/industry_useful_demand_for_other_paper_useable_heat_efficiency.ad
+++ b/inputs/demand/industry/industry_useful_demand_for_other_paper_useable_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- disabled_by = external_coupling_industry_other_paper_useable_heat
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_ht_waste_mix.ad
+++ b/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_ht_waste_mix.ad
@@ -30,11 +30,11 @@
             V(energy_chp_supercritical_ccs_ht_waste_mix, production_based_on_number_of_units)
         )
     )
-    
+
 - priority = 2
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:DIVIDE(
       V(energy_chp_supercritical_ccs_ht_waste_mix,"number_of_units*electricity_output_capacity"),
       SUM(
@@ -45,4 +45,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_ht_waste_mix.ad
+++ b/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_ht_waste_mix.ad
@@ -45,4 +45,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_mt_waste_mix.ad
+++ b/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_mt_waste_mix.ad
@@ -30,11 +30,11 @@
             V(energy_chp_supercritical_ccs_mt_waste_mix, production_based_on_number_of_units)
         )
     )
-    
+
 - priority = 2
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:DIVIDE(
       V(energy_chp_supercritical_ccs_mt_waste_mix,"number_of_units*electricity_output_capacity"),
       SUM(
@@ -45,4 +45,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_mt_waste_mix.ad
+++ b/inputs/emissions/ccus/capture/share_of_energy_chp_supercritical_ccs_mt_waste_mix.ad
@@ -45,4 +45,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_combustion_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_combustion_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_combustion_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_combustion_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_combustion_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_processes_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_processes_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_processes_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_fertilizers_captured_processes_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_processes_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_other_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_other_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_other_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_other_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_refineries_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_refineries_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/emissions/ccus/capture/share_of_industry_chemicals_refineries_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_chemicals_refineries_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/emissions/ccus/capture/share_of_industry_other_food_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_other_food_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/emissions/ccus/capture/share_of_industry_other_food_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_other_food_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/emissions/ccus/capture/share_of_industry_other_paper_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_other_paper_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/emissions/ccus/capture/share_of_industry_other_paper_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_other_paper_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/emissions/ccus/capture/share_of_industry_steel_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_steel_captured_co2.ad
@@ -16,4 +16,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_metal_steel_ccus_captured_co2
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/emissions/ccus/capture/share_of_industry_steel_captured_co2.ad
+++ b/inputs/emissions/ccus/capture/share_of_industry_steel_captured_co2.ad
@@ -16,4 +16,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_chemical_feedstock_coal_gas.ad
+++ b/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_chemical_feedstock_coal_gas.ad
@@ -15,4 +15,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_distribution_coal_gas_chemical_feedstock_share
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_chemical_feedstock_coal_gas.ad
+++ b/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_chemical_feedstock_coal_gas.ad
@@ -15,4 +15,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_energy_production_coal_gas.ad
+++ b/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_energy_production_coal_gas.ad
@@ -22,4 +22,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_distribution_coal_gas_energy_production_share
+- disabled_by_couplings = [ctm, industry_metal_steel]

--- a/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_energy_production_coal_gas.ad
+++ b/inputs/emissions/ccus/steel_coal_gas/share_of_energy_steel_energy_production_coal_gas.ad
@@ -22,4 +22,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_metal_steel]
+- disabled_by_couplings = [external_model_industry, industry_metal_steel]

--- a/inputs/emissions/ccus/utilisation_storage/demand_of_molecules_other_utilisation_co2.ad
+++ b/inputs/emissions/ccus/utilisation_storage/demand_of_molecules_other_utilisation_co2.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = MT
 - update_period = future
-- disabled_by = external_coupling_molecules_other_utilisation_demand
+- disabled_by_couplings = [ctm, ccus]

--- a/inputs/emissions/ccus/utilisation_storage/demand_of_molecules_other_utilisation_co2.ad
+++ b/inputs/emissions/ccus/utilisation_storage/demand_of_molecules_other_utilisation_co2.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = MT
 - update_period = future
-- disabled_by_couplings = [ctm, ccus]
+- disabled_by_couplings = [external_model_industry, ccus]

--- a/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_kerosene_must_run.ad
+++ b/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_kerosene_must_run.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- disabled_by = external_coupling_energy_production_synthetic_kerosene_demand
+- disabled_by_couplings = [ctm, ccus]

--- a/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_kerosene_must_run.ad
+++ b/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_kerosene_must_run.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- disabled_by_couplings = [ctm, ccus]
+- disabled_by_couplings = [external_model_industry, ccus]

--- a/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_methanol.ad
+++ b/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_methanol.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- disabled_by = external_coupling_energy_production_synthetic_methanol_demand
+- disabled_by_couplings = [ctm, ccus]

--- a/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_methanol.ad
+++ b/inputs/emissions/ccus/utilisation_storage/output_of_energy_production_synthetic_methanol.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- disabled_by_couplings = [ctm, ccus]
+- disabled_by_couplings = [external_model_industry, ccus]

--- a/inputs/flexibility/energy/wtp_of_agriculture_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/energy/wtp_of_agriculture_flexibility_p2h_electricity.ad
@@ -14,4 +14,3 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-#- disabled_by = 

--- a/inputs/flexibility/industry/wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_fertilizers_p2h_wtp
+- disabled_by_couplings = [ctm, industry_chemical_fertilizers]

--- a/inputs/flexibility/industry/wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_fertilizers]
+- disabled_by_couplings = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/flexibility/industry/wtp_of_industry_chemicals_other_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_chemicals_other_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_other_p2h_wtp
+- disabled_by_couplings = [ctm, industry_chemical_other]

--- a/inputs/flexibility/industry/wtp_of_industry_chemicals_other_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_chemicals_other_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_other]
+- disabled_by_couplings = [external_model_industry, industry_chemical_other]

--- a/inputs/flexibility/industry/wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by = external_coupling_industry_chemical_refineries_p2h_wtp
+- disabled_by_couplings = [ctm, industry_chemical_refineries]

--- a/inputs/flexibility/industry/wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chemical_refineries]
+- disabled_by_couplings = [external_model_industry, industry_chemical_refineries]

--- a/inputs/flexibility/industry/wtp_of_industry_other_food_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_other_food_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_food]
+- disabled_by_couplings = [external_model_industry, industry_other_food]

--- a/inputs/flexibility/industry/wtp_of_industry_other_food_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_other_food_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by = external_coupling_industry_other_food_p2h_wtp
+- disabled_by_couplings = [ctm, industry_other_food]

--- a/inputs/flexibility/industry/wtp_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by_couplings = [ctm, industry_other_paper]
+- disabled_by_couplings = [external_model_industry, industry_other_paper]

--- a/inputs/flexibility/industry/wtp_of_industry_other_paper_flexibility_p2h_electricity.ad
+++ b/inputs/flexibility/industry/wtp_of_industry_other_paper_flexibility_p2h_electricity.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- disabled_by = external_coupling_industry_other_paper_p2h_wtp
+- disabled_by_couplings = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_kerosene_demand.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_kerosene_demand.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, ccus]

--- a/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_kerosene_demand.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_kerosene_demand.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, ccus]
+- coupling_groups = [external_model_industry, ccus]

--- a/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_methanol_demand.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_methanol_demand.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, ccus]

--- a/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_methanol_demand.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_energy_production_synthetic_methanol_demand.ad
@@ -11,4 +11,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, ccus]
+- coupling_groups = [external_model_industry, ccus]

--- a/inputs/modules/external_coupling/ccus/external_coupling_molecules_other_utilisation_demand.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_molecules_other_utilisation_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, ccus]

--- a/inputs/modules/external_coupling/ccus/external_coupling_molecules_other_utilisation_demand.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_molecules_other_utilisation_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = MT
 - update_period = future
-- coupling_groups = [ctm, ccus]
+- coupling_groups = [external_model_industry, ccus]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_ammonia_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_crude_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_diesel_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_diesel_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_diesel_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_diesel_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_electricity_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_electricity_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_electricity_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_electricity_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_gasoline_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_gasoline_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_gasoline_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_gasoline_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_greengas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_hydrogen_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_kerosene_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_kerosene_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_kerosene_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_kerosene_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_loss_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_loss_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_loss_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_loss_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_lpg_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_lpg_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_lpg_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_lpg_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_methanol_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_natural_gas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_not_defined_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_steam_hot_water_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_steam_hot_water_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_steam_hot_water_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_steam_hot_water_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_total_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_total_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_waste_mix_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_waste_mix_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_waste_mix_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_waste_mix_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_wood_pellets_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_wood_pellets_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_wood_pellets_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_energy_chemical_fertilizers_transformation_external_coupling_node_wood_pellets_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_coal_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_coal_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_crude_oil_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_crude_oil_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_hydrogen_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_hydrogen_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_network_gas_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_network_gas_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_wood_pellets_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_burner_wood_pellets_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_combustion_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_electricity.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_electricity.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_coal_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_coal_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_wood_pellets_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_non_energetic_wood_pellets_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_processes_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_residual_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_residual_heat_share.ad
@@ -22,4 +22,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_residual_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_residual_heat_share.ad
@@ -2,16 +2,16 @@
     EACH(
       UPDATE(
         OUTPUT_SLOTS(
-          V(industry_chemicals_fertilizers_production), 
+          V(industry_chemicals_fertilizers_production),
           residual_heat
-        ), 
+        ),
         conversion, DIVIDE(USER_INPUT(), 100.0)
       ),
       UPDATE(
         OUTPUT_SLOTS(
-          V(industry_chemicals_fertilizers_production), 
+          V(industry_chemicals_fertilizers_production),
           useable_heat
-        ), 
+        ),
         conversion, (1.0 - DIVIDE(USER_INPUT(), 100.0))
       )
     )
@@ -22,4 +22,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_steam_hot_water_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_steam_hot_water_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_excluding_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_excluding_electricity.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_excluding_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_excluding_electricity.ad
@@ -15,4 +15,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_useable_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_useable_heat_share.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_fertilizers]
+- coupling_groups = [external_model_industry, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_useable_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_fertilizers/external_coupling_industry_chemical_fertilizers_total_useable_heat_share.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_fertilizers]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_ammonia_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_crude_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_diesel_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_diesel_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_diesel_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_diesel_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_electricity_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_electricity_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_electricity_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_electricity_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_gasoline_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_gasoline_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_gasoline_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_gasoline_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_greengas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_hydrogen_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_kerosene_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_kerosene_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_kerosene_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_kerosene_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_loss_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_loss_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_loss_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_loss_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_lpg_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_lpg_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_lpg_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_lpg_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_methanol_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_natural_gas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_not_defined_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_steam_hot_water_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_steam_hot_water_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_steam_hot_water_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_steam_hot_water_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_total_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_total_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_waste_mix_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_waste_mix_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_waste_mix_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_waste_mix_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_wood_pellets_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_wood_pellets_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_wood_pellets_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_energy_chemical_other_transformation_external_coupling_node_wood_pellets_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heater_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heater_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heater_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heater_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heatpump_water_water_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heatpump_water_water_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heatpump_water_water_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_heatpump_water_water_electricity_share.ad
@@ -27,4 +27,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_non_energetic_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_residual_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_residual_heat_share.ad
@@ -2,16 +2,16 @@
     EACH(
       UPDATE(
         OUTPUT_SLOTS(
-          V(industry_useful_demand_for_chemical_other_useable_heat), 
+          V(industry_useful_demand_for_chemical_other_useable_heat),
           residual_heat
-        ), 
+        ),
         conversion, DIVIDE(USER_INPUT(), 100.0)
       ),
       UPDATE(
         OUTPUT_SLOTS(
-          V(industry_useful_demand_for_chemical_other_useable_heat), 
+          V(industry_useful_demand_for_chemical_other_useable_heat),
           useable_heat
-        ), 
+        ),
         conversion, (1.0 - DIVIDE(USER_INPUT(), 100.0))
       )
     )
@@ -22,4 +22,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_residual_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_residual_heat_share.ad
@@ -22,4 +22,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_recompression_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_recompression_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_recompression_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_steam_recompression_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_total_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_total_non_energetic.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_total_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_total_non_energetic.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_chemical_other/external_coupling_industry_chemical_other_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_chemical_other]
+- coupling_groups = [external_model_industry, industry_chemical_other]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_ammonia_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_crude_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_diesel_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_diesel_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_diesel_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_diesel_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_electricity_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_electricity_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_electricity_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_electricity_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_gasoline_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_gasoline_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_gasoline_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_gasoline_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_greengas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_heavy_fuel_oil_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_hydrogen_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_kerosene_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_kerosene_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_kerosene_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_kerosene_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_loss_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_loss_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_loss_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_loss_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_lpg_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_lpg_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_lpg_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_lpg_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_methanol_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_natural_gas_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_output_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_not_defined_output_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_steam_hot_water_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_steam_hot_water_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_steam_hot_water_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_steam_hot_water_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_total_demand.ad
@@ -1,11 +1,11 @@
-# By setting the refinery transformation on the external coupling node, the 
+# By setting the refinery transformation on the external coupling node, the
 # demand on the regular transformation node is set to 0.0 PJ.
 
-- query = 
+- query =
     EACH(
       UPDATE(
         V(industry_useful_demand_for_chemical_refineries_crude_oil_non_energetic),
-        preset_demand, 
+        preset_demand,
         0.0
       ),
       UPDATE(
@@ -20,4 +20,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_total_demand.ad
@@ -20,4 +20,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_waste_mix_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_waste_mix_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_waste_mix_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_waste_mix_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_wood_pellets_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_wood_pellets_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_wood_pellets_input_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_energy_chemical_refineries_transformation_external_coupling_node_wood_pellets_input_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_residual_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_residual_heat_share.ad
@@ -22,4 +22,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_residual_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_residual_heat_share.ad
@@ -2,16 +2,16 @@
     EACH(
       UPDATE(
         OUTPUT_SLOTS(
-          V(industry_useful_demand_for_chemical_refineries_useable_heat), 
+          V(industry_useful_demand_for_chemical_refineries_useable_heat),
           residual_heat
-        ), 
+        ),
         conversion, DIVIDE(USER_INPUT(), 100.0)
       ),
       UPDATE(
         OUTPUT_SLOTS(
-          V(industry_useful_demand_for_chemical_refineries_useable_heat), 
+          V(industry_useful_demand_for_chemical_refineries_useable_heat),
           useable_heat
-        ), 
+        ),
         conversion, (1.0 - DIVIDE(USER_INPUT(), 100.0))
       )
     )
@@ -22,4 +22,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_chemical_refineries/external_coupling_industry_chemical_refineries_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_chemical_refineries]
+- coupling_groups = [external_model_industry, industry_chemical_refineries]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -2,7 +2,7 @@
 # This input sets the:
 # 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
 # 2. typical input capacity of CHP and heater node based on corrected efficiency
-# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity
 #    (based on updated typical input capacity)
 # 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
 
@@ -17,7 +17,7 @@
     electricity_component_demand_per_mw = V(industry_chp_combined_cycle_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
     electricity_component_efficiency_electricity = chp_useful_output;
     electricity_component_efficiency_heat = 0.0;
-    
+
     heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
     heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
     heat_component_demand_per_mw = V(industry_heat_combined_cycle_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
@@ -43,7 +43,7 @@
         V(industry_chp_combined_cycle_gas_power_fuelmix),
         number_of_units,
         electricity_component_total_output_capacity / V(industry_chp_combined_cycle_gas_power_fuelmix, electricity_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_chp_combined_cycle_gas_power_fuelmix),
         preset_demand,
@@ -63,7 +63,7 @@
         V(industry_heat_combined_cycle_gas_power_fuelmix),
         number_of_units,
         heat_component_total_output_capacity / V(industry_heat_combined_cycle_gas_power_fuelmix, heat_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_heat_combined_cycle_gas_power_fuelmix),
         preset_demand,
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -2,7 +2,7 @@
 # This input sets the:
 # 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
 # 2. typical input capacity of CHP and heater node based on corrected efficiency
-# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity
 #    (based on updated typical input capacity)
 # 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
 
@@ -17,7 +17,7 @@
     electricity_component_demand_per_mw = V(industry_chp_engine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
     electricity_component_efficiency_electricity = chp_useful_output;
     electricity_component_efficiency_heat = 0.0;
-    
+
     heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
     heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
     heat_component_demand_per_mw = V(industry_heat_engine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
@@ -43,7 +43,7 @@
         V(industry_chp_engine_gas_power_fuelmix),
         number_of_units,
         electricity_component_total_output_capacity / V(industry_chp_engine_gas_power_fuelmix, electricity_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_chp_engine_gas_power_fuelmix),
         preset_demand,
@@ -63,7 +63,7 @@
         V(industry_heat_engine_gas_power_fuelmix),
         number_of_units,
         heat_component_total_output_capacity / V(industry_heat_engine_gas_power_fuelmix, heat_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_heat_engine_gas_power_fuelmix),
         preset_demand,
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -2,7 +2,7 @@
 # This input sets the:
 # 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
 # 2. typical input capacity of CHP and heater node based on corrected efficiency
-# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity
 #    (based on updated typical input capacity)
 # 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
 
@@ -17,7 +17,7 @@
     electricity_component_demand_per_mw = V(industry_chp_turbine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
     electricity_component_efficiency_electricity = chp_useful_output;
     electricity_component_efficiency_heat = 0.0;
-    
+
     heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
     heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
     heat_component_demand_per_mw = V(industry_heat_turbine_gas_power_fuelmix, full_load_hours) * MJ_PER_MWH / chp_useful_output;
@@ -43,7 +43,7 @@
         V(industry_chp_turbine_gas_power_fuelmix),
         number_of_units,
         electricity_component_total_output_capacity / V(industry_chp_turbine_gas_power_fuelmix, electricity_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_chp_turbine_gas_power_fuelmix),
         preset_demand,
@@ -63,7 +63,7 @@
         V(industry_heat_turbine_gas_power_fuelmix),
         number_of_units,
         heat_component_total_output_capacity / V(industry_heat_turbine_gas_power_fuelmix, heat_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_heat_turbine_gas_power_fuelmix),
         preset_demand,
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_hydrogen.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_hydrogen.ad
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_hydrogen.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_turbine_hydrogen.ad
@@ -2,7 +2,7 @@
 # This input sets the:
 # 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
 # 2. typical input capacity of CHP and heater node based on corrected efficiency
-# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity
 #    (based on updated typical input capacity)
 # 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
 
@@ -17,7 +17,7 @@
     electricity_component_demand_per_mw = V(industry_chp_turbine_hydrogen, full_load_hours) * MJ_PER_MWH / chp_useful_output;
     electricity_component_efficiency_electricity = chp_useful_output;
     electricity_component_efficiency_heat = 0.0;
-    
+
     heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
     heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
     heat_component_demand_per_mw = V(industry_heat_turbine_hydrogen, full_load_hours) * MJ_PER_MWH / chp_useful_output;
@@ -43,7 +43,7 @@
         V(industry_chp_turbine_hydrogen),
         number_of_units,
         electricity_component_total_output_capacity / V(industry_chp_turbine_hydrogen, electricity_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_chp_turbine_hydrogen),
         preset_demand,
@@ -63,7 +63,7 @@
         V(industry_heat_turbine_hydrogen),
         number_of_units,
         heat_component_total_output_capacity / V(industry_heat_turbine_hydrogen, heat_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_heat_turbine_hydrogen),
         preset_demand,
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -2,7 +2,7 @@
 # This input sets the:
 # 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
 # 2. typical input capacity of CHP and heater node based on corrected efficiency
-# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity
 #    (based on updated typical input capacity)
 # 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
 
@@ -17,7 +17,7 @@
     electricity_component_demand_per_mw = V(industry_chp_ultra_supercritical_coal, full_load_hours) * MJ_PER_MWH / chp_useful_output;
     electricity_component_efficiency_electricity = chp_useful_output;
     electricity_component_efficiency_heat = 0.0;
-    
+
     heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
     heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
     heat_component_demand_per_mw = V(industry_heat_ultra_supercritical_coal, full_load_hours) * MJ_PER_MWH / chp_useful_output;
@@ -43,7 +43,7 @@
         V(industry_chp_ultra_supercritical_coal),
         number_of_units,
         electricity_component_total_output_capacity / V(industry_chp_ultra_supercritical_coal, electricity_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_chp_ultra_supercritical_coal),
         preset_demand,
@@ -63,7 +63,7 @@
         V(industry_heat_ultra_supercritical_coal),
         number_of_units,
         heat_component_total_output_capacity / V(industry_heat_ultra_supercritical_coal, heat_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_heat_ultra_supercritical_coal),
         preset_demand,
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_wood_pellets.ad
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_capacity_of_industry_chp_wood_pellets.ad
@@ -2,7 +2,7 @@
 # This input sets the:
 # 1. conversion efficiencies of the CHP and heater nodes with corrected efficiency
 # 2. typical input capacity of CHP and heater node based on corrected efficiency
-# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity 
+# 3. number of CHP and heater units, based on automatically calculated electricity / heat output capacity
 #    (based on updated typical input capacity)
 # 4. preset demand of CHP and heater based on respective full load hours and corrected efficiency
 
@@ -17,7 +17,7 @@
     electricity_component_demand_per_mw = V(industry_chp_wood_pellets, full_load_hours) * MJ_PER_MWH / chp_useful_output;
     electricity_component_efficiency_electricity = chp_useful_output;
     electricity_component_efficiency_heat = 0.0;
-    
+
     heat_component_input_capacity = chp_input_capacity * chp_heat_efficiency / chp_useful_output;
     heat_component_total_output_capacity = electricity_component_total_output_capacity / chp_electricity_efficiency * chp_heat_efficiency;
     heat_component_demand_per_mw = V(industry_heat_wood_pellets, full_load_hours) * MJ_PER_MWH / chp_useful_output;
@@ -43,7 +43,7 @@
         V(industry_chp_wood_pellets),
         number_of_units,
         electricity_component_total_output_capacity / V(industry_chp_wood_pellets, electricity_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_chp_wood_pellets),
         preset_demand,
@@ -63,7 +63,7 @@
         V(industry_heat_wood_pellets),
         number_of_units,
         heat_component_total_output_capacity / V(industry_heat_wood_pellets, heat_output_capacity)
-      ),  
+      ),
       UPDATE(
         L(industry_heat_wood_pellets),
         preset_demand,
@@ -78,4 +78,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_combined_cycle_gas_power_fuelmix_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_engine_gas_power_fuelmix_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_gas_power_fuelmix_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_turbine_hydrogen_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_ultra_supercritical_coal_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_electricity.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_electricity.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_chp]

--- a/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_heat.ad
+++ b/inputs/modules/external_coupling/industry_chp/external_coupling_efficiency_industry_chp_wood_pellets_heat.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_chp]
+- coupling_groups = [external_model_industry, industry_chp]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_carbothermalreduction_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_carbothermalreduction_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_carbothermalreduction_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_carbothermalreduction_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_bat_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_bat_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_bat_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_bat_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_current_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_current_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_current_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_electrolysis_current_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_smeltoven_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_smeltoven_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_smeltoven_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_aluminium_smeltoven_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_efficiency.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_efficiency.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_efficiency.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_efficiency.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_energetic_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_external_coupling_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_external_coupling_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_external_coupling_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_external_coupling_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_fixed_om_costs.ad
@@ -1,7 +1,7 @@
 - query =
     UPDATE(
-      V(industry_aluminium_external_coupling_node), 
-      fixed_operation_and_maintenance_costs_per_year, 
+      V(industry_aluminium_external_coupling_node),
+      fixed_operation_and_maintenance_costs_per_year,
       USER_INPUT()
     )
 - priority = 0
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_fixed_om_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_investment_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_investment_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_investment_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_investment_costs.ad
@@ -1,7 +1,7 @@
 - query =
     UPDATE(
-      V(industry_aluminium_external_coupling_node), 
-      initial_investment, 
+      V(industry_aluminium_external_coupling_node),
+      initial_investment,
       USER_INPUT()
     )
 - priority = 0
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_production.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_production.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_production.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_technical_lifetime.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_technical_lifetime.ad
@@ -1,7 +1,7 @@
 - query =
     UPDATE(
-      V(industry_aluminium_external_coupling_node), 
-      technical_lifetime, 
+      V(industry_aluminium_external_coupling_node),
+      technical_lifetime,
       USER_INPUT()
     )
 - priority = 0
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm, industry_metal_aluminium]
+- coupling_groups = [external_model_industry, industry_metal_aluminium]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_fixed_om_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_fixed_om_costs.ad
@@ -1,7 +1,7 @@
 - query =
     UPDATE(
-      V(industry_other_metals_external_coupling_node), 
-      fixed_operation_and_maintenance_costs_per_year, 
+      V(industry_other_metals_external_coupling_node),
+      fixed_operation_and_maintenance_costs_per_year,
       USER_INPUT()
     )
 - priority = 0
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_hydrogen_efficiency.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_hydrogen_efficiency.ad
@@ -6,4 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_hydrogen_efficiency.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_hydrogen_efficiency.ad
@@ -6,4 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_investment_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_investment_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_investment_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_investment_costs.ad
@@ -1,7 +1,7 @@
 - query =
     UPDATE(
-      V(industry_other_metals_external_coupling_node), 
-      initial_investment, 
+      V(industry_other_metals_external_coupling_node),
+      initial_investment,
       USER_INPUT()
     )
 - priority = 0
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_technical_lifetime.ad
@@ -1,7 +1,7 @@
 - query =
     UPDATE(
-      V(industry_other_metals_external_coupling_node), 
-      technical_lifetime, 
+      V(industry_other_metals_external_coupling_node),
+      technical_lifetime,
       USER_INPUT()
     )
 - priority = 0
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_technical_lifetime.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_total_demand.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_total_demand.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_coal_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_coal_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_external_coupling_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_external_coupling_share.ad
@@ -8,4 +8,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_external_coupling_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_external_coupling_share.ad
@@ -1,4 +1,4 @@
-- query = 
+- query =
       UPDATE(EDGE(industry_other_metals_production,industry_other_metals_external_coupling_node), share, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_other_metal_production_route
 - priority = 0
@@ -8,4 +8,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_heat_useable_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_heat_useable_heat_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_heat_useable_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_heat_useable_heat_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_electricity_share.ad
@@ -8,4 +8,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_electricity_share.ad
@@ -1,4 +1,4 @@
-- query = 
+- query =
       UPDATE(EDGE(industry_other_metals_production,industry_other_metals_process_electricity), share, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_other_metal_production_route
 - priority = 0
@@ -8,4 +8,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_heat_useable_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_heat_useable_heat_share.ad
@@ -1,4 +1,4 @@
-- query = 
+- query =
       UPDATE(EDGE(industry_other_metals_production,industry_other_metals_process_heat_useable_heat), share, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_other_metal_production_route
 - priority = 0
@@ -8,4 +8,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_other]
+- coupling_groups = [external_model_industry, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_heat_useable_heat_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_other_metals_process_heat_useable_heat_share.ad
@@ -8,4 +8,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_other]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_chemical_feedstock_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_chemical_feedstock_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.01
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_chemical_feedstock_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_chemical_feedstock_share.ad
@@ -15,4 +15,4 @@
 - step_value = 0.01
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_energy_production_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_energy_production_share.ad
@@ -34,4 +34,4 @@
 - step_value = 0.01
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_energy_production_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_energy_production_share.ad
@@ -34,4 +34,4 @@
 - step_value = 0.01
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_final_demand_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_final_demand_share.ad
@@ -1,4 +1,4 @@
-# This input is left empty. Explicitly setting the share to final demand produces incorrect 
+# This input is left empty. Explicitly setting the share to final demand produces incorrect
 # results. Only setting the other outgoing shares allows the share to final demand to be
 # calculated correctly. However, it cannot go to 0.0, nor can all outgoing share exceed 100.0.
 # Therefore this input is added to the share_group with a min_value of 0.01.
@@ -12,4 +12,4 @@
 - step_value = 0.01
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_final_demand_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_energy_distribution_coal_gas_final_demand_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.01
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_blastfurnace_bof_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_blastfurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_blastfurnace_bof_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_blastfurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_captured_co2.ad
@@ -16,4 +16,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_captured_co2.ad
@@ -16,4 +16,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_cyclonefurnace_bof_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_cyclonefurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_cyclonefurnace_bof_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_cyclonefurnace_bof_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_dri_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_efficiency.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_efficiency.ad
@@ -6,4 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_efficiency.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_efficiency.ad
@@ -6,4 +6,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_coal_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_cokes_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_cokes_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_cokes_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_cokes_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_electricity_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_hydrogen_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_network_gas_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_steam_hot_water_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_steam_hot_water_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_wood_pellets_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_energetic_wood_pellets_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_external_coupling_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_external_coupling_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_external_coupling_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_external_coupling_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_fixed_om_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_fixed_om_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_investment_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_investment_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_investment_costs.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_investment_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_scrap_hbi_eaf_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_scrap_hbi_eaf_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_scrap_hbi_eaf_share.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_scrap_hbi_eaf_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_technical_lifetime.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_technical_lifetime.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_total_demand.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_total_demand.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_total_demand.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_wacc.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_wacc.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_metal_steel]
+- coupling_groups = [external_model_industry, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_wacc.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_wacc.ad
@@ -12,4 +12,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_metal_steel]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_bio_kerosene_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_bio_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_bio_kerosene_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_bio_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_biodiesel_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_biodiesel_in_crude_oil_share.ad
@@ -1,10 +1,10 @@
 - query = UPDATE(INPUT_SLOTS(industry_final_demand_crude_oil,biodiesel), conversion, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_crude_oil
 - priority = 0
-- max_value = 100.0 
+- max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_final_demand_crude_oil,biodiesel_input_conversion) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_biodiesel_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_biodiesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_diesel_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_diesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_diesel_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_diesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_kerosene_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_kerosene_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_lpg_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_lpg_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_lpg_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_lpg_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_bio_oil_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_bio_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_bio_oil_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_bio_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_oil_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_oil_in_crude_oil_share.ad
@@ -1,10 +1,10 @@
 - query = UPDATE(INPUT_SLOTS(industry_final_demand_crude_oil,crude_oil), conversion, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_crude_oil
 - priority = 0
-- max_value = 100.0 
+- max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_final_demand_crude_oil,crude_oil_input_conversion) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_oil_in_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/energetic/external_coupling_industry_other_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_bio_kerosene_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_bio_kerosene_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_bio_kerosene_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_bio_kerosene_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_biodiesel_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_biodiesel_in_crude_oil_non_energetic_share.ad
@@ -1,10 +1,10 @@
 - query = UPDATE(INPUT_SLOTS(industry_final_demand_crude_oil_non_energetic,biodiesel), conversion, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_crude_oil_non_energetic
 - priority = 0
-- max_value = 100.0 
+- max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_final_demand_crude_oil_non_energetic,biodiesel_input_conversion) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_biodiesel_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_biodiesel_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_diesel_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_diesel_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_diesel_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_diesel_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_kerosene_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_kerosene_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_kerosene_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_kerosene_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_lpg_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_lpg_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_lpg_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_lpg_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_bio_oil_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_bio_oil_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_bio_oil_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_bio_oil_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_oil_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_oil_in_crude_oil_non_energetic_share.ad
@@ -1,10 +1,10 @@
 - query = UPDATE(INPUT_SLOTS(industry_final_demand_crude_oil_non_energetic,crude_oil), conversion, DIVIDE(USER_INPUT(),100))
 - share_group = external_coupling_industry_crude_oil_non_energetic
 - priority = 0
-- max_value = 100.0 
+- max_value = 100.0
 - min_value = 0.0
 - start_value_gql = present:V(industry_final_demand_crude_oil_non_energetic,crude_oil_input_conversion) * 100
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_oil_mix]
+- coupling_groups = [external_model_industry, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_oil_in_crude_oil_non_energetic_share.ad
+++ b/inputs/modules/external_coupling/industry_oil_mix/non_energetic/external_coupling_industry_other_oil_in_crude_oil_non_energetic_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_oil_mix]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_electricity.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_electricity.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_heater_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_heater_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_other_food/external_coupling_industry_other_food_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_other_food]
+- coupling_groups = [external_model_industry, industry_other_food]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_ammonia_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_ammonia_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_ammonia_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_ammonia_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_coal_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_cokes_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_crude_oil_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_electricity_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_electricity_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_electricity_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_electricity_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_hydrogen_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_methanol_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_methanol_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_methanol_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_methanol_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_network_gas_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_useable_heat_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_useable_heat_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_useable_heat_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_useable_heat_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_waste_mix_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_waste_mix_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_waste_mix_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_waste_mix_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_non_energetic.ad
@@ -9,3 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_other_non_specified_industry_wood_pellets_share_non_energetic.ad
@@ -9,4 +9,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_non_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_other_non_specified]
+- coupling_groups = [external_model_industry, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_non_energetic.ad
+++ b/inputs/modules/external_coupling/industry_other_non_specified/external_coupling_industry_useful_demand_for_other_non_specified_non_energetic.ad
@@ -8,4 +8,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_non_specified]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_coal_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_coal_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_crude_oil_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_crude_oil_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_hydrogen_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_hydrogen_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_network_gas_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_network_gas_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_wood_pellets_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_burner_wood_pellets_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_capture_potential.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_capture_potential.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_captured_co2.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_captured_co2.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_electricity_use.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_ccus_electricity_use.ad
@@ -14,4 +14,4 @@
 - step_value = 1.0
 - unit = PJ/MT
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_electricity.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_electricity.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_electricity.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_heater_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_heater_electricity_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_heater_electricity_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_capacity.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_capacity.ad
@@ -21,4 +21,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_wtp.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_p2h_wtp.ad
@@ -14,4 +14,4 @@
 - step_value = 0.1
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_steam_hot_water_share.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_steam_hot_water_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm, industry_other_paper]
+- coupling_groups = [external_model_industry, industry_other_paper]

--- a/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_useable_heat.ad
+++ b/inputs/modules/external_coupling/industry_other_paper/external_coupling_industry_other_paper_useable_heat.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 - update_type = %
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, industry_other_paper]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_fixed_om_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, residual_heat]
+- coupling_groups = [external_model_industry, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_fixed_om_costs.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_fixed_om_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_investment_costs.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_investment_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm, residual_heat]
+- coupling_groups = [external_model_industry, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_investment_costs.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_investment_costs.ad
@@ -11,4 +11,4 @@
 - step_value = 1.0
 - unit = euro
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_technical_lifetime.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_technical_lifetime.ad
@@ -10,4 +10,4 @@
 - step_value = 1.0
 - unit = year
 - update_period = future
-- coupling_groups = [ctm, residual_heat]
+- coupling_groups = [external_model_industry, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_wacc.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_wacc.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, residual_heat]
+- coupling_groups = [external_model_industry, residual_heat]

--- a/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_wacc.ad
+++ b/inputs/modules/external_coupling/residual_heat/external_coupling_energy_heat_production_ht_residual_heat_wacc.ad
@@ -9,4 +9,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, residual_heat]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_biogenic_waste_max_demand.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_biogenic_waste_max_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_biogenic_waste_max_demand.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_biogenic_waste_max_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2.ad
@@ -28,4 +28,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_captured_co2.ad
@@ -28,4 +28,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_heat_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_heat_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_capacity.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_capacity.ad
@@ -29,4 +29,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_capacity.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_capacity.ad
@@ -29,4 +29,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_heat_efficiency.ad
@@ -8,4 +8,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_non_biogenic_waste_max_demand.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_non_biogenic_waste_max_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_non_biogenic_waste_max_demand.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_non_biogenic_waste_max_demand.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_biogenic_waste_share.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_biogenic_waste_share.ad
@@ -1,4 +1,4 @@
-- query = 
+- query =
     UPDATE(
       EDGE(energy_distribution_biogenic_waste, energy_distribution_waste_mix),
       share,
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_biogenic_waste_share.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_biogenic_waste_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_non_biogenic_waste_share.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_non_biogenic_waste_share.ad
@@ -1,4 +1,4 @@
-- query = 
+- query =
     UPDATE(
       EDGE(energy_distribution_non_biogenic_waste, energy_distribution_waste_mix),
       share,
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm, waste_chp]
+- coupling_groups = [external_model_industry, waste_chp]

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_non_biogenic_waste_share.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_waste_mix_non_biogenic_waste_share.ad
@@ -12,4 +12,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- coupling_groups = [ctm]
+- coupling_groups = [ctm, waste_chp]

--- a/inputs/supply/biomass_potential/max_demand_of_biogenic_waste.ad
+++ b/inputs/supply/biomass_potential/max_demand_of_biogenic_waste.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/supply/biomass_potential/max_demand_of_biogenic_waste.ad
+++ b/inputs/supply/biomass_potential/max_demand_of_biogenic_waste.ad
@@ -6,4 +6,4 @@
 - step_value = 0.1
 - unit = PJ
 - update_period = future
-- disabled_by = external_coupling_biogenic_waste_max_demand
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_ht_waste_mix.ad
+++ b/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_ht_waste_mix.ad
@@ -35,7 +35,7 @@
 - priority = 1
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:PRODUCT(
       (1 -
         DIVIDE(
@@ -56,4 +56,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_waste_mix_capacity
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_ht_waste_mix.ad
+++ b/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_ht_waste_mix.ad
@@ -56,4 +56,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_mt_waste_mix.ad
+++ b/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_mt_waste_mix.ad
@@ -35,7 +35,7 @@
 - priority = 1
 - max_value = 100.0
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:PRODUCT(
       DIVIDE(
         SUM(
@@ -54,4 +54,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_waste_mix_capacity
+- disabled_by_couplings = [ctm, waste_chp]

--- a/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_mt_waste_mix.ad
+++ b/inputs/supply/heat/energy/overview/chps/share_of_energy_chp_supercritical_mt_waste_mix.ad
@@ -54,4 +54,4 @@
 - step_value = 1.0
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_capacity_of_industry_chp_combined_cycle_gas_power_fuelmix
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -18,4 +18,4 @@
 - step_value = 0.1
 - unit = #
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_engine_gas_power_fuelmix.ad
@@ -18,4 +18,4 @@
 - step_value = 0.1
 - unit = #
 - update_period = future
-- disabled_by = external_coupling_capacity_of_industry_chp_engine_gas_power_fuelmix
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_gas_power_fuelmix.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_capacity_of_industry_chp_turbine_gas_power_fuelmix
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_hydrogen.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_hydrogen.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_hydrogen.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_turbine_hydrogen.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_capacity_of_industry_chp_turbine_hydrogen
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_capacity_of_industry_chp_ultra_supercritical_coal
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_ultra_supercritical_coal.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, industry_chp]
+- disabled_by_couplings = [external_model_industry, industry_chp]

--- a/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
+++ b/inputs/supply/heat/industry/capacity_of_industry_chp_wood_pellets.ad
@@ -18,4 +18,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_capacity_of_industry_chp_wood_pellets
+- disabled_by_couplings = [ctm, industry_chp]

--- a/inputs/supply/oil_mix/industry_bio_kerosene_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_bio_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_bio_kerosene_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_bio_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_bio_kerosene_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_biodiesel_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_biodiesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_biodiesel_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_biodiesel_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_biodiesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_diesel_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_diesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_diesel_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_diesel_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_diesel_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_kerosene_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_kerosene_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_kerosene_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_kerosene_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_lpg_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_lpg_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_lpg_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_lpg_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_lpg_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_other_bio_oil_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_other_bio_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_bio_oil_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_other_bio_oil_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_other_bio_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_other_oil_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_other_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by_couplings = [ctm, industry_oil_mix]
+- disabled_by_couplings = [external_model_industry, industry_oil_mix]

--- a/inputs/supply/oil_mix/industry_other_oil_in_crude_oil_share.ad
+++ b/inputs/supply/oil_mix/industry_other_oil_in_crude_oil_share.ad
@@ -7,4 +7,4 @@
 - step_value = 0.1
 - unit = %
 - update_period = future
-- disabled_by = external_coupling_industry_other_oil_in_crude_oil_share
+- disabled_by_couplings = [ctm, industry_oil_mix]

--- a/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
+++ b/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
@@ -62,4 +62,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by_couplings = [ctm, waste_chp]
+- disabled_by_couplings = [external_model_industry, waste_chp]

--- a/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
+++ b/inputs/supply/renewable_electricity/waste_power/capacity_of_energy_chp_supercritical_waste_mix.ad
@@ -54,7 +54,7 @@
 - priority = 0
 - max_value_gql = present:2*DIVIDE(DIVIDE(Q(total_electricity_consumed), V(energy_chp_supercritical_ht_waste_mix,full_load_hours)), MJ_PER_MWH)
 - min_value = 0.0
-- start_value_gql = 
+- start_value_gql =
     present:SUM(
       PRODUCT(V(energy_chp_supercritical_mt_waste_mix,number_of_units),V(energy_chp_supercritical_mt_waste_mix,electricity_output_capacity)),
       PRODUCT(V(energy_chp_supercritical_ht_waste_mix,number_of_units),V(energy_chp_supercritical_ht_waste_mix,electricity_output_capacity))
@@ -62,4 +62,4 @@
 - step_value = 1.0
 - unit = MW
 - update_period = future
-- disabled_by = external_coupling_energy_chp_supercritical_waste_mix_capacity
+- disabled_by_couplings = [ctm, waste_chp]


### PR DESCRIPTION
This PR adds the functionality to swap 'regular' input elements with external coupling input elements in the front-end. Coupling groups and disabled by couplings are used to enable this feature. Specifically, the external coupling inputs for the CTM are brought to the front-end.

Goes with:
- ETEngine: https://github.com/quintel/etengine/pull/1457
- ETModel: https://github.com/quintel/etmodel/pull/4323