### PR TITLE
Change min value of external input for waste CHP electrical efficiency

### DIFF
--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_ccs_waste_mix_electrical_efficiency.ad
@@ -3,7 +3,7 @@
 - query = UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ccs_ht_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
 - priority = 2
 - max_value = 100.0
-- min_value = 0.0
+- min_value = 1.0
 - start_value_gql = present:V(energy_chp_supercritical_ccs_ht_waste_mix, electricity_output_conversion) * 100.0
 - step_value = 1.0
 - unit = %

--- a/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
+++ b/inputs/modules/external_coupling/waste_chp/external_coupling_energy_chp_supercritical_waste_mix_electrical_efficiency.ad
@@ -3,7 +3,7 @@
 - query = UPDATE(OUTPUT_SLOTS(V(energy_chp_supercritical_ht_waste_mix), electricity), conversion, DIVIDE(USER_INPUT(), 100.0))
 - priority = 2
 - max_value = 100.0
-- min_value = 0.0
+- min_value = 1.0
 - start_value_gql = present:V(energy_chp_supercritical_ht_waste_mix, electricity_output_conversion) * 100.0
 - step_value = 1.0
 - unit = %


### PR DESCRIPTION
An electrical efficiency of 0 breaks the model. Therefore the min value of the efficiency inputs are set to 0 for the waste CHP external coupling inputs.