### PR TITLE
Double the maximum value of ammonia import

### DIFF
--- a/inputs/supply/ammonia/ammonia_production/capacity_of_energy_imported_ammonia_baseload.ad
+++ b/inputs/supply/ammonia/ammonia_production/capacity_of_energy_imported_ammonia_baseload.ad
@@ -12,7 +12,7 @@
         )
     )
 - priority = 0
-- max_value_gql = present:MAX(500,DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_imported_ammonia_baseload,full_load_hours),MJ_PER_MWH)))
+- max_value_gql = present:MAX(1000,PRODUCT(DIVIDE(Q(total_gas_consumed),PRODUCT(V(energy_imported_ammonia_baseload,full_load_hours),MJ_PER_MWH)),2))
 - min_value = 0.0
 - start_value_gql = present:V(energy_imported_ammonia_baseload,number_of_units)
 - step_value = 0.1


### PR DESCRIPTION
#### Context
Double the maximum value of the slider "ammonia import". 
This slider is located at Supply, Hydrogen, Ammonia production.
#### Implemented changes
Doubled "max_value_gql"

#### Related

Closes issue #3434


## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
