### PR TITLE
Add queries for electricity input of cooling technologies

### DIFF
--- a/gqueries/general/heat/input_of_electricity_per_heat_technology/buildings_cooling_airconditioning_electricity_input_of_electricity.gql
+++ b/gqueries/general/heat/input_of_electricity_per_heat_technology/buildings_cooling_airconditioning_electricity_input_of_electricity.gql
@@ -1,0 +1,2 @@
+- query = V(buildings_cooling_airconditioning_electricity,input_of_electricity)
+- unit = MJ

--- a/gqueries/general/heat/input_of_electricity_per_heat_technology/buildings_cooling_heatpump_surface_water_water_ts_electricity_input_of_electricity.gql
+++ b/gqueries/general/heat/input_of_electricity_per_heat_technology/buildings_cooling_heatpump_surface_water_water_ts_electricity_input_of_electricity.gql
@@ -1,0 +1,2 @@
+- query = V(buildings_cooling_heatpump_surface_water_water_ts_electricity,input_of_electricity)
+- unit = MJ

--- a/gqueries/general/heat/input_of_electricity_per_heat_technology/households_cooling_airconditioning_electricity_input_of_electricity.gql
+++ b/gqueries/general/heat/input_of_electricity_per_heat_technology/households_cooling_airconditioning_electricity_input_of_electricity.gql
@@ -1,0 +1,2 @@
+- query = V(households_cooling_airconditioning_electricity,input_of_electricity)
+- unit = MJ

--- a/gqueries/general/heat/input_of_electricity_per_heat_technology/households_cooling_heatpump_surface_water_water_ts_electricity_input_of_electricity.gql
+++ b/gqueries/general/heat/input_of_electricity_per_heat_technology/households_cooling_heatpump_surface_water_water_ts_electricity_input_of_electricity.gql
@@ -1,0 +1,2 @@
+- query = V(households_cooling_heatpump_surface_water_water_ts_electricity,input_of_electricity)
+- unit = MJ


### PR DESCRIPTION
This PR adds missing input of electricity queries for cooling technologies in the built environment. Should be cherry-picked to tyndp-2026 after merging.