### PR TITLE
Update external coupling inputs technical lifetime min and start value

### DIFF
--- a/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_aluminium/external_coupling_industry_metal_aluminium_technical_lifetime.ad
@@ -6,8 +6,8 @@
     )
 - priority = 0
 - max_value = 100.0
-- min_value = 0.0
-- start_value = 0.0
+- min_value = 1.0
+- start_value_gql = present:V(industry_aluminium_external_coupling_node, technical_lifetime)
 - step_value = 1.0
 - unit = year
 - update_period = future

--- a/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_other/external_coupling_industry_metal_other_metals_technical_lifetime.ad
@@ -6,8 +6,8 @@
     )
 - priority = 0
 - max_value = 100.0
-- min_value = 0.0
-- start_value = 0.0
+- min_value = 1.0
+- start_value_gql = present:V(industry_other_metals_external_coupling_node, technical_lifetime)
 - step_value = 1.0
 - unit = year
 - update_period = future

--- a/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_technical_lifetime.ad
+++ b/inputs/modules/external_coupling/industry_metal_steel/external_coupling_industry_metal_steel_technical_lifetime.ad
@@ -3,12 +3,14 @@
       V(
         industry_steel_external_coupling_node,
         industry_steel_external_coupling_node_production
-      ), technical_lifetime, USER_INPUT()
+      ),
+      technical_lifetime,
+      USER_INPUT()
     )
 - priority = 0
 - max_value = 100.0
-- min_value = 0.0
-- start_value = 0.0
+- min_value = 1.0
+- start_value_gql = present:V(industry_steel_external_coupling_node, technical_lifetime)
 - step_value = 1.0
 - unit = year
 - update_period = future


### PR DESCRIPTION
The min and start value of the external coupling inputs that set technical lifetime are set to non-zero value. This avoids the inputs to be set to zero, which breaks the `dashboard_total_costs` query in loading the ETM front-end. 