### PR TITLE
Redesign Buildings solar thermal slider

### DIFF
--- a/inputs/demand/buildings/buildings_heating/buildings_space_heater_solar_thermal_share.ad
+++ b/inputs/demand/buildings/buildings_heating/buildings_space_heater_solar_thermal_share.ad
@@ -2,8 +2,8 @@
 
 - query =
     EACH(
-      UPDATE(EDGE(buildings_space_heater_solar_thermal, buildings_useful_demand_for_space_heating_buildings_present), share, (USER_INPUT()*0.13)/100.0),
-      UPDATE(EDGE(buildings_space_heater_solar_thermal, buildings_useful_demand_for_space_heating_buildings_future), share, (USER_INPUT()*0.13)/100.0)
+      UPDATE(EDGE(buildings_space_heater_solar_thermal, buildings_useful_demand_for_space_heating_buildings_present), share, (USER_INPUT())/100.0),
+      UPDATE(EDGE(buildings_space_heater_solar_thermal, buildings_useful_demand_for_space_heating_buildings_future), share, (USER_INPUT())/100.0)
       )
 
 - priority = 0


### PR DESCRIPTION
This PR closes https://github.com/quintel/etmodel/issues/4477

In the previous modelling, the solar thermal sliders could provide for a maximum of 13% of the building heating demand.
This maximum was not documented, and hardcoded in the slider settings. 

As indicated in the issue this was not correctly shown in the front-end as well.