### PR TITLE
Renaming external coupling groups in regular front end inputs

### DIFF
--- a/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_1]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_1_must_run]

--- a/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_1]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_1_must_run]

--- a/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_1]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_1_must_run]

--- a/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_1/electricity_interconnector_1_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_1]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_1_must_run]

--- a/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_10]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_10_must_run]

--- a/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_10]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_10_must_run]

--- a/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_10]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_10_must_run]

--- a/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_10/electricity_interconnector_10_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_10]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_10_must_run]

--- a/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_11]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_11_must_run]

--- a/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_11]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_11_must_run]

--- a/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_11]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_11_must_run]

--- a/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_11/electricity_interconnector_11_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_11]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_11_must_run]

--- a/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_12]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_12_must_run]

--- a/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_12]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_12_must_run]

--- a/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_12]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_12_must_run]

--- a/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_12/electricity_interconnector_12_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_12]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_12_must_run]

--- a/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_2]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_2_must_run]

--- a/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_export_availability.ad
@@ -7,5 +7,5 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_2]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_2_must_run]
 

--- a/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_import_availability.ad
@@ -7,5 +7,5 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_2]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_2_must_run]
 

--- a/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_2/electricity_interconnector_2_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_2]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_2_must_run]

--- a/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_3]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_3_must_run]

--- a/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_3]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_3_must_run]

--- a/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_3]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_3_must_run]

--- a/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_3/electricity_interconnector_3_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_3]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_3_must_run]

--- a/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_4]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_4_must_run]

--- a/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_4]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_4_must_run]

--- a/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_4]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_4_must_run]

--- a/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_4/electricity_interconnector_4_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_4]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_4_must_run]

--- a/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_5]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_5_must_run]

--- a/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_5]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_5_must_run]

--- a/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_5]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_5_must_run]

--- a/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_5/electricity_interconnector_5_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_5]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_5_must_run]

--- a/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_6]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_6_must_run]

--- a/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_6]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_6_must_run]

--- a/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_6]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_6_must_run]

--- a/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_6/electricity_interconnector_6_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_6]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_6_must_run]

--- a/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_7]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_7_must_run]

--- a/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_7]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_7_must_run]

--- a/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_7]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_7_must_run]

--- a/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_7/electricity_interconnector_7_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_7]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_7_must_run]

--- a/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_8]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_8_must_run]

--- a/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_8]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_8_must_run]

--- a/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_8]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_8_must_run]

--- a/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_8/electricity_interconnector_8_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_8]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_8_must_run]

--- a/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_capacity.ad
+++ b/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_capacity.ad
@@ -11,4 +11,4 @@
 - unit = MW
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_9]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_9_must_run]

--- a/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_export_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_export_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_9]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_9_must_run]

--- a/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_import_availability.ad
+++ b/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_import_availability.ad
@@ -7,4 +7,4 @@
 - unit = %
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_9]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_9_must_run]

--- a/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_marginal_costs.ad
+++ b/inputs/flexibility/import_export/interconnector_9/electricity_interconnector_9_marginal_costs.ad
@@ -15,4 +15,4 @@
 - unit = euro
 - update_period = future
 
-- disabled_by_couplings = [external_model_interconnectors, interconnector_9]
+- disabled_by_couplings = [external_model_interconnectors, interconnector_9_must_run]


### PR DESCRIPTION
This PR adds the correct external coupling group in the disabled_by_couplings argument for each interconnector.
@kndehaan Could you check if this is now working correctly?