### PR TITLE
Fix unit in temperature cut off for p2h input

### DIFF
--- a/inputs/flexibility/energy/temperature_cutoff_of_energy_flexibility_p2h.ad
+++ b/inputs/flexibility/energy/temperature_cutoff_of_energy_flexibility_p2h.ad
@@ -27,5 +27,5 @@
 - min_value = 5.0
 - start_value_gql = present:V(energy_heat_flexibility_p2h_heatpump_ht_electricity, "merit_order.temperature_cutoff")
 - step_value = 0.1
-- unit = #
+- unit = degC
 - update_period = future


### PR DESCRIPTION
## Description

The unit for the input temperature_cutoff_of_energy_flexibility_p2h was set in '#'.
This led to a scaling of the input settings for regional datasets. 

<img width="1053" height="820" alt="Screenshot 2025-11-24 at 10 05 38" src="https://github.com/user-attachments/assets/ce3bb64e-5e31-43a1-a8af-166622d72e83" />

With this update, the input is set to 'degC' which is an input that does not scale across datasets. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [ ] I have tagged the relevant people for review

## Related Issues

Closes #
