### PR TITLE
Move industry final demand edge group to include DSR demand

### DIFF
--- a/graphs/energy/edges/industry/buildings_local_production_electricity-industry_final_demand_for_other_ict_dsr_electricity@electricity.ad
+++ b/graphs/energy/edges/industry/buildings_local_production_electricity-industry_final_demand_for_other_ict_dsr_electricity@electricity.ad
@@ -1,6 +1,5 @@
 - type = flexible
 - reversed = false
-- groups = [final_demand, other_industry, ict_industry]
 - graph_methods = [parent_share]
 
 ~ parent_share = SHARE("energy/buildings_local_production_electricity_parent_share", industry_final_demand_for_other_ict_electricity)

--- a/graphs/energy/edges/industry/industry_final_demand_for_other_ict_dsr_electricity-industry_final_demand_for_other_ict_electricity@electricity.ad
+++ b/graphs/energy/edges/industry/industry_final_demand_for_other_ict_dsr_electricity-industry_final_demand_for_other_ict_electricity@electricity.ad
@@ -1,3 +1,3 @@
 - type = share
 - reversed = false
-- groups = []
+- groups = [final_demand, other_industry, ict_industry]


### PR DESCRIPTION
Before, only one of the edges from buildings local production to the ICT sector was marked with an edge group. The edge to DSR was empty. To solve this, the edge group is moved 'deeper' into the graph, where the DSR edge recombines with the regular demand edge. This way, all ICT demand is include in the final demand edge group.

In scenarios with DSR active in ICT, this query `final_demand_of_electricity_in_ict_industry` should now match the annual demand for ICT in the graph.