### PR TITLE
Remove green gas series in MYC to fix double-counting

### DIFF
--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_green_gas.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_green_gas.gql
@@ -1,8 +1,0 @@
-# Final demand of greengas carrier group
-
-- unit = MJ
-- query =
-    SUM(
-      V(G(final_demand_group), input_of_network_gas).sum * V(energy_national_gas_network_natural_gas,greengas_input_conversion),
-      V(G(final_demand_group), input_of_compressed_network_gas).sum * V(energy_national_gas_network_natural_gas,greengas_input_conversion)
-    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_natural_gas_and_derivatives.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_carrier/myc_final_demand_of_natural_gas_and_derivatives.gql
@@ -1,12 +1,4 @@
-# Final demand of the 'natural_gas_and_derivatives' (excl. green gas) carrier group
+# Final demand of the 'natural_gas_and_derivatives' carrier group
 
 - unit = MJ
-- query =
-    SUM(
-      SUM(V(G(final_demand_group), input_of_network_gas)) *
-      V(energy_national_gas_network_natural_gas,natural_gas_input_conversion),
-      SUM(V(G(final_demand_group), input_of_compressed_network_gas)) *
-      V(energy_national_gas_network_natural_gas,natural_gas_input_conversion),
-      SUM(V(G(final_demand_group), input_of_lng)),
-      SUM(V(G(final_demand_group), input_of_propane))
-    )
+- query = PRODUCT(Q(final_demand_of_natural_gas_and_derivatives), BILLIONS)

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_agriculture.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_agriculture) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_buildings.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_buildings) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_bunkers.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the green_gas carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_bunkers) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_energy.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_energy) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_energy_and_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_energy_and_other.gql
@@ -1,8 +1,0 @@
-# Energetic final demand of the 'green_gas' carrier group
-
-- unit = MJ
-- query =
-    SUM(
-      Q(myc_final_demand_of_green_gas_in_energy),
-      Q(myc_final_demand_of_green_gas_in_other)
-    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_households.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_households) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_industry.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_industry) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_other.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_other) * BILLIONS

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_green_gas_in_transport.gql
@@ -1,4 +1,0 @@
-# Energetic final demand of the 'greengas' carrier group
-
-- unit = MJ
-- query = Q(final_demand_of_greengas_in_transport) * BILLIONS


### PR DESCRIPTION
This PR removes the green gas series in the final demand per carrier and final demand per sector per carrier overviews in Collections. This PR includes:
- Removal of green gas series, locales and myc queries
- Updating final demand natural gas and derivatives query to also include green gas

Goes with https://github.com/quintel/multi-year-charts/pull/84

Solves https://github.com/quintel/multi-year-charts/issues/82