### PR TITLE
Revise costs of electricity carrier query

### DIFF
--- a/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_electricity_future.gql
+++ b/gqueries/general/costs/mece_costs/4_energy_carriers/costs_carriers_electricity_future.gql
@@ -1,56 +1,24 @@
+# The domestic country pays the price of the internal market when importing.
+# The domestic country receives the price of the internal market when exporting.
+
 - query =
-    future:SUM(
-      PRODUCT_CURVES(
-        V(energy_interconnector_1_imported_electricity, electricity_output_curve),
-        Q(interconnector_1_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_2_imported_electricity, electricity_output_curve),
-        Q(interconnector_2_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_3_imported_electricity, electricity_output_curve),
-        Q(interconnector_3_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_4_imported_electricity, electricity_output_curve),
-        Q(interconnector_4_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_5_imported_electricity, electricity_output_curve),
-        Q(interconnector_5_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_6_imported_electricity, electricity_output_curve),
-        Q(interconnector_6_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_7_imported_electricity, electricity_output_curve),
-        Q(interconnector_7_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_8_imported_electricity, electricity_output_curve),
-        Q(interconnector_8_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_9_imported_electricity, electricity_output_curve),
-        Q(interconnector_9_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_10_imported_electricity, electricity_output_curve),
-        Q(interconnector_10_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_11_imported_electricity, electricity_output_curve),
-        Q(interconnector_11_marginal_cost_curve)
-      ),
-      PRODUCT_CURVES(
-        V(energy_interconnector_12_imported_electricity, electricity_output_curve),
-        Q(interconnector_12_marginal_cost_curve)
+    future:V(
+      SUM(
+        PRODUCT_CURVES(
+          SUM_CURVES(
+            V(G(electricity_interconnectors_import), electricity_output_curve)
+            ),
+          Q(merit_order_price_curve)
+        )
       )
-    ) -
-    PRODUCT(
-      V(energy_export_electricity, weighted_carrier_cost_per_mj),
-      V(energy_export_electricity, demand)
+      -
+      SUM(
+        PRODUCT_CURVES(
+          SUM_CURVES(
+            V(G(electricity_interconnectors_export), electricity_input_curve)
+          ),
+          Q(merit_order_price_curve)
+        )
+      )
     )
 - unit = euro


### PR DESCRIPTION
This PR solves #2991. The way that the costs of electricity was defined was conceptually not valid and this has been corrected.

**Old situation before this fix**
The import costs used the hourly price in the external market. The export revenue used the weighted carrier costs.

**Real world situation**
When markets are cleared, the domestic market will pay the domestic price for import. The external market receives the external market price for that export. If the market prices are not converged, the price difference is revenue for the interconnector, also known as congestion rent. When exporting, the domestic market therefore receives the price of the domestic market.

**New situation after this fix**
Both the import costs and the export revenue now use the hourly domestic price. The weighted carrier approach was blatantly wrong.

Because we have now switched from costs to price for export revenue, the net costs of electricity in scenarios is expected to go down. This is confirmed on production, where I tested the old and new query for II3050v2 INT. They respectively gave 1,172 million euros and -446 million euros.

**To do**
@kndehaan can you please thoroughly review my calculations? Before merging I would still shortly like to discuss the conceptual difference between costs and price - even though I think that the approach implemented in this PR is correct.