### PR TITLE
Pv curtailment

### DIFF
--- a/inputs/flexibility/weather/settings_weather_curve_set.ad
+++ b/inputs/flexibility/weather/settings_weather_curve_set.ad
@@ -32,11 +32,11 @@
       cool_factor = 1.0 + 0.5669449 * x + 0.1598105 * x**2 + 0.0253755 * x**3 + 0.00163210 * x**4;
       original_number_of_solar_parks = V(energy_power_solar_pv_solar_radiation, number_of_units);
 
-      solar_original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
-      solar_households_nou = V(households_solar_pv_solar_radiation, number_of_units);
-      solar_buildings_nou = V(buildings_solar_pv_solar_radiation, number_of_units);
-      solar_offshore_nou = V(energy_power_solar_pv_offshore, number_of_units);
-      solar_battery_nou = V(energy_battery_solar_pv_solar_radiation,number_of_units);
+      orginal_number_of_power_solar_pv = V(energy_power_solar_pv_solar_radiation, number_of_units);
+      orginal_number_of_households_solar_pv = V(households_solar_pv_solar_radiation, number_of_units);
+      orginal_number_of_buildings_solar_pv = V(buildings_solar_pv_solar_radiation, number_of_units);
+      orginal_number_of_power_solar_pv_offshore = V(energy_power_solar_pv_offshore, number_of_units);
+      orginal_number_of_battery_solar_pv = V(energy_battery_solar_pv_solar_radiation,number_of_units);
       original_number_of_wind_turbine_coastal = V(energy_power_wind_turbine_coastal, number_of_units);
       original_number_of_wind_turbine_inland = V(energy_power_wind_turbine_inland, number_of_units);
       original_number_of_wind_turbine_offshore = V(energy_power_wind_turbine_offshore, number_of_units);
@@ -93,31 +93,31 @@
           preset_demand_by_electricity_production,
           V(energy_power_hybrid_wind_turbine_offshore, production_based_on_number_of_units)
         ),
-        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, solar_original_nou),
+        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, orginal_number_of_power_solar_pv),
         UPDATE(
           V(energy_power_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,
           V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
            ),
-        UPDATE(V(households_solar_pv_solar_radiation), number_of_units, solar_households_nou),
+        UPDATE(V(households_solar_pv_solar_radiation), number_of_units, orginal_number_of_households_solar_pv),
         UPDATE(
           V(households_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,
           V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
           ),
-        UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, solar_buildings_nou),
+        UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, orginal_number_of_buildings_solar_pv),
         UPDATE(
           V(buildings_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,
           V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
           ),
-        UPDATE(V(energy_power_solar_pv_offshore), number_of_units, solar_offshore_nou),
+        UPDATE(V(energy_power_solar_pv_offshore), number_of_units, orginal_number_of_power_solar_pv_offshore),
         UPDATE(
           V(energy_power_solar_pv_offshore),
             preset_demand_by_electricity_production,
           V(energy_power_solar_pv_offshore, production_based_on_number_of_units)
           ),
-        UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, solar_battery_nou),
+        UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, orginal_number_of_battery_solar_pv),
         UPDATE(
           V(energy_battery_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,

--- a/inputs/flexibility/weather/settings_weather_curve_set.ad
+++ b/inputs/flexibility/weather/settings_weather_curve_set.ad
@@ -31,6 +31,12 @@
       heat_factor = 1.0 - 0.1507409694 * x;
       cool_factor = 1.0 + 0.5669449 * x + 0.1598105 * x**2 + 0.0253755 * x**3 + 0.00163210 * x**4;
       original_number_of_solar_parks = V(energy_power_solar_pv_solar_radiation, number_of_units);
+
+      solar_original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+      solar_households_nou = V(households_solar_pv_solar_radiation, number_of_units);
+      solar_buildings_nou = V(buildings_solar_pv_solar_radiation, number_of_units);
+      solar_offshore_nou = V(energy_power_solar_pv_offshore, number_of_units);
+      solar_battery_nou = V(energy_battery_solar_pv_solar_radiation,number_of_units);
       original_number_of_wind_turbine_coastal = V(energy_power_wind_turbine_coastal, number_of_units);
       original_number_of_wind_turbine_inland = V(energy_power_wind_turbine_inland, number_of_units);
       original_number_of_wind_turbine_offshore = V(energy_power_wind_turbine_offshore, number_of_units);
@@ -86,7 +92,37 @@
           V(energy_power_hybrid_wind_turbine_offshore),
           preset_demand_by_electricity_production,
           V(energy_power_hybrid_wind_turbine_offshore, production_based_on_number_of_units)
-        )
+        ),
+        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, solar_original_nou),
+        UPDATE(
+          V(energy_power_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
+           ),
+        UPDATE(V(households_solar_pv_solar_radiation), number_of_units, solar_households_nou),
+        UPDATE(
+          V(households_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
+          ),
+        UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, solar_buildings_nou),
+        UPDATE(
+          V(buildings_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
+          ),
+        UPDATE(V(energy_power_solar_pv_offshore), number_of_units, solar_offshore_nou),
+        UPDATE(
+          V(energy_power_solar_pv_offshore),
+            preset_demand_by_electricity_production,
+          V(energy_power_solar_pv_offshore, production_based_on_number_of_units)
+          ),
+        UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, solar_battery_nou),
+        UPDATE(
+          V(energy_battery_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(energy_battery_solar_pv_solar_radiation, production_based_on_number_of_units)
+          )
       )
     }
   )

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
@@ -7,7 +7,11 @@
     IF(
       EQUALS(AREA(weather_curve_set), "default"),
       ->{
-        original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+        solar_original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+        solar_households_nou = V(households_solar_pv_solar_radiation, number_of_units);
+        solar_buildings_nou = V(buildings_solar_pv_solar_radiation, number_of_units);
+        solar_offshore_nou = V(energy_power_solar_pv_offshore, number_of_units);
+        solar_battery_nou = V(energy_battery_solar_pv_solar_radiation,number_of_units);
 
         share_2 =
             DIVIDE(
@@ -16,17 +20,47 @@
             );
 
         EACH(
-            UPDATE(V(energy_power_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-            UPDATE(V(energy_hydrogen_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-            UPDATE(V(energy_power_solar_pv_offshore), full_load_hours, USER_INPUT()),
-            UPDATE(V(energy_battery_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-            UPDATE(V(buildings_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-            UPDATE(V(households_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-            UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, original_nou),
             UPDATE(
-            V(energy_power_solar_pv_solar_radiation),
-            preset_demand_by_electricity_production,
-            V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
+              V(
+                energy_power_solar_pv_solar_radiation,
+                energy_hydrogen_solar_pv_solar_radiation,
+                energy_power_solar_pv_offshore,
+                energy_battery_solar_pv_solar_radiation,
+                buildings_solar_pv_solar_radiation,
+                households_solar_pv_solar_radiation
+                ),
+                full_load_hours,
+                USER_INPUT()
+              ),
+            UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, solar_original_nou),
+            UPDATE(
+              V(energy_power_solar_pv_solar_radiation),
+              preset_demand_by_electricity_production,
+              V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
+            ),
+            UPDATE(V(households_solar_pv_solar_radiation), number_of_units, solar_households_nou),
+            UPDATE(
+              V(households_solar_pv_solar_radiation),
+              preset_demand_by_electricity_production,
+              V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
+            ),
+            UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, solar_buildings_nou),
+            UPDATE(
+              V(buildings_solar_pv_solar_radiation),
+              preset_demand_by_electricity_production,
+              V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
+            ),
+            UPDATE(V(energy_power_solar_pv_offshore), number_of_units, solar_offshore_nou),
+            UPDATE(
+              V(energy_power_solar_pv_offshore),
+              preset_demand_by_electricity_production,
+              V(energy_power_solar_pv_offshore, production_based_on_number_of_units)
+            ),
+            UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, solar_battery_nou),
+            UPDATE(
+              V(energy_battery_solar_pv_solar_radiation),
+              preset_demand_by_electricity_production,
+              V(energy_battery_solar_pv_solar_radiation, production_based_on_number_of_units)
             ),
             UPDATE(AREA(), solar_pv_profile_1_share, (1 - share_2)),
             UPDATE(AREA(), solar_pv_profile_2_share, share_2)

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation.ad
@@ -7,11 +7,11 @@
     IF(
       EQUALS(AREA(weather_curve_set), "default"),
       ->{
-        solar_original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
-        solar_households_nou = V(households_solar_pv_solar_radiation, number_of_units);
-        solar_buildings_nou = V(buildings_solar_pv_solar_radiation, number_of_units);
-        solar_offshore_nou = V(energy_power_solar_pv_offshore, number_of_units);
-        solar_battery_nou = V(energy_battery_solar_pv_solar_radiation,number_of_units);
+        orginal_number_of_power_solar_pv = V(energy_power_solar_pv_solar_radiation, number_of_units);
+        orginal_number_of_households_solar_pv = V(households_solar_pv_solar_radiation, number_of_units);
+        orginal_number_of_buildings_solar_pv = V(buildings_solar_pv_solar_radiation, number_of_units);
+        orginal_number_of_power_solar_pv_offshore = V(energy_power_solar_pv_offshore, number_of_units);
+        orginal_number_of_battery_solar_pv = V(energy_battery_solar_pv_solar_radiation,number_of_units);
 
         share_2 =
             DIVIDE(
@@ -32,31 +32,31 @@
                 full_load_hours,
                 USER_INPUT()
               ),
-            UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, solar_original_nou),
+            UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, orginal_number_of_power_solar_pv),
             UPDATE(
               V(energy_power_solar_pv_solar_radiation),
               preset_demand_by_electricity_production,
               V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
             ),
-            UPDATE(V(households_solar_pv_solar_radiation), number_of_units, solar_households_nou),
+            UPDATE(V(households_solar_pv_solar_radiation), number_of_units, orginal_number_of_households_solar_pv),
             UPDATE(
               V(households_solar_pv_solar_radiation),
               preset_demand_by_electricity_production,
               V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
             ),
-            UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, solar_buildings_nou),
+            UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, orginal_number_of_buildings_solar_pv),
             UPDATE(
               V(buildings_solar_pv_solar_radiation),
               preset_demand_by_electricity_production,
               V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
             ),
-            UPDATE(V(energy_power_solar_pv_offshore), number_of_units, solar_offshore_nou),
+            UPDATE(V(energy_power_solar_pv_offshore), number_of_units, orginal_number_of_power_solar_pv_offshore),
             UPDATE(
               V(energy_power_solar_pv_offshore),
               preset_demand_by_electricity_production,
               V(energy_power_solar_pv_offshore, production_based_on_number_of_units)
             ),
-            UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, solar_battery_nou),
+            UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, orginal_number_of_battery_solar_pv),
             UPDATE(
               V(energy_battery_solar_pv_solar_radiation),
               preset_demand_by_electricity_production,

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation_user_curve.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation_user_curve.ad
@@ -5,11 +5,11 @@
 # to prevent interpolation.
 
 - query =
-    solar_original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
-    solar_households_nou = V(households_solar_pv_solar_radiation, number_of_units);
-    solar_buildings_nou = V(buildings_solar_pv_solar_radiation, number_of_units);
-    solar_offshore_nou = V(energy_power_solar_pv_offshore, number_of_units);
-    solar_battery_nou = V(energy_battery_solar_pv_solar_radiation,number_of_units);
+      orginal_number_of_power_solar_pv = V(energy_power_solar_pv_solar_radiation, number_of_units);
+      orginal_number_of_households_solar_pv = V(households_solar_pv_solar_radiation, number_of_units);
+      orginal_number_of_buildings_solar_pv = V(buildings_solar_pv_solar_radiation, number_of_units);
+      orginal_number_of_power_solar_pv_offshore = V(energy_power_solar_pv_offshore, number_of_units);
+      orginal_number_of_battery_solar_pv = V(energy_battery_solar_pv_solar_radiation,number_of_units);
 
     EACH(
         UPDATE(
@@ -24,31 +24,31 @@
             full_load_hours,
             USER_INPUT()
           ),
-        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, solar_original_nou),
+        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, orginal_number_of_power_solar_pv),
         UPDATE(
           V(energy_power_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,
           V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
            ),
-        UPDATE(V(households_solar_pv_solar_radiation), number_of_units, solar_households_nou),
+        UPDATE(V(households_solar_pv_solar_radiation), number_of_units, orginal_number_of_households_solar_pv),
         UPDATE(
           V(households_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,
           V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
           ),
-        UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, solar_buildings_nou),
+        UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, orginal_number_of_buildings_solar_pv),
         UPDATE(
           V(buildings_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,
           V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
           ),
-        UPDATE(V(energy_power_solar_pv_offshore), number_of_units, solar_offshore_nou),
+        UPDATE(V(energy_power_solar_pv_offshore), number_of_units, orginal_number_of_power_solar_pv_offshore),
         UPDATE(
           V(energy_power_solar_pv_offshore),
             preset_demand_by_electricity_production,
           V(energy_power_solar_pv_offshore, production_based_on_number_of_units)
           ),
-        UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, solar_battery_nou),
+        UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, orginal_number_of_battery_solar_pv),
         UPDATE(
           V(energy_battery_solar_pv_solar_radiation),
             preset_demand_by_electricity_production,

--- a/inputs/full_load_hours/flh_of_solar_pv_solar_radiation_user_curve.ad
+++ b/inputs/full_load_hours/flh_of_solar_pv_solar_radiation_user_curve.ad
@@ -5,20 +5,55 @@
 # to prevent interpolation.
 
 - query =
-    original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+    solar_original_nou = V(energy_power_solar_pv_solar_radiation, number_of_units);
+    solar_households_nou = V(households_solar_pv_solar_radiation, number_of_units);
+    solar_buildings_nou = V(buildings_solar_pv_solar_radiation, number_of_units);
+    solar_offshore_nou = V(energy_power_solar_pv_offshore, number_of_units);
+    solar_battery_nou = V(energy_battery_solar_pv_solar_radiation,number_of_units);
+
     EACH(
-        UPDATE(V(energy_power_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-        UPDATE(V(energy_hydrogen_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-        UPDATE(V(energy_power_solar_pv_offshore), full_load_hours, USER_INPUT()),
-        UPDATE(V(energy_battery_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-        UPDATE(V(buildings_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-        UPDATE(V(households_solar_pv_solar_radiation), full_load_hours, USER_INPUT()),
-        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, original_nou),
         UPDATE(
-        V(energy_power_solar_pv_solar_radiation),
-        preset_demand_by_electricity_production,
-        V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
-        ),
+          V(
+            energy_power_solar_pv_solar_radiation,
+            energy_hydrogen_solar_pv_solar_radiation,
+            energy_power_solar_pv_offshore,
+            energy_battery_solar_pv_solar_radiation
+            buildings_solar_pv_solar_radiation,
+            households_solar_pv_solar_radiation
+            ),
+            full_load_hours,
+            USER_INPUT()
+          ),
+        UPDATE(V(energy_power_solar_pv_solar_radiation), number_of_units, solar_original_nou),
+        UPDATE(
+          V(energy_power_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(energy_power_solar_pv_solar_radiation, production_based_on_number_of_units)
+           ),
+        UPDATE(V(households_solar_pv_solar_radiation), number_of_units, solar_households_nou),
+        UPDATE(
+          V(households_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
+          ),
+        UPDATE(V(buildings_solar_pv_solar_radiation), number_of_units, solar_buildings_nou),
+        UPDATE(
+          V(buildings_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
+          ),
+        UPDATE(V(energy_power_solar_pv_offshore), number_of_units, solar_offshore_nou),
+        UPDATE(
+          V(energy_power_solar_pv_offshore),
+            preset_demand_by_electricity_production,
+          V(energy_power_solar_pv_offshore, production_based_on_number_of_units)
+          ),
+        UPDATE(V(energy_battery_solar_pv_solar_radiation), number_of_units, solar_battery_nou),
+        UPDATE(
+          V(energy_battery_solar_pv_solar_radiation),
+            preset_demand_by_electricity_production,
+          V(energy_battery_solar_pv_solar_radiation, production_based_on_number_of_units)
+          )
         UPDATE(AREA(), solar_pv_profile_1_share, 1.0),
         UPDATE(AREA(), solar_pv_profile_2_share, 0.0)
     )

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_buildings_solar_pv_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_buildings_solar_pv_solar_radiation.ad
@@ -9,7 +9,7 @@
       ),
       UPDATE(
         V(buildings_solar_pv_solar_radiation),
-        preset_demand,
+        preset_demand_by_electricity_production,
         V(buildings_solar_pv_solar_radiation, production_based_on_number_of_units)
       )
     )

--- a/inputs/supply/renewable_electricity/solar_power/capacity_of_households_solar_pv_solar_radiation.ad
+++ b/inputs/supply/renewable_electricity/solar_power/capacity_of_households_solar_pv_solar_radiation.ad
@@ -9,7 +9,7 @@
       ),
       UPDATE(
         V(households_solar_pv_solar_radiation),
-        preset_demand,
+        preset_demand_by_electricity_production,
         V(households_solar_pv_solar_radiation, production_based_on_number_of_units)
       )
     )


### PR DESCRIPTION
This PR closes #3199 by updating the capacity_of_buildings_solar_pv_solar_radiation and the capacity_of_households_solar_pv_solar_radiation.

In addition this PR partly solves #3002 by revising the flh inputs for the following nodes:

- households_solar_pv_solar_radiation
- buildings_solar_pv_solar_radiation
- energy_power_solar_pv_offshore
- energy_battery_solar_pv_solar_radiation

For energy_hydrogen_solar_pv_solar_radiation this issue still remains, since this producer is not in the preset_demand group. At the moment, this is not a great issue since dedicated hydrogen pv plants are not in any of the datasets.
