### PR TITLE
Add detailed CO2 emissions queries for the industry sector

### DIFF
--- a/gqueries/general/co2/industry/captured_co2_emissions_in_industry.gql
+++ b/gqueries/general/co2/industry/captured_co2_emissions_in_industry.gql
@@ -1,0 +1,13 @@
+# This query gives the captured CO2 emissions in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        MV(
+          MG(captured_energetic_emissions_industry),
+          demand
+        )
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_ammonia_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_ammonia_in_industry_energetic.gql
@@ -1,0 +1,35 @@
+# This query gives CO2 emissions from energetic use of ammonia in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "ammonia_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "ammonia_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_biomass_products_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_biomass_products_in_industry_energetic.gql
@@ -1,0 +1,36 @@
+# This query gives CO2 emissions from energetic use of biomass products in industry
+# Note: this query does not include all biomass products. Depends on etsource#2781.
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "wood_pellets_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "wood_pellets_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_coal_and_coal_products_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_coal_and_coal_products_in_industry_energetic.gql
@@ -1,0 +1,35 @@
+# This query gives CO2 emissions from energetic use of coal and coal products in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "coal_input_conversion > 0.0 || cokes_input_conversion > 0.0 || coal_gas_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "coal_input_conversion > 0.0 || cokes_input_conversion > 0.0 || coal_gas_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_electricity_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_electricity_in_industry_energetic.gql
@@ -1,0 +1,35 @@
+# This query gives CO2 emissions from energetic use of electricity in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "electricity_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "electricity_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_hydrogen_carriers_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_hydrogen_carriers_in_industry_energetic.gql
@@ -1,0 +1,35 @@
+# This query gives CO2 emissions from energetic use of hydrogen carriers in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "hydrogen_input_conversion > 0.0 || liquid_hydrogen_input_conversion > 0.0 || lohc_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "hydrogen_input_conversion > 0.0 || liquid_hydrogen_input_conversion > 0.0 || lohc_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_methanol_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_methanol_in_industry_energetic.gql
@@ -1,0 +1,35 @@
+# This query gives CO2 emissions from energetic use of methanol in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "methanol_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "methanol_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_natural_gas_and_derivatives_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_natural_gas_and_derivatives_in_industry_energetic.gql
@@ -1,0 +1,36 @@
+# This query gives CO2 emissions from energetic use of natural gas and derivatives in industry
+# Note: this query does not include all natural gas products. Depends on etsource#2781.
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "network_gas_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "network_gas_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_oil_and_oil_products_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_oil_and_oil_products_in_industry_energetic.gql
@@ -1,0 +1,36 @@
+# This query gives CO2 emissions from energetic use of oil and derivatives in industry
+# Note: this query does not include all oil products. Depends on etsource#2781.
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "crude_oil_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "crude_oil_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt

--- a/gqueries/general/co2/industry/primary_co2_emissions_of_steam_hot_water_in_industry_energetic.gql
+++ b/gqueries/general/co2/industry/primary_co2_emissions_of_steam_hot_water_in_industry_energetic.gql
@@ -1,0 +1,35 @@
+# This query gives CO2 emissions from energetic use of steam hot water in industry
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_primary),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "steam_hot_water_input_conversion > 0.0"
+          ),
+          primary_co2_emission
+        ),
+        V(
+          FILTER(
+            INTERSECTION(
+              INTERSECTION(
+                G(co2_emissions_refinery_products),
+                SECTOR(industry)
+              ),
+              USE(energetic)
+            ),
+            "steam_hot_water_input_conversion > 0.0"
+          ),
+          "demand * weighted_carrier_co2_per_mj"
+        ),
+      ),
+      BILLIONS
+    )
+- unit = mt


### PR DESCRIPTION
The chart "Total CO2 emissions" includes emissions for the industry, which refers to the query `primary_co2_of_industry`:

```
- query =
    DIVIDE(
      SUM(
        V(
          INTERSECTION(
            INTERSECTION(
              G(co2_emissions_primary),
              SECTOR(industry)),
            USE(energetic)),
          primary_co2_emission),
        V(
          INTERSECTION(
            G(co2_emissions_refinery_products),
            SECTOR(industry)),
          "demand * weighted_carrier_co2_per_mj"),
        NEG(
          SUM(
            MV(
              MG(captured_energetic_emissions_industry),
              demand)
            )
          )
        ),
      BILLIONS)
```

In this PR I have broken down this query into queries per carrier, including a separate query for the captured emissions. These queries are added on request to give a **quick** estimate of direct emissions (for carriers like coal etc.) and indirect emissions (for carriers like hydrogen etc.).

A completely calculation of scope 1 and 2 emissions would require a dedicated project. I have therefore taken the liberty to simplify the aggregation of oil, biomass and natural gas carriers to crude_oil, wood_pellets and network_gas respectively.