### PR TITLE
Omit outdated area attribute man_hours_per_man_year

### DIFF
--- a/datasets/RES03_regio_drenthe/RES03_regio_drenthe.derived.ad
+++ b/datasets/RES03_regio_drenthe/RES03_regio_drenthe.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0078
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 19600507.74
 - lv_net_costs_per_capacity_step = 18320.0

--- a/datasets/RES09_hart_van_brabant/RES09_hart_van_brabant.derived.ad
+++ b/datasets/RES09_hart_van_brabant/RES09_hart_van_brabant.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0078
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 20247272.75
 - lv_net_costs_per_capacity_step = 18320.0

--- a/datasets/RES12_metropoolregio_eindhoven/RES12_metropoolregio_eindhoven.derived.ad
+++ b/datasets/RES12_metropoolregio_eindhoven/RES12_metropoolregio_eindhoven.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0078
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 45513442.01
 - lv_net_costs_per_capacity_step = 18320.0

--- a/datasets/RES16_noord_holland_noord/RES16_noord_holland_noord.derived.ad
+++ b/datasets/RES16_noord_holland_noord/RES16_noord_holland_noord.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0078
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 25308502.970852
 - lv_net_costs_per_capacity_step = 18320.0

--- a/datasets/RES20_noord_oost_brabant/RES20_noord_oost_brabant.derived.ad
+++ b/datasets/RES20_noord_oost_brabant/RES20_noord_oost_brabant.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0078
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 28681088.54
 - lv_net_costs_per_capacity_step = 18320.0

--- a/datasets/RES28_west_brabant/RES28_west_brabant.derived.ad
+++ b/datasets/RES28_west_brabant/RES28_west_brabant.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 40934345.71
 - lv_net_costs_per_capacity_step = 18320.0

--- a/datasets/RES30_zeeland/RES30_zeeland.derived.ad
+++ b/datasets/RES30_zeeland/RES30_zeeland.derived.ad
@@ -38,7 +38,6 @@
 - co2_price = 0.0078
 - captured_biogenic_co2_price = 0.0078
 - offshore_ccs_potential_mt_per_year = 41.95
-- man_hours_per_man_year = 1800.0
 - lv_net_spare_capacity = 0.25
 - lv_net_total_costs_present = 20637377.84
 - lv_net_costs_per_capacity_step = 18320.0


### PR DESCRIPTION
Area attributed `man_hours_per_man_year` is outdated and not used anymore. Removed from the following datasets:
- RES03_regio_drenthe
- RES09_hart_van_brabant
- RES12_metropoolregio_eindhoven
- RES16_noord_holland_noord
- RES20_noord_oost_brabant
- RES28_west_brabant
- RES30_zeeland