### PR TITLE
Adding other sector to Industry and energy section in co2 sheet

### DIFF
--- a/gqueries/modules/co2_sheet/indicators/co2_sheet_energetic_emissions_share.gql
+++ b/gqueries/modules/co2_sheet/indicators/co2_sheet_energetic_emissions_share.gql
@@ -6,7 +6,7 @@
       ),
       SUM(
         Q(co2_sheet_agriculture_total_emissions),
-        Q(co2_sheet_industry_energy_total_emissions),
+        Q(co2_sheet_industry_energy_other_total_emissions),
         Q(co2_sheet_transport_total_emissions),
         Q(co2_sheet_buildings_households_total_emissions),
         Q(co2_sheet_indirect_delayed_emissions)

--- a/gqueries/modules/co2_sheet/sector_totals/co2_sheet_industry_energy_other_total_emissions.gql
+++ b/gqueries/modules/co2_sheet/sector_totals/co2_sheet_industry_energy_other_total_emissions.gql
@@ -6,7 +6,8 @@
       Q(co2_sheet_industry_paper_co2_emissions),
       Q(co2_sheet_industry_metal_co2_emissions),
       Q(co2_sheet_industry_other_all_emissions),
-      Q(co2_sheet_industry_energy_sector_all_emissions)
+      Q(co2_sheet_industry_energy_sector_all_emissions),
+      Q(co2_sheet_other_sector_co2_emissions)
   )
 
 - unit = T


### PR DESCRIPTION
This PR solves the quick fix as proposed in #3217 by adding the emissions of the Other sector to the Industry & Energy sectors. 

Goes together with:
https://github.com/quintel/etmodel/pull/4443
