### PR TITLE
 Adding queries to refinery sankey to include industry transformation

### DIFF
--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_ammonia_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_ammonia_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_ammonia"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_crude_oil_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_crude_oil_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_crude_oil"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_electricity_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_electricity_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_electricity"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_greengas_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_greengas_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_greengas"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_hydrogen_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_hydrogen_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_hydrogen"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_methanol_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_methanol_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_methanol"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_natural_gas_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_natural_gas_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_natural_gas"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_not_defined_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_not_defined_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_not_defined"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_steam_hot_water_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_steam_hot_water_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_steam_hot_water"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_waste_mix_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_waste_mix_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_waste_mix"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/input/input_of_wood_pellets_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/input/input_of_wood_pellets_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "input_of_wood_pellets"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_ammonia_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_ammonia_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_ammonia"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_crude_oil_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_crude_oil_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_crude_oil"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_diesel_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_diesel_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_diesel"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_gasoline_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_gasoline_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_gasoline"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_greengas_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_greengas_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_greengas"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_heavy_fuel_oil_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_heavy_fuel_oil_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_heavy_fuel_oil"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_hydrogen_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_hydrogen_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_hydrogen"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_kerosene_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_kerosene_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_kerosene"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_loss_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_loss_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "loss_output_conversion"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_lpg_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_lpg_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_lpg"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_methanol_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_methanol_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_methanol"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_natural_gas_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_natural_gas_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_natural_gas"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/general/final_demand/industry/industry_transformation/output/output_of_not_defined_in_industry_transformation.gql
+++ b/gqueries/general/final_demand/industry/industry_transformation/output/output_of_not_defined_in_industry_transformation.gql
@@ -1,0 +1,12 @@
+- unit = PJ
+- query =
+    DIVIDE(
+      SUM(
+          V(
+            G(industry_transformation),
+            "output_of_not_defined"
+          )
+        ),
+      BILLIONS
+    )
+

--- a/gqueries/output_elements/output_series/refinery_189/crude_oil_extraction_to_industry_transformation_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/crude_oil_extraction_to_industry_transformation_in_sankey.gql
@@ -1,0 +1,10 @@
+# Query for refinery sankey: connection between extraction of crude oil and refinery
+
+- unit = PJ
+- query =
+      SUM(
+        PRODUCT(
+          Q(input_of_crude_oil_in_industry_transformation),
+          V(energy_extraction_crude_oil, share_of_energy_distribution_crude_oil)
+          )
+        )

--- a/gqueries/output_elements/output_series/refinery_189/crude_oil_import_to_industry_transformation_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/crude_oil_import_to_industry_transformation_in_sankey.gql
@@ -1,0 +1,11 @@
+# Query for refinery sankey: connection between import of crude oil and industry transformation
+
+- unit = PJ
+- query =
+      SUM(
+        PRODUCT(
+          Q(input_of_crude_oil_in_industry_transformation),
+          V(energy_import_crude_oil, share_of_energy_distribution_crude_oil)
+          )
+        )
+

--- a/gqueries/output_elements/output_series/refinery_189/diesel_industry_transformation_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/diesel_industry_transformation_to_distribution_in_sankey.gql
@@ -1,0 +1,5 @@
+# Query for refinery sankey: connection between refinery and distribution of diesel
+
+- unit = PJ
+- query = Q(output_of_diesel_in_industry_transformation)
+

--- a/gqueries/output_elements/output_series/refinery_189/gasoline_industry_transformation_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/gasoline_industry_transformation_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of gasoline
+
+- unit = PJ
+- query = Q(output_of_gasoline_in_industry_transformation)

--- a/gqueries/output_elements/output_series/refinery_189/hfo_industry_transformation_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/hfo_industry_transformation_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refeinry and distribution of heavy fuel oil
+
+- unit = PJ
+- query = Q(output_of_heavy_fuel_oil_in_industry_transformation)

--- a/gqueries/output_elements/output_series/refinery_189/industry_transformation_heat_input_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/industry_transformation_heat_input_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between heat input and refinery
+
+- unit = PJ
+- query = Q(input_of_steam_hot_water_in_industry_transformation)

--- a/gqueries/output_elements/output_series/refinery_189/industry_transformation_loss_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/industry_transformation_loss_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and loss
+
+- unit = PJ
+- query = Q(output_of_loss_in_industry_transformation)

--- a/gqueries/output_elements/output_series/refinery_189/industry_transformation_to_non_refinery_products_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/industry_transformation_to_non_refinery_products_in_sankey.gql
@@ -1,0 +1,12 @@
+# Query for refinery sankey: connection between refinery and distribution of oil products
+
+- unit = PJ
+- query = 
+    SUM(
+      Q(output_of_ammonia_in_industry_transformation),
+      Q(output_of_greengas_in_industry_transformation),
+      Q(output_of_hydrogen_in_industry_transformation),
+      Q(output_of_natural_gas_in_industry_transformation),
+      Q(output_of_methanol_in_industry_transformation),
+      Q(output_of_not_defined_in_industry_transformation)
+    )

--- a/gqueries/output_elements/output_series/refinery_189/kerosene_industry_transformation_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/kerosene_industry_transformation_to_distribution_in_sankey.gql
@@ -1,0 +1,5 @@
+# Query for refinery sankey: connection between refinery and distribution of kerosene
+
+- unit = PJ
+- query = 
+    Q(output_of_kerosene_in_industry_transformation)

--- a/gqueries/output_elements/output_series/refinery_189/lpg_industry_transformation_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/lpg_industry_transformation_to_distribution_in_sankey.gql
@@ -1,0 +1,5 @@
+# Query for refinery sankey: connection between refinery and distribution of lpg
+
+- unit = PJ
+- query = 
+    Q(output_of_lpg_in_industry_transformation)

--- a/gqueries/output_elements/output_series/refinery_189/non_refinery_products_to_industry_transformation_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/non_refinery_products_to_industry_transformation_in_sankey.gql
@@ -1,0 +1,16 @@
+# Query for refinery sankey: connection between import of crude oil and industry transformation
+
+- unit = PJ
+- query =
+    SUM(
+      Q(input_of_ammonia_in_industry_transformation),
+      Q(input_of_electricity_in_industry_transformation),
+      Q(input_of_greengas_in_industry_transformation),
+      Q(input_of_hydrogen_in_industry_transformation),
+      Q(input_of_methanol_in_industry_transformation),
+      Q(input_of_natural_gas_in_industry_transformation),
+      Q(input_of_not_defined_in_industry_transformation),
+      Q(input_of_waste_mix_in_industry_transformation),
+      Q(input_of_wood_pellets_in_industry_transformation)
+    )
+

--- a/gqueries/output_elements/output_series/refinery_189/oil_products_industry_transformation_to_distribution_in_sankey.gql
+++ b/gqueries/output_elements/output_series/refinery_189/oil_products_industry_transformation_to_distribution_in_sankey.gql
@@ -1,0 +1,4 @@
+# Query for refinery sankey: connection between refinery and distribution of oil products
+
+- unit = PJ
+- query = Q(output_of_crude_oil_in_industry_transformation)


### PR DESCRIPTION
Goes together with:

Fixes  [ETModel issue #4330](https://github.com/quintel/etmodel/issues/4330)

This PR aims to add the industry transformation flows to the refinery sankey.
It does this by showing the inflow of oil and the aggregate carrier 'non-refinery' products. 
This consists of all carriers that are not classified as oil products. 

It also shows the outflow of refinery products from the industry transformation products.

