### PR TITLE
Fixing fossil gas share in national network gas grid

### DIFF
--- a/gqueries/general/shares/share_of_fossil_gas_in_gas_network.gql
+++ b/gqueries/general/shares/share_of_fossil_gas_in_gas_network.gql
@@ -1,3 +1,3 @@
 - query = 
-        1 - V(energy_national_gas_network_natural_gas, sustainability_share)
+        1 - Q(share_of_greengas_in_gas_network)
 - unit = factor


### PR DESCRIPTION
This PR fixes the fossil gas share in gas network query. 
Before, this query could generate incorrect values due to a bug in the circularity calculations of the transformation nodes. 
The greengas flow to the national network gas node could be set to zero in the recursive factors. 
This lead to the sustainability share of the node to be also set to zero.

This new calculation approach calculates the share based on the share_of_greengas_in_gas_network, which in turn is based on the input conversion of greengas, so the recursive factors are not used. 

To-DO: Create issue in ETEngine for the recursive factor bug.