### PR TITLE
Add external coupling of generic captured industry emissions

### DIFF
--- a/config/molecules_node_positions.yml
+++ b/config/molecules_node_positions.yml
@@ -79,7 +79,7 @@ energy_hydrogen_steam_methane_reformer_ccs_must_run_co2:
   "y": 1280
 energy_methanol_production_coal_gas_co:
   x: 1940
-  "y": 1660
+  "y": 1680
 energy_power_captured_co2:
   x: 1940
   "y": 440
@@ -191,6 +191,9 @@ industry_chemicals_refineries_combustion_co2:
 industry_chemicals_refineries_emitted_co2:
   x: 1940
   "y": 2300
+industry_external_coupling_node_captured_co2:
+  x: 1940
+  "y": 1620
 industry_final_demand_for_chemical_fertilizers_coal_co2:
   x: 3440
   "y": 2500

--- a/gqueries/general/emissions/supply/industry/emissions_captured_industry_external_coupling.gql
+++ b/gqueries/general/emissions/supply/industry/emissions_captured_industry_external_coupling.gql
@@ -1,0 +1,2 @@
+- query = DIVIDE(MV(industry_external_coupling_node_captured_co2,demand),1000)
+- unit = tonne

--- a/gqueries/general/emissions/supply/industry/emissions_captured_industry_steel.gql
+++ b/gqueries/general/emissions/supply/industry/emissions_captured_industry_steel.gql
@@ -1,2 +1,2 @@
-- query = DIVIDE(MV(indsutry_steel_captured_co2,demand),1000)
+- query = DIVIDE(MV(industry_steel_captured_co2,demand),1000)
 - unit = tonne

--- a/gqueries/general/emissions/supply/industry/emissions_captured_industry_total.gql
+++ b/gqueries/general/emissions/supply/industry/emissions_captured_industry_total.gql
@@ -1,11 +1,12 @@
 - query = 
     SUM(
-        Q(emissions_captured_industry_chemicals_fertilizers),
-        Q(emissions_captured_industry_other),
-        Q(emissions_captured_industry_other_food),
-        Q(emissions_captured_industry_other_paper),
-        Q(emissions_captured_industry_chemicals_refineries),
-        Q(emissions_captured_industry_chemicals_other),
-        Q(emissions_captured_industry_steel)
+      Q(emissions_captured_industry_chemicals_fertilizers),
+      Q(emissions_captured_industry_other),
+      Q(emissions_captured_industry_other_food),
+      Q(emissions_captured_industry_other_paper),
+      Q(emissions_captured_industry_chemicals_refineries),
+      Q(emissions_captured_industry_chemicals_other),
+      Q(emissions_captured_industry_steel),
+      Q(emissions_captured_industry_external_coupling)
     )
 - unit = tonne

--- a/gqueries/output_elements/output_series/mekko_of_co2_demand_supply/co2_supply_import_baseload.gql
+++ b/gqueries/output_elements/output_series/mekko_of_co2_demand_supply/co2_supply_import_baseload.gql
@@ -1,2 +1,2 @@
-- unit = Mt
 - query = MV(molecules_import_co2_baseload, demand) / BILLIONS
+- unit = MT

--- a/gqueries/output_elements/output_series/mekko_of_co2_demand_supply/co2_supply_industry_external_coupling.gql
+++ b/gqueries/output_elements/output_series/mekko_of_co2_demand_supply/co2_supply_industry_external_coupling.gql
@@ -1,0 +1,2 @@
+- query = MV(industry_external_coupling_node_captured_co2, demand) / BILLIONS
+- unit = MT

--- a/gqueries/output_elements/output_series/sankey_ccus/captured_co2_industry_external_coupling_in_ccus_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_ccus/captured_co2_industry_external_coupling_in_ccus_sankey.gql
@@ -1,0 +1,2 @@
+- query = MV(industry_external_coupling_node_captured_co2, demand) / BILLIONS
+- unit = MT

--- a/gqueries/output_elements/output_series/sankey_ccus/import_captured_co2_baseload_in_ccus_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_ccus/import_captured_co2_baseload_in_ccus_sankey.gql
@@ -1,2 +1,2 @@
-- unit = MT
 - query = MV(molecules_import_co2_baseload, demand) / BILLIONS
+- unit = MT

--- a/graphs/molecules/edges/molecules/industry_external_coupling_node_captured_co2-molecules_distribution_before_transport_co2@co2.ad
+++ b/graphs/molecules/edges/molecules/industry_external_coupling_node_captured_co2-molecules_distribution_before_transport_co2@co2.ad
@@ -1,0 +1,2 @@
+- type = flexible
+- reversed = true

--- a/graphs/molecules/nodes/molecules/industry_external_coupling_node_captured_co2.ad
+++ b/graphs/molecules/nodes/molecules/industry_external_coupling_node_captured_co2.ad
@@ -1,0 +1,8 @@
+# This node is used to allocate captured CO2 flows from emissions that are out of scope of the ETM.
+# Such emissions for example include proces emissions in the refinery sector.
+# Because these emissions are out of scope of the ETM, the captured flow is not subtracted from
+# the total emissions.
+
+- groups = [preset_demand]
+
+~ demand = 0.0

--- a/inputs/modules/external_coupling/ccus/external_coupling_industry_external_coupling_node_captured_co2_supply.ad
+++ b/inputs/modules/external_coupling/ccus/external_coupling_industry_external_coupling_node_captured_co2_supply.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(MV(industry_external_coupling_node_captured_co2), preset_demand, (USER_INPUT() * BILLIONS))
+- priority = 0
+- max_value_gql = present:AREA(co2_emission_1990)
+- min_value = 0.0
+- start_value_gql = present:MV(industry_external_coupling_node_captured_co2, demand) / BILLIONS
+- step_value = 0.1
+- unit = MT
+- update_period = future
+- coupling_groups = [external_model_industry, ccus]


### PR DESCRIPTION
**Background**
Structural changes have recently been implemented for the coupling to the CTM, most notably https://github.com/quintel/etsource/pull/3107. However, not all CO2 flows can be allocated from the CTM to the ETM. For example, process emissions of refineries are not accounted for in the ETM. Normally, this would be solved by increasing the captured emissions in the final demand sectors. However, due to the addition of the generic transformation nodes, the potential to (over)allocate emissions to the final demand is significantly reduced, since a large part of industry demand is specified on the transformation nodes.

**Solution**
A generic capture node for the industry is implemented to be specified by external models. This node is specifically aimed at allocating captured flows for emissions that are **not** in scope of the ETM. Therefore, when capture is set on this node, the total emissions do not decrease.

Goes with: https://github.com/quintel/etmodel/pull/4335