### PR TITLE
Adding a unique external coupling group for each interconnector.

### DIFF
--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_1.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_1.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors,interconnector_1_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_10.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_10.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_10_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_11.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_11.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_11_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_12.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_12.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_12_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_2.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_2.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors,interconnector_2_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_3.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_3.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_3_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_4.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_4.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_4_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_5.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_5.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_5]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_5.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_5.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors, interconnector_5]
+- coupling_groups = [external_model_interconnectors, interconnector_5_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_6.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_6.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_6_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_7.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_7.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_7_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_8.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_8.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_8_must_run]
 

--- a/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_9.ad
+++ b/inputs/modules/external_coupling/interconnectors/external_coupling_interconnector_9.ad
@@ -18,5 +18,5 @@
 - step_value = 1.0
 - unit = bool
 - update_period = future
-- coupling_groups = [external_model_interconnectors]
+- coupling_groups = [external_model_interconnectors, interconnector_9_must_run]
 


### PR DESCRIPTION
This PR adds a unique external coupling group for each interconnector.
This distinction creates the possibilty to set each interconnector to must-run seperately. 
In the current setup this is not yet possible.