### PR TITLE
Robust queries for MYC

### DIFF
--- a/gqueries/general/final_demand/final_demand_of_electricity.gql
+++ b/gqueries/general/final_demand/final_demand_of_electricity.gql
@@ -1,5 +1,0 @@
-# The total amount of electricity demand in the final demand.
-
-- unit = MJ
-- query = V(G(final_demand_group),input_of_electricity).sum
-- deprecated_key = final_demand_electricity

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_electricity.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_electricity.gql
@@ -1,0 +1,4 @@
+# Final demand of electricity
+
+- query = Q(final_demand_of_electricity) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_heat.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_heat.gql
@@ -1,0 +1,4 @@
+# Final demand of heat
+
+- query = Q(final_demand_of_heat) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_agriculture.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_agriculture) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_buildings.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_buildings) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_bunkers.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_bunkers) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_energy.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_energy) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_energy_and_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_energy_and_other.gql
@@ -1,0 +1,8 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query =
+    SUM(
+      Q(myc_final_demand_of_electricity_in_energy),
+      Q(myc_final_demand_of_electricity_in_other)
+    )
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_households.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_households) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_industry.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_industry) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_other.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_other) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_electricity_in_transport.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'electricity' carrier group
+
+- query = Q(final_demand_of_electricity_in_transport) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_agriculture.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_agriculture) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_buildings.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_buildings) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_bunkers.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_bunkers) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_energy.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_energy) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_energy_and_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_energy_and_other.gql
@@ -1,0 +1,8 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query =
+    SUM(
+      Q(myc_final_demand_of_heat_in_energy),
+      Q(myc_final_demand_of_heat_in_other)
+    )
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_households.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_households) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_industry.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_industry) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_other.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_other) * BILLIONS
+- unit = MJ

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_heat_in_transport.gql
@@ -1,0 +1,4 @@
+# Energetic final demand of the 'heat' carrier group
+
+- query = Q(final_demand_of_heat_in_transport) * BILLIONS
+- unit = MJ


### PR DESCRIPTION
This PR solves https://github.com/quintel/multi-year-charts/issues/70. The edge group method and node group method of querying final demand per carrier leads to different results with the sustainability share. Therefore, the difference between fossil and renewable electricity is dropped from the MYC.

To do:

- [x] Update labels and queries in the MYC
- [x] See if the same changes should be implemented for Heat. @kaskranenburgQ do we want this?