### PR TITLE
Splitting non-energetic and delayed emissions in co2 chart

### DIFF
--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/primary_co2_of_delayed_emissions.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/primary_co2_of_delayed_emissions.gql
@@ -1,0 +1,13 @@
+# Includes non_energetic emissions from the fertilizer industry (SMR),
+# non-energetic hydrogen final demand, non-energetic ammonia final demand and
+# 'delayed' emissions in molecules_other_utilisation_co2 node
+# More non_energetic emissions may be added in the future
+
+- unit = mt
+- query =
+    DIVIDE(
+        MV(
+          molecules_other_utilisation_delayed_emitted_co2,
+          demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/primary_co2_of_industry.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/primary_co2_of_industry.gql
@@ -1,3 +1,8 @@
+# Within the co2_emissions_refinery_products the node industry_final_demand_methanol_non_energetic is queried. 
+# This node should actually be in query : primary_co2_of_non_energetic_and_delayed_emissions.
+# the primary CO2 emissions will at the moment always be 0 since its free_co2_factor is 1 (no C atoms will be released in non-energetic use of methanol). 
+# For now, there is no situation where we have nodes with group co2_emissions_refinery_products with non-energetic use where primary CO2 emissions should be taken into account.
+
 - unit = mt
 - query =
     DIVIDE(

--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/primary_co2_of_non_energetic.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/primary_co2_of_non_energetic.gql
@@ -2,6 +2,7 @@
 # non-energetic hydrogen final demand, non-energetic ammonia final demand and
 # 'delayed' emissions in molecules_other_utilisation_co2 node
 # More non_energetic emissions may be added in the future
+# non-energetic methanol is not (yet) included in this query. At the moment this is queried in the query primary_co2_of_industry, since the free_co2_factor of the node industry_final_demand_methanol_non_energetic is 1.0.
 
 - unit = mt
 - query =
@@ -14,9 +15,6 @@
               SECTOR(industry)),
             USE(non_energetic)),
           primary_co2_emission),
-        MV(
-          molecules_other_utilisation_delayed_emitted_co2,
-          demand),
         NEG(
           SUM(
             MV(

--- a/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/total_net_co2_emissions.gql
+++ b/gqueries/output_elements/output_series/vertical_bar_46_co2_emissions/total_net_co2_emissions.gql
@@ -8,7 +8,8 @@
       Q(primary_co2_of_energy),
       Q(primary_co2_of_households),
       Q(primary_co2_of_industry),
-      Q(primary_co2_of_non_energetic_and_delayed_emissions),
+      Q(primary_co2_of_non_energetic),
+      Q(primary_co2_of_delayed_emissions),
       Q(primary_co2_of_other),
       Q(primary_co2_of_transport)
     )

--- a/graphs/energy/nodes/industry/industry_final_demand_methanol_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_final_demand_methanol_non_energetic.ad
@@ -1,6 +1,7 @@
 # Methanol is treated as a refinery product, since it can be produced synthetically
 # The primary emissions of the hydrogen and electricity required to produce the synthetic
 # methanol, are allocated to the relevant synthetic production nodes.
+# In the future we might want to attribute these emissions to the relevant final demand groups, the free_co2_factor should be set to 0.0 at that time.
 
 - use = non_energetic
 - groups = [final_demand_group, non_energetic_use, co2_emissions_refinery_products]


### PR DESCRIPTION
This PR splits the non-energetic and delayed emissions in the co2 chart. 
In addition, some documentation about the modeling choices cocnerning non energetic final demand of methanol is added.

Goes together with: 
https://github.com/quintel/documentation/pull/213
