### PR TITLE
Update final demand aluminium and other metal queries to omit final_demand_of_carrier method

### DIFF
--- a/gqueries/output_elements/output_series/bezier_130_use_of_final_demand_in_industry_metal_aluminium/electricity_in_use_of_final_demand_in_industry_aluminium.gql
+++ b/gqueries/output_elements/output_series/bezier_130_use_of_final_demand_in_industry_metal_aluminium/electricity_in_use_of_final_demand_in_industry_aluminium.gql
@@ -1,2 +1,6 @@
 - unit = PJ
-- query = V(industry_aluminium_production, final_demand_of(:electricity))/BILLIONS
+- query =
+    DIVIDE(
+      V(industry_final_demand_for_metal_aluminium_electricity, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_130_use_of_final_demand_in_industry_metal_aluminium/hydrogen_in_use_of_final_demand_in_industry_aluminium.gql
+++ b/gqueries/output_elements/output_series/bezier_130_use_of_final_demand_in_industry_metal_aluminium/hydrogen_in_use_of_final_demand_in_industry_aluminium.gql
@@ -1,2 +1,6 @@
 - unit = PJ
-- query = V(industry_aluminium_production, final_demand_of(:hydrogen))/BILLIONS
+- query =
+    DIVIDE(
+      V(industry_final_demand_for_metal_aluminium_hydrogen, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_130_use_of_final_demand_in_industry_metal_aluminium/network_gas_in_use_of_final_demand_in_industry_aluminium.gql
+++ b/gqueries/output_elements/output_series/bezier_130_use_of_final_demand_in_industry_metal_aluminium/network_gas_in_use_of_final_demand_in_industry_aluminium.gql
@@ -1,2 +1,6 @@
 - unit = PJ
-- query = V(industry_aluminium_production, final_demand_of(:network_gas))/BILLIONS
+- query =
+    DIVIDE(
+      V(industry_final_demand_for_metal_aluminium_network_gas, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/coal_in_use_of_final_demand_in_industry_other_metals.gql
+++ b/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/coal_in_use_of_final_demand_in_industry_other_metals.gql
@@ -1,6 +1,6 @@
 - unit = PJ
 - query =
-    V(
-      industry_other_metals_production, "final_demand_of(:coal) +
-      final_demand_of(:coal_gas) + final_demand_of(:cokes)"
-    ) / BILLIONS
+    DIVIDE(
+      V(industry_final_demand_for_metal_other_metals_coal, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/electricity_in_use_of_final_demand_in_industry_other_metals.gql
+++ b/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/electricity_in_use_of_final_demand_in_industry_other_metals.gql
@@ -1,5 +1,6 @@
 - unit = PJ
 - query =
-    V(
-      industry_other_metals_production, final_demand_of(:electricity)
-    ) / BILLIONS
+    DIVIDE(
+      V(industry_final_demand_for_metal_other_metals_electricity, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/hydrogen_in_use_of_final_demand_in_industry_other_metals.gql
+++ b/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/hydrogen_in_use_of_final_demand_in_industry_other_metals.gql
@@ -1,5 +1,6 @@
 - unit = PJ
 - query =
-    V(
-      industry_other_metals_production, final_demand_of(:hydrogen)
-    ) / BILLIONS
+    DIVIDE(
+      V(industry_final_demand_for_metal_other_metals_hydrogen, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/network_gas_in_use_of_final_demand_in_industry_other_metals.gql
+++ b/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/network_gas_in_use_of_final_demand_in_industry_other_metals.gql
@@ -1,5 +1,6 @@
 - unit = PJ
 - query =
-    V(
-      industry_other_metals_production, final_demand_of(:network_gas)
-    ) / BILLIONS
+    DIVIDE(
+      V(industry_final_demand_for_metal_other_metals_network_gas, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/oil_in_use_of_final_demand_in_industry_other_metals.gql
+++ b/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/oil_in_use_of_final_demand_in_industry_other_metals.gql
@@ -1,5 +1,6 @@
 - unit = PJ
 - query =
-    V(
-      industry_other_metals_production, final_demand_of(:crude_oil)
-    ) / BILLIONS
+    DIVIDE(
+      V(industry_final_demand_for_metal_other_metals_crude_oil, demand),
+      BILLIONS
+    )

--- a/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/steam_hot_water_in_use_of_final_demand_in_industry_other_metals.gql
+++ b/gqueries/output_elements/output_series/bezier_131_use_of_final_demand_in_industry_other_metals/steam_hot_water_in_use_of_final_demand_in_industry_other_metals.gql
@@ -1,5 +1,6 @@
 - unit = PJ
 - query =
-    V(
-      industry_other_metals_production, final_demand_of(:steam_hot_water)
-    ) / BILLIONS
+    DIVIDE(
+      V(industry_final_demand_for_metal_other_metals_steam_hot_water, demand),
+      BILLIONS
+    )


### PR DESCRIPTION
## Description

This PR omits the use of `final_demand_of_carrier` and simply queries the flows instead. For the setup of the nodes and edges, I wasn't able to find a more robust way (using groups, etc.) to query the flows. @kaskranenburgQ do you have an idea to easily query the flows in a more robust way?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #https://github.com/quintel/etsource/issues/3361
