### PR TITLE
Merge household appliances efficiency sliders into one

### DIFF
--- a/inputs/demand/households/households_efficiency/households_appliances_clothes_dryer_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_clothes_dryer_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_clothes_dryer_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 69.0
-- min_value = -36.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_computer_media_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_computer_media_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_computer_media_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 80.0
-- min_value = -20.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_dishwasher_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_dishwasher_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_dishwasher_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 35.0
-- min_value = -34.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_electricity_efficiency.ad
@@ -1,0 +1,9 @@
+- query = UPDATE(PARENTS(V(households_final_demand_for_appliances_electricity)), preset_demand, NEG(USER_INPUT()))
+- priority = 0
+- max_value = 90.0
+- min_value = -90.0
+- start_value = 0.0
+- step_value = 0.1
+- unit = %
+- update_period = future
+- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_fridge_freezer_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_fridge_freezer_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_fridge_freezer_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 66.0
-- min_value = -132.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_other_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_other_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_other_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 80.0
-- min_value = -20.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_television_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_television_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_television_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 92.0
-- min_value = -93.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_vacuum_cleaner_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_vacuum_cleaner_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_vacuum_cleaner_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 75.0
-- min_value = -15.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %

--- a/inputs/demand/households/households_efficiency/households_appliances_washing_machine_electricity_efficiency.ad
+++ b/inputs/demand/households/households_efficiency/households_appliances_washing_machine_electricity_efficiency.ad
@@ -1,9 +1,0 @@
-- query = UPDATE(V(households_appliances_washing_machine_electricity), preset_demand, NEG(USER_INPUT()))
-- priority = 0
-- max_value = 28.0
-- min_value = -56.0
-- start_value = 0.0
-- step_value = 0.1
-- unit = %
-- update_period = future
-- update_type = %


### PR DESCRIPTION
This PR adresses https://github.com/quintel/etmodel/issues/4479. There are currently 8 household appliances efficiency sliders. This seems excessive. They are merged into one.

Goes with: 
- https://github.com/quintel/etmodel/pull/4481