### PR TITLE
Adding hybrid heat input queries for hydrogen and crude oil

### DIFF
--- a/gqueries/general/heat/input_of_crude_oil_per_heat_technology/buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil.gql
+++ b/gqueries/general/heat/input_of_crude_oil_per_heat_technology/buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil.gql
@@ -1,0 +1,2 @@
+- query = V(buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity,input_of_crude_oil)
+- unit = MJ

--- a/gqueries/general/heat/input_of_crude_oil_per_heat_technology/households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil.gql
+++ b/gqueries/general/heat/input_of_crude_oil_per_heat_technology/households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity,input_of_crude_oil)
+- unit = MJ

--- a/gqueries/general/heat/input_of_crude_oil_per_heat_technology/households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil.gql
+++ b/gqueries/general/heat/input_of_crude_oil_per_heat_technology/households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil.gql
@@ -1,0 +1,2 @@
+- query = V(households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity,input_of_crude_oil)
+- unit = MJ

--- a/gqueries/general/heat/input_of_hydrogen_per_heat_technology/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_of_hydrogen.gql
+++ b/gqueries/general/heat/input_of_hydrogen_per_heat_technology/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_of_hydrogen.gql
@@ -1,0 +1,2 @@
+- query = V(buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,input_of_hydrogen)
+- unit = MJ

--- a/gqueries/general/heat/input_of_hydrogen_per_heat_technology/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_of_hydrogen.gql
+++ b/gqueries/general/heat/input_of_hydrogen_per_heat_technology/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_of_hydrogen.gql
@@ -1,0 +1,2 @@
+- query = V(households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity,input_of_hydrogen)
+- unit = MJ

--- a/gqueries/general/heat/input_of_hydrogen_per_heat_technology/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_input_of_hydrogen.gql
+++ b/gqueries/general/heat/input_of_hydrogen_per_heat_technology/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_input_of_hydrogen.gql
@@ -1,0 +1,2 @@
+- query = V(households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity,input_of_hydrogen)
+- unit = MJ


### PR DESCRIPTION
This PR adds input queries for hydrogen and crude oil for the hybrid heat pumps. 
You can test the working for these queries by taking a non-Dutch dataset and setting the following or similar input setting:

```
households_heater_combined_network_gas_share: 14.2688407
households_heater_hybrid_hydrogen_heatpump_air_water_electricity_share: 5.0
households_heater_hybrid_crude_oil_heatpump_air_water_electricity_share: 5.0
buildings_space_heater_network_gas_share: 69.3686397
buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_share: 5.0
buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_share: 5.0
```

In the sandbox you can query the queries with:
```
EACH(
	Q(buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil),
	Q(households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil),
	Q(households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity_input_of_crude_oil),
	Q(buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_of_hydrogen),
	Q(households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_of_hydrogen),
	Q(households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity_input_input_of_hydrogen)
)
```