### PR TITLE
Removing buildings from household behaviour input

### DIFF
--- a/inputs/demand/households/households_misc/households_behavior_standby_killer_turn_off_appliances.ad
+++ b/inputs/demand/households/households_misc/households_behavior_standby_killer_turn_off_appliances.ad
@@ -3,14 +3,14 @@
       V(
         households_appliances_television_electricity,
         households_appliances_computer_media_electricity
-        ),
-        preset_demand, 
-        NEG(
-          DIVIDE(
-            USER_INPUT()
-            ,V(4.54)
-            )
-          )
+      ),
+      preset_demand, 
+      NEG(
+        DIVIDE(
+          USER_INPUT(),
+          V(4.54)
+        )
+      )
     )
 - priority = 0
 - max_value = 100.0

--- a/inputs/demand/households/households_misc/households_behavior_standby_killer_turn_off_appliances.ad
+++ b/inputs/demand/households/households_misc/households_behavior_standby_killer_turn_off_appliances.ad
@@ -1,4 +1,17 @@
-- query = UPDATE(V(households_appliances_television_electricity,households_appliances_computer_media_electricity,buildings_useful_demand_for_appliances), preset_demand, NEG(DIVIDE(USER_INPUT(),V(4.54))))
+- query = 
+    UPDATE(
+      V(
+        households_appliances_television_electricity,
+        households_appliances_computer_media_electricity
+        ),
+        preset_demand, 
+        NEG(
+          DIVIDE(
+            USER_INPUT()
+            ,V(4.54)
+            )
+          )
+    )
 - priority = 0
 - max_value = 100.0
 - min_value = 0.0


### PR DESCRIPTION
This PR acts as a 'quick fix' for #3193 by removing the buildings from the household appliances slider. 
In the future we might want to evaluate the necessity of this slider.

Assigned to @mabijkerk since he opened the issue, re-assign at will.

