### PR TITLE
Lower minimum value for buildings insulation inputs

### DIFF
--- a/inputs/demand/buildings/buildings_insulation/buildings_insulation_level_buildings_future.ad
+++ b/inputs/demand/buildings/buildings_insulation/buildings_insulation_level_buildings_future.ad
@@ -19,7 +19,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_buildings_future),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_buildings_future),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_buildings_future),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_buildings_future)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/buildings/buildings_insulation/buildings_insulation_level_buildings_present.ad
+++ b/inputs/demand/buildings/buildings_insulation/buildings_insulation_level_buildings_present.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_buildings_present),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_buildings_present),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_buildings_present),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_buildings_present)
 - step_value = 0.1
 - unit = kWh/m2


### PR DESCRIPTION
**Issue**
In Cyprus, the start value for buildings insulation is 24.34 kWh/m2. This is also the minimum value for Cyprus, because it is set to be the lower value of either the start value or 25.0 kWh/m2. The issue here is that this means that users are not able to reduce heat demand for buildings in Cyprus.

**Solution**
To fix the issue addressed above, the hardcoded minimum value is set to 10 kWh/m2. This should gives users enough room to reduce heat demand for buildings.

@kaskranenburgQ could you please verify that buildings insulation sliders can be set lower than 25 kWh/m2, to 10 kWh/m2 at the least? I was not able to test it on my local model.