### PR TITLE
Lower minimum value for households insulation inputs

### DIFF
--- a/inputs/demand/households/households_insulation/households_insulation_level_apartments_1945_1964.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_apartments_1945_1964.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_apartments_1945_1964),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_1945_1964),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_1945_1964),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_apartments_1945_1964)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_apartments_1965_1984.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_apartments_1965_1984.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_apartments_1965_1984),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_1965_1984),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_1965_1984),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_apartments_1965_1984)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_apartments_1985_2004.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_apartments_1985_2004.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_apartments_1985_2004),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_1985_2004),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_1985_2004),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_apartments_1985_2004)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_apartments_2005_present.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_apartments_2005_present.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_apartments_2005_present),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_2005_present),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_2005_present),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_apartments_2005_present)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_apartments_before_1945.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_apartments_before_1945.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_apartments_before_1945),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_before_1945),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_before_1945),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_apartments_before_1945)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_apartments_future.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_apartments_future.ad
@@ -19,7 +19,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_apartments_future),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_future),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_apartments_future),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_apartments_future)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_1945_1964.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_1945_1964.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_detached_houses_1945_1964),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_1945_1964),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_1945_1964),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_detached_houses_1945_1964)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_1965_1984.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_1965_1984.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_detached_houses_1965_1984),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_1965_1984),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_1965_1984),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_detached_houses_1965_1984)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_1985_2004.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_1985_2004.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_detached_houses_1985_2004),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_1985_2004),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_1985_2004),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_detached_houses_1985_2004)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_2005_present.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_2005_present.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_detached_houses_2005_present),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_2005_present),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_2005_present),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_detached_houses_2005_present)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_before_1945.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_before_1945.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_detached_houses_before_1945),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_before_1945),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_before_1945),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_detached_houses_before_1945)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_future.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_detached_houses_future.ad
@@ -19,7 +19,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_detached_houses_future),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_future),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_detached_houses_future),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_detached_houses_future)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_1945_1964.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_1945_1964.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1945_1964),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1945_1964),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1945_1964),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1945_1964)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_1965_1984.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_1965_1984.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1965_1984),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1965_1984),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1965_1984),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1965_1984)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_1985_2004.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_1985_2004.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1985_2004),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1985_2004),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1985_2004),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_semi_detached_houses_1985_2004)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_2005_present.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_2005_present.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_2005_present),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_2005_present),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_2005_present),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_semi_detached_houses_2005_present)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_before_1945.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_before_1945.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_before_1945),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_before_1945),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_before_1945),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_semi_detached_houses_before_1945)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_future.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_semi_detached_houses_future.ad
@@ -19,7 +19,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_1945_1964.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_1945_1964.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_terraced_houses_1945_1964),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_1945_1964),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_1945_1964),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_terraced_houses_1945_1964)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_1965_1984.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_1965_1984.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_terraced_houses_1965_1984),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_1965_1984),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_1965_1984),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_terraced_houses_1965_1984)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_1985_2004.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_1985_2004.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_terraced_houses_1985_2004),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_1985_2004),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_1985_2004),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_terraced_houses_1985_2004)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_2005_present.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_2005_present.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_terraced_houses_2005_present),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_2005_present),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_2005_present),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_terraced_houses_2005_present)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_before_1945.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_before_1945.ad
@@ -23,7 +23,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_terraced_houses_before_1945),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_before_1945),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_before_1945),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_terraced_houses_before_1945)
 - step_value = 0.1
 - unit = kWh/m2

--- a/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_future.ad
+++ b/inputs/demand/households/households_insulation/households_insulation_level_terraced_houses_future.ad
@@ -19,7 +19,7 @@
     )
 - priority = 1
 - max_value_gql = present:MAX(AREA(typical_useful_demand_for_space_heating_terraced_houses_future),500.0)
-- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_future),25.0)
+- min_value_gql = present:MIN(AREA(typical_useful_demand_for_space_heating_terraced_houses_future),10.0)
 - start_value_gql = present:AREA(typical_useful_demand_for_space_heating_terraced_houses_future)
 - step_value = 0.1
 - unit = kWh/m2


### PR DESCRIPTION
Similar to https://github.com/quintel/etsource/pull/3208, the minimum value for insulation sliders in Cyprus for households is not much lower than the default value. Therefore, users do not have a lot of leeway to reduce heat demand in Cyprus. As requested by a client this PR therefore lowers the minimum values to align with those in the buildings sector.