### PR TITLE
Add installed capacity queries for DSR in industry

### DIFF
--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_chemical_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_chemical_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_chemical_dsr_load_shifting_electricity,
+      "availability * merit_order.input_capacity_from_share * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_metal_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_metal_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_metal_dsr_load_shifting_electricity,
+      "availability * merit_order.input_capacity_from_share * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_other_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_other_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_other_dsr_load_shifting_electricity,
+      "availability * merit_order.input_capacity_from_share * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_other_ict_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_increase_capacity_industry_final_demand_for_other_ict_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_other_ict_dsr_load_shifting_electricity,
+      "availability * merit_order.input_capacity_from_share * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_chemical_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_chemical_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_chemical_dsr_load_shifting_electricity,
+      "availability * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_metal_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_metal_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_metal_dsr_load_shifting_electricity,
+      "availability * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_other_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_other_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_other_dsr_load_shifting_electricity,
+      "availability * electricity_output_capacity"
+    )
+- unit = MW

--- a/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_other_ict_dsr_load_shifting_electricity.gql
+++ b/gqueries/general/capacity/installed_capacity/electricity/installed_load_reduction_capacity_industry_final_demand_for_other_ict_dsr_load_shifting_electricity.gql
@@ -1,0 +1,6 @@
+- query =
+    V(
+      industry_final_demand_for_other_ict_dsr_load_shifting_electricity,
+      "availability * electricity_output_capacity"
+    )
+- unit = MW


### PR DESCRIPTION
Adds input (load increase) and output (load reduction) capacity queries for DSR in the industry. These queries are added to the general folder to be queried by API users.