### PR TITLE
Apply node group approach to final demand per sector per carrier queries for biofuels and oils

### DIFF
--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_agriculture.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_agriculture) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(agriculture)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_buildings.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_buildings) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(buildings)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_bunkers.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_bunkers) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(bunkers)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_energy.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_energy) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(energy)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_households.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_households) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(households)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_industry.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_industry) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(industry)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_other.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_other) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(other)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_liquid_biofuels_in_transport.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'liquid_biofuels' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of biofuels in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_liquid_biofuels_in_transport) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(transport)),
+        input_of(
+          bio_kerosene,
+          bio_lng,
+          bio_ethanol,
+          biodiesel,
+          bio_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_agriculture.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_agriculture.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_agriculture) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(agriculture)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_buildings.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_buildings.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_buildings) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(buildings)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_bunkers.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_bunkers.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_bunkers) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(bunkers)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_energy.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_energy.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_energy) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(energy)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_households.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_households.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_households) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(households)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_industry.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_industry.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_industry) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(industry)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_other.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_other.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_other) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(other)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )

--- a/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_transport.gql
+++ b/gqueries/modules/multi_year_charts/final_demand_chart/per_sector_and_carrier/myc_final_demand_of_oil_and_derivatives_in_transport.gql
@@ -1,4 +1,19 @@
 # Energetic final demand of the 'oil_and_derivatives' carrier group
+# The applied query differs from the other per sector per carrier queries
+# This is a quick fix to align total final demand of oil and derivatives in the per sector per carrier queries
+# with the per carrier queries
 
 - unit = MJ
-- query = Q(final_demand_of_oil_and_derivatives_in_transport) * BILLIONS
+- query =
+    SUM(
+      V(
+        INTERSECTION(G(final_demand_group), SECTOR(transport)),
+        input_of(
+          kerosene,
+          lpg,
+          diesel,
+          gasoline,
+          crude_oil
+        )
+      )
+    )


### PR DESCRIPTION
This PR applies the `final_demand_group` node group to the the per sector per carrier queries used in Collection for biofuels and oils and derivatives. Note that this is a quick fix to align the total final demand of these carriers in the per sector per carrier queries and per carrier queries, as mentioned here https://github.com/quintel/multi-year-charts/issues/83#issuecomment-2709869486