### PR TITLE
Update ETLocal key names gas plants

### DIFF
--- a/sparse_graph_queries/energy/electricity_production/energy_power_combined_cycle_network_gas_dispatchable+full_load_hours.ad
+++ b/sparse_graph_queries/energy/electricity_production/energy_power_combined_cycle_network_gas_dispatchable+full_load_hours.ad
@@ -1,2 +1,2 @@
 - query =
-    DATASET_INPUT(energy_power_combined_cycle_network_gas_full_load_hours)
+    DATASET_INPUT(input_energy_power_combined_cycle_network_gas_full_load_hours)

--- a/sparse_graph_queries/energy/electricity_production/energy_power_combined_cycle_network_gas_must_run+full_load_hours.ad
+++ b/sparse_graph_queries/energy/electricity_production/energy_power_combined_cycle_network_gas_must_run+full_load_hours.ad
@@ -1,2 +1,2 @@
 - query =
-    DATASET_INPUT(energy_power_combined_cycle_network_gas_full_load_hours)
+    DATASET_INPUT(input_energy_power_combined_cycle_network_gas_full_load_hours)

--- a/sparse_graph_queries/energy/electricity_production/energy_power_turbine_network_gas_dispatchable+full_load_hours.ad
+++ b/sparse_graph_queries/energy/electricity_production/energy_power_turbine_network_gas_dispatchable+full_load_hours.ad
@@ -1,2 +1,2 @@
 - query =
-    DATASET_INPUT(energy_power_turbine_network_gas_full_load_hours)
+    DATASET_INPUT(input_energy_power_turbine_network_gas_full_load_hours)

--- a/sparse_graph_queries/energy/electricity_production/energy_power_turbine_network_gas_must_run+full_load_hours.ad
+++ b/sparse_graph_queries/energy/electricity_production/energy_power_turbine_network_gas_must_run+full_load_hours.ad
@@ -1,2 +1,2 @@
 - query =
-    DATASET_INPUT(energy_power_turbine_network_gas_full_load_hours)
+    DATASET_INPUT(input_energy_power_turbine_network_gas_full_load_hours)


### PR DESCRIPTION
#### Context
Following the changes in [this PR](https://github.com/quintel/etsource/pull/3433), it was necessary to rename the full load hour ETLocal keys of gas power plants.

#### Implemented changes
- The prefix `input_` has been added to the ETLocal keys `energy_power_combined_cycle_network_gas_full_load_hours` and `energy_power_turbine_network_gas_full_load_hours`
- The SQGs on ETSource have been updated with the renamed keys. 
- A migration file is written to update the datasets with the renamed keys

At some point, the key names should be updated in the dataset pipeline. I will add the key name change in the file `Deferred work tracking.xlsx` on ETDataset while reviewing [this PR](https://github.com/quintel/etdataset/pull/1085).

#### Related

Closes issue #681 

Goes with pull request https://github.com/quintel/etlocal/pull/683

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
