### PR TITLE
Removing greengas flows from biomass to heat conversion query

### DIFF
--- a/gqueries/general/conversion/heat/conversion_from_carrier_to_heat/conversion_from_biomass_products_to_heat.gql
+++ b/gqueries/general/conversion/heat/conversion_from_carrier_to_heat/conversion_from_biomass_products_to_heat.gql
@@ -9,13 +9,6 @@
       Q(conversion_from_wood_pellets_to_heat),
       Q(conversion_from_bio_lng_to_heat),
       PRODUCT(
-        PRODUCT(
-          Q(conversion_from_gas_power_fuelmix_to_heat),
-          V(energy_mixer_for_gas_power_fuel, network_gas_input_conversion)
-        ),
-        Q(share_of_sustainable_gas_in_gas_network)
-      ),
-      PRODUCT(
         Q(conversion_from_gas_power_fuelmix_to_heat),
         V(energy_mixer_for_gas_power_fuel, bio_oil_input_conversion)
       )

--- a/gqueries/general/conversion/heat/conversion_from_carrier_to_heat/conversion_from_biomass_products_to_heat.gql
+++ b/gqueries/general/conversion/heat/conversion_from_carrier_to_heat/conversion_from_biomass_products_to_heat.gql
@@ -8,8 +8,6 @@
       Q(conversion_from_bio_oil_to_heat),
       Q(conversion_from_wood_pellets_to_heat),
       Q(conversion_from_bio_lng_to_heat),
-      PRODUCT(Q(conversion_from_network_gas_to_heat),Q(share_of_sustainable_gas_in_gas_network)),
-      PRODUCT(Q(conversion_from_compressed_network_gas_to_heat),Q(share_of_sustainable_gas_in_gas_network)),
       PRODUCT(
         PRODUCT(
           Q(conversion_from_gas_power_fuelmix_to_heat),


### PR DESCRIPTION
This PR removes greengas from the biomass to heat query. 
With the addition of the network gas conversion step in the energy flow overview sankey, we had a double count in the flows of greengas to heat production. This flow is also counted via the biomass products --> network gas --> Heat flows. 

Closes #3159 