### PR TITLE
Emmen 2019 dataset update fix

### DIFF
--- a/datasets/GM0114_emmen/graph_values.yml
+++ b/datasets/GM0114_emmen/graph_values.yml
@@ -650,8 +650,8 @@ industry_chp_engine_gas_power_fuelmix:
 industry_chp_turbine_gas_power_fuelmix:
   demand: 3454.0
   output:
-    :steam_hot_water: 0.6804000000000001
-    :electricity: 0.2895
+    :steam_hot_water: 0.6803705800000001
+    :electricity: 0.2895194
   full_load_hours: 3200.0
 industry_chp_turbine_hydrogen:
   demand: 0.0


### PR DESCRIPTION
This PR fixes the industry gas turbine CHP conversion efficiences. The corresponding data migration in ETLocal lists these figures with more decimal figures than is currently visible in the dataset.