### PR TITLE
Update waste mix sparse graph query

### DIFF
--- a/sparse_graph_queries/energy/energy_distribution_waste_mix+input.ad
+++ b/sparse_graph_queries/energy/energy_distribution_waste_mix+input.ad
@@ -2,6 +2,6 @@
 
 - query =
     {
-      biogenic_waste: DATASET_INPUT(energy_distribution_biogenic_waste_energy_distribution_waste_mix_child_share),
-      non_biogenic_waste: DATASET_INPUT(energy_distribution_non_biogenic_waste_energy_distribution_waste_mix_child_share)
+      biogenic_waste: DATASET_INPUT(input_percentage_of_biogenic_waste_energy_distribution_waste_mix),
+      non_biogenic_waste: DATASET_INPUT(input_percentage_of_non_biogenic_waste_energy_distribution_waste_mix)
     }


### PR DESCRIPTION
The ETLocal keys used in the sparse graph query `energy_distribution_waste_mix+input` are renamed. 