### PR TITLE
Adding turk queries for hourly network gas

### DIFF
--- a/gqueries/mechanical_turk/mekko/turk_mekko_of_network_gas_network_total_demand.gql
+++ b/gqueries/mechanical_turk/mekko/turk_mekko_of_network_gas_network_total_demand.gql
@@ -1,0 +1,9 @@
+- query =
+    DIVIDE(
+      PRODUCT(
+        SUM(Q(network_gas_demand_input_curve)),
+        MJ_PER_MWH
+      ),
+      BILLIONS
+    )
+- unit = PJ

--- a/gqueries/mechanical_turk/mekko/turk_mekko_of_network_gas_network_total_supply.gql
+++ b/gqueries/mechanical_turk/mekko/turk_mekko_of_network_gas_network_total_supply.gql
@@ -1,0 +1,9 @@
+- query =
+    DIVIDE(
+      PRODUCT(
+        SUM(Q(network_gas_production_output_curve)),
+        MJ_PER_MWH
+      ),
+      BILLIONS
+    )
+- unit = PJ


### PR DESCRIPTION
This PR adds queries for the network gas mekko specs. 
These queries are based on the network_gas_demand_input_curve, and network_gas_production_output_curve queries to compare the annual demand and supply with the annual demand and supply.

In support of:
https://github.com/quintel/mechanical_turk/pull/189