### PR TITLE
Splitting energetic and non energetic demand in final demand other sector chart

### DIFF
--- a/gqueries/general/final_demand/mece_non_energetic/final_demand_of_oil_and_derivatives_in_other_non_energetic.gql
+++ b/gqueries/general/final_demand/mece_non_energetic/final_demand_of_oil_and_derivatives_in_other_non_energetic.gql
@@ -1,4 +1,4 @@
-# Non-nergetic final demand of the 'oil_and_derivatives' carrier group 
+# Non-nergetic final demand of the 'oil_and_derivatives' carrier group
 
 - unit = PJ
 - query =
@@ -10,7 +10,7 @@
               FILTER(
                 EG(final_demand),"sector == :other"
               ),
-              ! energetic?
+              "!energetic?"
             ),
             "crude_oil? ||  gasoline? ||  diesel? ||  lpg? || kerosene? || heavy_fuel_oil? || bio_oil? || bio_kerosene?"
           ),
@@ -19,4 +19,3 @@
       ),
       BILLIONS
     )
-      

--- a/gqueries/general/final_demand/other/final_demand_of_oil_and_derivatives_in_other_non_energetic.gql
+++ b/gqueries/general/final_demand/other/final_demand_of_oil_and_derivatives_in_other_non_energetic.gql
@@ -1,4 +1,4 @@
-# Energetic final demand of the 'oil_and_derivatives' carrier group 
+# Non-nergetic final demand of the 'oil_and_derivatives' carrier group 
 
 - unit = PJ
 - query =
@@ -10,7 +10,7 @@
               FILTER(
                 EG(final_demand),"sector == :other"
               ),
-              energetic?
+              ! energetic?
             ),
             "crude_oil? ||  gasoline? ||  diesel? ||  lpg? || kerosene? || heavy_fuel_oil? || bio_oil? || bio_kerosene?"
           ),

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/biomass_products_energetic_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/biomass_products_energetic_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_biomass_products_in_other_energetic)
+- unit = PJ

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/coal_and_derivatives_energetic_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/coal_and_derivatives_energetic_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_coal_and_derivatives_in_other_energetic)
+- unit = PJ

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/electricity_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/electricity_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_electricity_in_other)
+- unit = PJ

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/heat_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/heat_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_heat_in_other)
+- unit = PJ

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/natural_gas_and_derivatives_energetic_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/natural_gas_and_derivatives_energetic_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_natural_gas_and_derivatives_in_other_energetic)
+- unit = PJ

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/oil_and_derivatives_energetic_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/oil_and_derivatives_energetic_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_oil_and_derivatives_in_other_energetic)
+- unit = PJ

--- a/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/oil_and_derivatives_non_energetic_use_of_final_demand_in_other_sector.gql
+++ b/gqueries/output_elements/output_series/use_of_final_demand_in_other_sector/oil_and_derivatives_non_energetic_use_of_final_demand_in_other_sector.gql
@@ -1,0 +1,3 @@
+- query =
+    Q(final_demand_of_oil_and_derivatives_in_other_non_energetic)
+- unit = PJ


### PR DESCRIPTION
This PR solves [ETModel #4425](https://github.com/quintel/etmodel/issues/4425) by splitting non-energetic and energetic final demand in the Other sector chart and updates the labels.
In addition I have added a dedicated querie-folder for this chart and moved all queries to this folder.

Goes together with: 
https://github.com/quintel/etmodel/pull/4445