### PR TITLE
Fixes in Sankey chart biofuels to electricity queries

### DIFF
--- a/gqueries/general/conversion/biomass_products/conversion_from_biomass_products_to_carrier/conversion_from_biomass_products_for_electricity.gql
+++ b/gqueries/general/conversion/biomass_products/conversion_from_biomass_products_to_carrier/conversion_from_biomass_products_for_electricity.gql
@@ -5,25 +5,11 @@
 
 - query =
     SUM(
-      DIVIDE(
-        SUM(
-          V(
-            Q(electricity_producing_converters_sankey),
-            input_of(
-              greengas,
-              biodiesel,
-              bio_ethanol,
-              bio_lng,
-              bio_oil,
-              biogas,
-              bio_kerosene,
-              torrefied_biomass_pellets,
-              wood_pellets
-            )
-          )
-        ),
-        BILLIONS
-      ),
-      Q(gas_power_fuelmix_for_electricity_conversion) * V(energy_mixer_for_gas_power_fuel, bio_oil_input_conversion)
+      Q(conversion_from_wood_pellets_to_electricity),
+      Q(conversion_from_biogas_to_electricity),
+      PRODUCT(
+        Q(conversion_from_gas_power_fuelmix_to_electricity),
+        V(energy_mixer_for_gas_power_fuel, bio_oil_input_conversion)
+      )
     )
 - unit = PJ

--- a/gqueries/general/conversion/electricity/conversion_from_carrier_to_electricity/conversion_from_biogas_to_electricity.gql
+++ b/gqueries/general/conversion/electricity/conversion_from_carrier_to_electricity/conversion_from_biogas_to_electricity.gql
@@ -1,0 +1,13 @@
+# Direct conversion input of biogas for central electricity production
+
+- query =
+    DIVIDE(
+      SUM(
+        V(
+          G(electricity_production),
+          "electricity_output_conversion / (1 - loss_output_conversion) * input_of_biogas"
+        )
+      ),
+      BILLIONS
+    )
+- unit = PJ

--- a/gqueries/output_elements/output_series/sankey_energy_overview/sankey_1_to_2_heat_to_loss.gql
+++ b/gqueries/output_elements/output_series/sankey_energy_overview/sankey_1_to_2_heat_to_loss.gql
@@ -4,7 +4,7 @@
       Q(conversion_loss_coal_and_derivatives_to_steam_hot_water),
       Q(conversion_loss_electricity_to_steam_hot_water),
       Q(conversion_loss_hydrogen_to_steam_hot_water),
-      Q(conversion_loss_natural_gas_and_derivatives_to_steam_hot_water),
+      Q(conversion_loss_network_gas_to_steam_hot_water),
       Q(conversion_loss_oil_and_derivatives_to_steam_hot_water),
       Q(conversion_loss_waste_mix_to_steam_hot_water),
       Q(conversion_loss_solar_thermal_to_steam_hot_water),


### PR DESCRIPTION
## Description

This PR fixes queries for the Sankey chart, related to biofuels to electricity. There was a double counting of biofuel input to CHPs since the biofuel to electricity flow also took into account input of biofuel for heat production. This has now been fixed. 

An additional fix was in heat to loss query related to network gas: the loss related to network gas is queried now instead of natural gas. 

## Steps to reproduce

I came across this imbalance on beta, for a blank scenario for Schiermonnikoog where only capacity of agriculture biomass CHP is set, see screenshot from beta:

<img width="1327" height="786" alt="image" src="https://github.com/user-attachments/assets/d6b83cec-1380-4124-9256-da7c733d7a74" />

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #
