### PR TITLE
Update power-to-gas in data export

### DIFF
--- a/config/hydrogen_integral_cost_csv.yml
+++ b/config/hydrogen_integral_cost_csv.yml
@@ -31,7 +31,7 @@
 - name: Production cost curve autothermal reformer (must-run) (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_autothermal_reformer_must_run
 
-- name: Production curve autothermal reformer (CCS must-run) (MWh) 
+- name: Production curve autothermal reformer (CCS must-run) (MWh)
   query: energy_hydrogen_autothermal_reformer_ccs_must_run_hydrogen_output_curve
 
 - name: Production cost curve autothermal reformer (CCS must-run) (Eur/MWh)
@@ -49,28 +49,28 @@
 - name: Production cost curve biomass gasification (CCS) (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_biomass_gasification_ccs
 
-- name: Production curve solar electrolysis (MWh)
+- name: Production curve electrolysis from solar on land (dedicated) (MWh)
   query: energy_hydrogen_electrolysis_solar_electricity_hydrogen_output_curve
 
-- name: Production cost curve solar electrolysis (Eur/MWh)
+- name: Production cost curve electrolysis from solar on land (dedicated) (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_solar_pv
 
-- name: Production curve wind electrolysis (MWh)
+- name: Production curve electrolysis from offshore wind (dedicated) (MWh)
   query: energy_hydrogen_electrolysis_wind_electricity_hydrogen_output_curve
 
-- name: Production cost curve wind electrolysis (Eur/MWh)
+- name: Production cost curve electrolysis from offshore wind (dedicated) (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_offshore_wind_turbine
 
-- name: Production curve hybrid offshore electrolyser (MWh)
+- name: Production curve wind offshore (with hybrid connection) (MWh)
   query: energy_hydrogen_hybrid_electrolysis_wind_electricity_hydrogen_output_curve
 
-- name: Production cost curve hybrid offshore electrolyser (Eur/MWh)
+- name: Production cost curve wind offshore (with hybrid connection) (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_hybrid_offshore_wind_turbine
 
-- name: Production curve power to gas (MWh)
+- name: Production curve electrolysis from grid on land (MWh)
   query: energy_hydrogen_flexibility_p2g_electricity_hydrogen_output_curve
 
-- name: Production cost curve power to gas (Eur/MWh)
+- name: Production cost curve electrolysis from grid on land (Eur/MWh)
   query: production_costs_per_mwh_curve_hydrogen_p2g
 
 - name: Production curve liquid hydrogen regasifier (MWh)

--- a/config/sankey_csv.yml
+++ b/config/sankey_csv.yml
@@ -192,22 +192,22 @@ rows:
     Value: electricity_for_autothermal_reformer_ccs_hydrogen_conversion
   - Group: Conversion
     Carrier: Electricity
-    Category: Power-to-gas
+    Category: Electrolysis from grid on land
     Type: Input
     Value: electricity_prod_to_p2g_in_sankey
   - Group: Conversion
     Carrier: Electricity
-    Category: Direct electrolysis of wind
+    Category: Electrolysis from offshore wind (dedicated)
     Type: Input
     Value: wind_to_hydrogen_prod_in_sankey
   - Group: Conversion
     Carrier: Electricity
-    Category: Direct electrolysis of solar
+    Category: Electrolysis from solar on land (dedicated)
     Type: Input
     Value: solar_to_hydrogen_prod_in_sankey
   - Group: Conversion
     Carrier: Electricity
-    Category: Electrolysis offshore (price-based)
+    Category: Wind offshore (with hybrid connection)
     Type: Input
     Value: electricity_prod_to_hybrid_electrolysis_in_sankey
   - Group: Conversion
@@ -478,22 +478,22 @@ rows:
     Value: steam_hot_water_in_source_of_hydrogen_industry_transformation_in_sankey
   - Group: Conversion
     Carrier: Hydrogen
-    Category: Power-to-gas
+    Category: Electrolysis from grid on land
     Type: Output
     Value: p2g_to_hydrogen_prod_in_sankey
   - Group: Conversion
     Carrier: Hydrogen
-    Category: Direct electrolysis of wind
+    Category: Electrolysis from offshore wind (dedicated)
     Type: Output
     Value: direct_electrolysis_wind_in_source_of_hydrogen_production
   - Group: Conversion
     Carrier: Hydrogen
-    Category: Direct electrolysis of solar
+    Category: Electrolysis from solar on land (dedicated)
     Type: Output
     Value: direct_electrolysis_solar_in_source_of_hydrogen_production
   - Group: Conversion
     Carrier: Hydrogen
-    Category: Electrolysis offshore (price-based)
+    Category: Wind offshore (with hybrid connection)
     Type: Output
     Value: hybrid_electrolysis_to_hydrogen_prod_in_sankey
   - Group: Conversion

--- a/gqueries/general/costs/mece_costs/2_flexibility_storage/costs_storage_and_conversion.gql
+++ b/gqueries/general/costs/mece_costs/2_flexibility_storage/costs_storage_and_conversion.gql
@@ -1,7 +1,7 @@
 - query =
     SUM(
       Q(costs_storage_and_conversion_p2p),
-      Q(costs_storage_and_conversion_p2g),
+      Q(costs_storage_and_conversion_electrolysis),
       Q(costs_storage_and_conversion_p2h),
       Q(costs_storage_and_conversion_heat_storage),
       Q(costs_storage_and_conversion_hydrogen_storage)

--- a/gqueries/general/costs/mece_costs/2_flexibility_storage/costs_storage_and_conversion_electrolysis.gql
+++ b/gqueries/general/costs/mece_costs/2_flexibility_storage/costs_storage_and_conversion_electrolysis.gql
@@ -1,0 +1,7 @@
+- query =
+    SUM(
+      V(G(costs_storage_and_conversion_electrolysis), capital_expenditures_excluding_ccs_per(:node)),
+      V(G(costs_storage_and_conversion_electrolysis), operating_expenses_excluding_ccs_per(:node))
+    )
+
+- unit = euro

--- a/gqueries/general/costs/mece_costs/2_flexibility_storage/costs_storage_and_conversion_p2g.gql
+++ b/gqueries/general/costs/mece_costs/2_flexibility_storage/costs_storage_and_conversion_p2g.gql
@@ -1,7 +1,0 @@
-- query =
-    SUM(
-      V(G(costs_storage_and_conversion_p2g), capital_expenditures_excluding_ccs_per(:node)),
-      V(G(costs_storage_and_conversion_p2g), operating_expenses_excluding_ccs_per(:node))
-    )
-
-- unit = euro

--- a/gqueries/general/costs/mece_costs/6_CCUS/costs_co2_energy_graph_co2_captured_biogenic_costs.gql
+++ b/gqueries/general/costs/mece_costs/6_CCUS/costs_co2_energy_graph_co2_captured_biogenic_costs.gql
@@ -14,7 +14,7 @@
       V(G(costs_production_liquid_fuels), captured_biogenic_co2_costs_per(:node)),
       V(G(costs_production_other), captured_biogenic_co2_costs_per(:node)),
       V(G(costs_storage_and_conversion_p2p), captured_biogenic_co2_costs_per(:node)),
-      V(G(costs_storage_and_conversion_p2g), captured_biogenic_co2_costs_per(:node)),
+      V(G(costs_storage_and_conversion_electrolysis), captured_biogenic_co2_costs_per(:node)),
       V(G(costs_storage_and_conversion_p2h), captured_biogenic_co2_costs_per(:node)),
       V(G(costs_infrastructure_hydrogen), captured_biogenic_co2_costs_per(:node)),
       V(G(costs_co2_ccus), captured_biogenic_co2_costs_per(:node))

--- a/gqueries/general/costs/mece_costs/6_CCUS/costs_co2_energy_graph_co2_emissions_costs.gql
+++ b/gqueries/general/costs/mece_costs/6_CCUS/costs_co2_energy_graph_co2_emissions_costs.gql
@@ -14,7 +14,7 @@
       V(G(costs_production_liquid_fuels), co2_emissions_costs_per(:node)),
       V(G(costs_production_other), co2_emissions_costs_per(:node)),
       V(G(costs_storage_and_conversion_p2p), co2_emissions_costs_per(:node)),
-      V(G(costs_storage_and_conversion_p2g), co2_emissions_costs_per(:node)),
+      V(G(costs_storage_and_conversion_electrolysis), co2_emissions_costs_per(:node)),
       V(G(costs_storage_and_conversion_p2h), co2_emissions_costs_per(:node)),
       V(G(costs_infrastructure_hydrogen), co2_emissions_costs_per(:node)),
       V(G(costs_co2_ccus), co2_emissions_costs_per(:node))

--- a/gqueries/modules/multi_year_charts/flexible_capacity_chart/myc_flexible_capacity_in_energy_hydrogen_flexibility_p2g.gql
+++ b/gqueries/modules/multi_year_charts/flexible_capacity_chart/myc_flexible_capacity_in_energy_hydrogen_flexibility_p2g.gql
@@ -1,4 +1,4 @@
-# The flexible capacity in energy hydrogen flexibility p2g electricity 
+# The flexible capacity in energy hydrogen flexibility electrolysis from grid on land
 
 - unit = MW
 - query = Q(energy_hydrogen_flexibility_p2g_electricity_capacity)

--- a/gqueries/modules/multi_year_charts/flexible_capacity_chart/myc_flexible_capacity_in_energy_hydrogen_flexibility_p2g_offshore.gql
+++ b/gqueries/modules/multi_year_charts/flexible_capacity_chart/myc_flexible_capacity_in_energy_hydrogen_flexibility_p2g_offshore.gql
@@ -1,4 +1,4 @@
-# The flexible capacity in energy hydrogen flexibility p2g offshore electricity 
+# The flexible capacity in energy hydrogen flexibility electrolysis (Wind offshore with hybrid connection)
 
 - unit = MW
 - query = Q(energy_hydrogen_flexibility_p2g_offshore_electricity_capacity)

--- a/gqueries/output_elements/output_series/category_bar_245_residual_heat_production_and_potential/energy_hydrogen_flexibility_p2g_potential_residual_heat.gql
+++ b/gqueries/output_elements/output_series/category_bar_245_residual_heat_production_and_potential/energy_hydrogen_flexibility_p2g_potential_residual_heat.gql
@@ -1,4 +1,4 @@
-# Potential of residual heat from P2G electrolyser hydrogen production
+# Potential of residual heat from electrolyser hydrogen production
 
 - unit = PJ
 - query =

--- a/gqueries/output_elements/output_series/sankey/p2g_producing_converters_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/p2g_producing_converters_sankey.gql
@@ -1,4 +1,4 @@
-# Group for Sankey: all p2g converters
+# Group for Sankey: electrolysis from grid on land
 
 - query =
     G(p2g)

--- a/gqueries/output_elements/output_series/sankey/p2g_to_conversion_loss_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/p2g_to_conversion_loss_in_sankey.gql
@@ -1,4 +1,4 @@
-# Group for Sankey: p2g to conversion loss
+# Group for Sankey: electrolysis conversion loss
 
 - query =
     DIVIDE(SUM(V(Q(p2g_producing_converters_sankey), "output_of_loss")), BILLIONS)

--- a/gqueries/output_elements/output_series/sankey/p2g_to_hydrogen_prod_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey/p2g_to_hydrogen_prod_in_sankey.gql
@@ -1,4 +1,4 @@
-# Group for Sankey: p2g to hydrogen production
+# Group for Sankey: hydrogen production by electrolysis
 
 - query =
     DIVIDE(SUM(V(INTERSECTION(Q(p2g_producing_converters_sankey), SECTOR(energy)), "output_of_hydrogen")), BILLIONS)

--- a/gqueries/output_elements/output_series/sankey_electrical_interconnection/network_to_p2g_offshore_in_sankey.gql
+++ b/gqueries/output_elements/output_series/sankey_electrical_interconnection/network_to_p2g_offshore_in_sankey.gql
@@ -1,4 +1,4 @@
-# Query for Sankey diagram: connection between electricity network and P2G offshore
+# Query for Sankey diagram: connection between electricity network and wind offshore with hybrid connection
 
 - query = DIVIDE(V(energy_hydrogen_hybrid_electrolysis_wind_electricity,input_of_electricity),BILLIONS)
 - unit = PJ

--- a/graphs/energy/nodes/energy/energy_hydrogen_flexibility_p2g_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_flexibility_p2g_electricity.ad
@@ -2,7 +2,7 @@
 - output.hydrogen = 0.66
 - output.loss = elastic
 - output.residual_heat = 0.195
-- groups = [hv_net_flexibility, hydrogen_production, p2g, wacc_unproven_tech, costs_storage_and_conversion_p2g, sankey_conversion_group]
+- groups = [hv_net_flexibility, hydrogen_production, p2g, wacc_unproven_tech, costs_storage_and_conversion_electrolysis, sankey_conversion_group]
 - use = undefined
 - presentation_group = p2g
 - availability = 0.9800228310502284

--- a/graphs/energy/nodes/energy/energy_hydrogen_hybrid_electrolysis_wind_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_hybrid_electrolysis_wind_electricity.ad
@@ -1,7 +1,7 @@
 - input.electricity = 1.0
 - output.hydrogen = 0.66
 - output.loss = elastic
-- groups = [hydrogen_production, wacc_unproven_tech, costs_storage_and_conversion_p2g, sankey_conversion_group]
+- groups = [hydrogen_production, wacc_unproven_tech, costs_storage_and_conversion_electrolysis, sankey_conversion_group]
 - use = undefined
 - presentation_group = hydrogen_production
 - availability = 0.98


### PR DESCRIPTION
#### Context
Power-to-gas was not yet renamed in data export. 

#### Implemented changes
Rename power-to-gas in the following files:
- sankey.csv (https://energytransitionmodel.com/scenario/data/data_export/yearly-energy-flows)
- costs_parameters.csv (https://energytransitionmodel.com/scenario/data/data_export/specifications-annual-costs)
- hydrogen_integral_costs.csv (https://energytransitionmodel.com/scenario/data/data_export/hourly-curves-for-hydrogen)

#### Related

Closes issue https://github.com/quintel/etsource/issues/3086

Goes with pull requests: 
- https://github.com/quintel/etmodel/pull/4707
- https://github.com/quintel/etengine/pull/1737
- https://github.com/quintel/documentation/pull/310
- https://github.com/quintel/etsource/pull/3439

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
