### PR TITLE
Align hourly and annual heat network for DAC

### DIFF
--- a/graphs/energy/edges/energy/energy_distribution_ht_steam_hot_water-energy_direct_air_capture_co2_electricity@steam_hot_water.ad
+++ b/graphs/energy/edges/energy/energy_distribution_ht_steam_hot_water-energy_direct_air_capture_co2_electricity@steam_hot_water.ad
@@ -1,3 +1,3 @@
 - type = share
 - reversed = false
-- groups = [final_demand]
+- groups = [final_demand, ht_heat]

--- a/graphs/energy/nodes/energy/energy_direct_air_capture_co2_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_direct_air_capture_co2_electricity.ad
@@ -7,7 +7,7 @@
 - from_molecules.conversion = 7.0
 - input.steam_hot_water = 0.857142857
 - input.electricity = 0.142857143
-- heat_network_mt.group = flat
-- heat_network_mt.type = consumer
+- heat_network_ht.group = flat
+- heat_network_ht.type = consumer
 
 ~ demand = 0.0


### PR DESCRIPTION
This solves part of #3080. The DAC was connected to the HT heat network in the energy graph, but had `heat_network_mt` attributes. This caused a misalignment between annual and hourly balancing in the model. To re-align this, the DAC has been added to `heat_network_ht`, because the input temperature is assumed to be 100 degrees Celcius.

In addition, the `ht_heat` final demand group is added to the edge to the DAC, in order for the energy sector heat demand to show up in the Sankey.