### PR TITLE
Adding queries for manual calculation of COP of HHP 

### DIFF
--- a/gqueries/general/heat/cop_manual_calculation/buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/buildings_space_heater_hybrid_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/buildings_space_heater_hybrid_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(buildings_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          buildings_space_heater_hybrid_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(buildings_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/households_space_heater_hybrid_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/households_space_heater_hybrid_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(households_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          households_space_heater_hybrid_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(households_space_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity, electricity_input_conversion)
+      ),
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/households_water_heater_hybrid_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/households_water_heater_hybrid_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(households_water_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          households_water_heater_hybrid_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(households_water_heater_hybrid_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP

--- a/gqueries/general/heat/cop_manual_calculation/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_cop_manual_calculation.gql
+++ b/gqueries/general/heat/cop_manual_calculation/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_cop_manual_calculation.gql
@@ -1,0 +1,13 @@
+- query =
+    IF(
+      V(households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity, electricity_input_conversion) == 0.0,
+      1.0,
+      DIVIDE(
+        V(
+          households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity,
+          "ambient_heat_input_conversion + electricity_input_conversion"
+        ),
+        V(households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity, electricity_input_conversion)
+      )
+    )
+- unit = COP


### PR DESCRIPTION
This PR adds queries to calculate the COP of Hybrid heat pumps "manually" via the yearly input flows of ambient heat and electricity. The underlying calculation formula is:

(S)COP = (ambient_heat_input_conversion + electricity_input_conversion)/ electricity_input_conversion. 

With the idea that we calculate the units of produced heat compared to the units of electricity necessary. 

The engine method for the calculation of COP's "coefficient_of_performance" which is used in the queries in the folder general/heat/cop  does not work correctly for hybrid heat pumps since the efficiency of the boiler component is not taken into account in it's calculation. 
For more information on this issue see https://github.com/quintel/etsource/issues/2706#issuecomment-2668508000.