### PR TITLE
Add dataset value molecule nodes with emissions data

### DIFF
--- a/config/molecules_node_positions.yml
+++ b/config/molecules_node_positions.yml
@@ -1,10 +1,19 @@
 ---
+agriculture_non-specified_non_energetic_other_ghg:
+  x: 1920
+  "y": 5140
+agriculture_non_specified_energetic_other_ghg:
+  x: 1920
+  "y": 5060
 agriculture_non_specified_non_energetic_co2:
   x: 1920
-  "y": 4900
+  "y": 4980
 buildings_non_specified_energetic_other_ghg:
   x: 1920
-  "y": 4980
+  "y": 4900
+energy_ccus_non_energetic_co2:
+  x: 1920
+  "y": 7620
 energy_chp_ht_wood_pellets_ccs_captured_co2:
   x: 2220
   "y": 0
@@ -53,6 +62,18 @@ energy_chp_supercritical_ccs_mt_waste_mix_co2:
 energy_chp_supercritical_ccs_mt_waste_mix_emitted_co2:
   x: 2220
   "y": 960
+energy_electricity_and_heat_production_energetic_other_ghg:
+  x: 1920
+  "y": 7540
+energy_fuels_production_energetic_other_ghg:
+  x: 1920
+  "y": 7460
+energy_fugitive_emissions_non_energetic_co2:
+  x: 1920
+  "y": 7380
+energy_fugitive_emissions_non_energetic_other_ghg:
+  x: 1920
+  "y": 7300
 energy_hydrogen_autothermal_reformer_ccs_captured_co2:
   x: 2220
   "y": 1520
@@ -74,6 +95,9 @@ energy_hydrogen_biomass_gasification_ccs_emitted_co2:
 energy_hydrogen_captured_co2:
   x: 1940
   "y": 1440
+energy_hydrogen_production_non_energetic_other_ghg:
+  x: 1920
+  "y": 7220
 energy_hydrogen_steam_methane_reformer_ccs_captured_co2:
   x: 2220
   "y": 1280
@@ -86,6 +110,9 @@ energy_hydrogen_steam_methane_reformer_ccs_must_run_co2:
 energy_methanol_production_coal_gas_co:
   x: 1940
   "y": 1680
+energy_methanol_production_non_energetic_other_ghg:
+  x: 1920
+  "y": 7140
 energy_power_captured_co2:
   x: 1940
   "y": 440
@@ -203,6 +230,15 @@ energy_production_methanol_synthesis_non_biogenic_waste_ccs_co2:
 energy_production_methanol_synthesis_non_biogenic_waste_ccs_emitted_co2:
   x: 2220
   "y": 4740
+households_non_specified_energetic_other_ghg:
+  x: 1920
+  "y": 7060
+industry_aluminium_non_energetic_co2:
+  x: 1920
+  "y": 6420
+industry_aluminium_non_energetic_other_ghg:
+  x: 1920
+  "y": 6340
 industry_chemical_other_capture_potential_co2:
   x: 2500
   "y": 2940
@@ -239,6 +275,12 @@ industry_chemicals_fertilizers_emitted_co2:
 industry_chemicals_fertilizers_processes_co2:
   x: 2940
   "y": 2680
+industry_chemicals_non_energetic_co2:
+  x: 1920
+  "y": 6260
+industry_chemicals_non_energetic_other_ghg:
+  x: 1920
+  "y": 6180
 industry_chemicals_refineries_capture_potential_co2:
   x: 2500
   "y": 2140
@@ -254,6 +296,9 @@ industry_chemicals_refineries_emitted_co2:
 industry_external_coupling_node_captured_co2:
   x: 1940
   "y": 1620
+industry_fertilizers_non_energetic_other_ghg:
+  x: 1920
+  "y": 6100
 industry_final_demand_for_chemical_fertilizers_coal_co2:
   x: 3440
   "y": 2500
@@ -317,6 +362,9 @@ industry_final_demand_for_other_paper_network_gas_co2:
 industry_final_demand_for_other_paper_wood_pellets_co2:
   x: 3440
   "y": 3460
+industry_non_specified_energetic_other_ghg:
+  x: 1920
+  "y": 6020
 industry_other_food_capture_potential_co2:
   x: 2500
   "y": 3600
@@ -329,6 +377,18 @@ industry_other_food_combustion_co2:
 industry_other_food_emitted_co2:
   x: 1940
   "y": 3780
+industry_other_metals_non_energetic_co2:
+  x: 1920
+  "y": 5940
+industry_other_metals_non_energetic_other_ghg:
+  x: 1920
+  "y": 5860
+industry_other_non_energetic_co2:
+  x: 1920
+  "y": 5780
+industry_other_non_energetic_other_ghg:
+  x: 1920
+  "y": 5700
 industry_other_paper_capture_potential_co2:
   x: 2500
   "y": 3280
@@ -341,6 +401,9 @@ industry_other_paper_combustion_co2:
 industry_other_paper_emitted_co2:
   x: 1940
   "y": 3460
+industry_refineries_energetic_other_ghg:
+  x: 1920
+  "y": 5620
 industry_steel_blastfurnace_bof_capture_potential_co2:
   x: 2500
   "y": 1740
@@ -383,6 +446,24 @@ industry_steel_external_coupling_node_captured_co2:
 industry_steel_external_coupling_node_co2:
   x: 2940
   "y": 1920
+industry_steel_non_energetic_co2:
+  x: 1920
+  "y": 5540
+industry_steel_non_energetic_other_ghg:
+  x: 1920
+  "y": 5460
+international_transport_international_aviation_energetic_other_ghg:
+  x: 1920
+  "y": 6980
+international_transport_international_navigation_energetic_other_ghg:
+  x: 1920
+  "y": 6900
+lulucf_non-specified_non_energetic_co2:
+  x: 1920
+  "y": 6820
+lulucf_non-specified_non_energetic_other_ghg:
+  x: 1920
+  "y": 6740
 molecules_direct_air_capture_co2:
   x: 1940
   "y": 200
@@ -434,3 +515,21 @@ molecules_transport_pipelines_co2:
 molecules_transport_ships_co2:
   x: 1140
   "y": 480
+national_transport_non-specified_energetic_other_ghg:
+  x: 1920
+  "y": 6660
+other_indirect_emissions_non_energetic_co2:
+  x: 1920
+  "y": 5380
+other_non_specified_energetic_other_ghg:
+  x: 1920
+  "y": 5300
+other_other_transportation_energetic_other_ghg:
+  x: 1920
+  "y": 5220
+waste_non_specified_non_energetic_co2:
+  x: 1920
+  "y": 6580
+waste_non_specified_non_energetic_other_ghg:
+  x: 1920
+  "y": 6500

--- a/config/molecules_node_positions.yml
+++ b/config/molecules_node_positions.yml
@@ -1,4 +1,10 @@
 ---
+agriculture_non_specified_non_energetic_co2:
+  x: 1920
+  "y": 4900
+buildings_non_specified_energetic_other_ghg:
+  x: 1920
+  "y": 4980
 energy_chp_ht_wood_pellets_ccs_captured_co2:
   x: 2220
   "y": 0
@@ -95,12 +101,6 @@ energy_power_combined_cycle_ccs_coal_emitted_co2:
 energy_power_combined_cycle_ccs_network_gas_dispatchable_captured_co2:
   x: 2220
   "y": 520
-energy_power_combined_cycle_ccs_network_gas_co2:
-  x: 2620
-  "y": 520
-energy_power_combined_cycle_ccs_network_gas_emitted_co2:
-  x: 2220
-  "y": 580
 energy_power_supercritical_ccs_waste_mix_captured_co2:
   x: 2220
   "y": 1140

--- a/config/molecules_node_positions.yml
+++ b/config/molecules_node_positions.yml
@@ -1,5 +1,5 @@
 ---
-agriculture_non-specified_non_energetic_other_ghg:
+agriculture_non_specified_non_energetic_other_ghg:
   x: 1920
   "y": 5140
 agriculture_non_specified_energetic_other_ghg:
@@ -458,10 +458,10 @@ international_transport_international_aviation_energetic_other_ghg:
 international_transport_international_navigation_energetic_other_ghg:
   x: 1920
   "y": 6900
-lulucf_non-specified_non_energetic_co2:
+lulucf_non_specified_non_energetic_co2:
   x: 1920
   "y": 6820
-lulucf_non-specified_non_energetic_other_ghg:
+lulucf_non_specified_non_energetic_other_ghg:
   x: 1920
   "y": 6740
 molecules_direct_air_capture_co2:
@@ -515,7 +515,7 @@ molecules_transport_pipelines_co2:
 molecules_transport_ships_co2:
   x: 1140
   "y": 480
-national_transport_non-specified_energetic_other_ghg:
+national_transport_non_specified_energetic_other_ghg:
   x: 1920
   "y": 6660
 other_indirect_emissions_non_energetic_co2:

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_agriculture, emissions_agriculture_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(agriculture_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(agriculture_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
@@ -1,4 +1,4 @@
 - groups = [preset_demand, emissions]
 - input.co2 = 1.0
 
-~ demand = 0.0
+~ demand = EMISSIONS(agriculture_non_specified, non_energetic, co2)

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = 0.0

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_agriculture, emissions_agriculture_non_specified]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(agriculture_non_specified, non_energetic, co2)

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_agriculture, emissions_agriculture_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(agriculture_non_specified, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(agriculture_non_specified, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/buildings/buildings_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/buildings/buildings_non_specified_energetic_other_ghg.ad
@@ -1,5 +1,4 @@
 - groups = [preset_demand, emissions]
-- use = energetic
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(buildings_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/buildings/buildings_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/buildings/buildings_non_specified_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_buildings, emissions_buildings_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(buildings_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_ccus_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_ccus_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(energy_ccus, non_energetic, co2)

--- a/graphs/molecules/nodes/energy/energy_ccus_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_ccus_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_ccus]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(energy_ccus, non_energetic, co2)

--- a/graphs/molecules/nodes/energy/energy_electricity_and_heat_production_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_electricity_and_heat_production_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_electricity_and_heat_production]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(energy_electricity_and_heat_production, energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_electricity_and_heat_production_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_electricity_and_heat_production_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(energy_electricity_and_heat_production, energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_fuels_production_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_fuels_production_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_fuels_production]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(energy_fuels_production, energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_fuels_production_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_fuels_production_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(energy_fuels_production, energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_fugitive_emissions]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(energy_fugitive_emissions, non_energetic, co2)

--- a/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(energy_fugitive_emissions, non_energetic, co2)

--- a/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(energy_fugitive_emissions, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_fugitive_emissions]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(energy_fugitive_emissions, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_hydrogen_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_hydrogen_production_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(energy_hydrogen_production, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_hydrogen_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_hydrogen_production_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_hydrogen_production]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(energy_hydrogen_production, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions,emissions_energy, emissions_energy_methanol_production]
+- groups = [preset_demand, emissions, emissions_energy, emissions_energy_methanol_production]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(energy_methanol_production, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(energy_methanol_production, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions,emissions_energy, emissions_energy_methanol_production]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(energy_methanol_production, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/households/households_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/households/households_non_specified_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_households, emissions_households_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(households_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/households/households_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/households/households_non_specified_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(households_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_aluminium]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(industry_aluminium, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(industry_aluminium, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_aluminium]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_aluminium, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_aluminium, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(industry_chemicals, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_chemicals]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(industry_chemicals, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_chemicals, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_chemicals]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_chemicals, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_fertilizers_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_fertilizers_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_fertilizers]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_fertilizers, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_fertilizers_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_fertilizers_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_fertilizers, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_non_specified_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_non_specified_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_other_metals]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(industry_other_metals, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(industry_other_metals, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_other_metals, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_other_metals]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_other_metals, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_other_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_other]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(industry_other, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_other_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(industry_other, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_other_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_other_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_other, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_other_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_other_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_other]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_other, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_refineries_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_refineries_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_refineries]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_refineries, energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_refineries_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_refineries_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_refineries, energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_steel_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_steel]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(industry_steel, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_steel_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(industry_steel, non_energetic, co2)

--- a/graphs/molecules/nodes/industry/industry_steel_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(industry_steel, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/industry/industry_steel_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_industry, emissions_industry_steel]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(industry_steel, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/international_transport/international_transport_international_aviation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/international_transport/international_transport_international_aviation_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_international_transport, emissions_international_transport_international_aviation]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(international_transport_international_aviation, energetic, other_ghg)

--- a/graphs/molecules/nodes/international_transport/international_transport_international_aviation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/international_transport/international_transport_international_aviation_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(international_transport_international_aviation, energetic, other_ghg)

--- a/graphs/molecules/nodes/international_transport/international_transport_international_navigation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/international_transport/international_transport_international_navigation_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(international_transport_international_navigation, energetic, other_ghg)

--- a/graphs/molecules/nodes/international_transport/international_transport_international_navigation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/international_transport/international_transport_international_navigation_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_international_transport, emissions_international_transport_international_navigation]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(international_transport_international_navigation, energetic, other_ghg)

--- a/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(lulucf_non_specified, non_energetic, co2)

--- a/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_lulucf, emissions_lulucf_non_specified]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(lulucf_non_specified, non_energetic, co2)

--- a/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(lulucf_non_specified, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_non_specified_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_lulucf, emissions_lulucf_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(lulucf_non_specified, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/national_transport/national_transport_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/national_transport/national_transport_non_specified_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_national_transport, emissions_national_transport_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(national_transport_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/national_transport/national_transport_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/national_transport/national_transport_non_specified_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(national_transport_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
@@ -1,4 +1,4 @@
 - groups = [preset_demand, emissions, emissions_other, emissions_other_indirect_emissions]
-- input.other_ghg = 1.0
+- input.co2 = 1.0
 
 ~ demand = EMISSIONS(other_indirect_emissions, non_energetic, co2)

--- a/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_other, emissions_other_indirect_emissions]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(other_indirect_emissions, non_energetic, co2)

--- a/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(other_indirect_emissions, non_energetic, co2)

--- a/graphs/molecules/nodes/other/other_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/other/other_non_specified_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_other, emissions_other_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(other_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/other/other_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/other/other_non_specified_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(other_non_specified, energetic, other_ghg)

--- a/graphs/molecules/nodes/other/other_other_transportation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/other/other_other_transportation_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_other, emissions_other_other_transportation]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(other_other_transportation, energetic, other_ghg)

--- a/graphs/molecules/nodes/other/other_other_transportation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/other/other_other_transportation_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(other_other_transportation, energetic, other_ghg)

--- a/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_co2.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_waste, emissions_waste_non_specified]
 - input.co2 = 1.0
 
 ~ demand = EMISSIONS(waste_non_specified, non_energetic, co2)

--- a/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_co2.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.co2 = 1.0
+
+~ demand = EMISSIONS(waste_non_specified, non_energetic, co2)

--- a/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_other_ghg.ad
@@ -1,0 +1,4 @@
+- groups = [preset_demand, emissions]
+- input.other_ghg = 1.0
+
+~ demand = EMISSIONS(waste_non_specified, non_energetic, other_ghg)

--- a/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, emissions, emissions_waste, emissions_waste_non_specified]
 - input.other_ghg = 1.0
 
 ~ demand = EMISSIONS(waste_non_specified, non_energetic, other_ghg)


### PR DESCRIPTION
#### Context
Adds molecule nodes that contains dataset value-based emissions data. Sector specific emissions node groups have been added to the molecule nodes.

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
