### PR TITLE
Have network gas hourly consumption reflect dispatchable hydrogen

### DIFF
--- a/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_dispatchable.ad
@@ -21,7 +21,7 @@
 - hydrogen.subtype = dispatchable
 - hydrogen.type = producer
 - network_gas.demand_carrier = natural_gas
-- network_gas.profile = flat
+- network_gas.profile = self: hydrogen_output_curve
 - network_gas.type = consumer
 - free_co2_factor = 0.0
 - takes_part_in_ets = 1.0

--- a/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_dispatchable.ad
@@ -21,7 +21,7 @@
 - hydrogen.subtype = dispatchable
 - hydrogen.type = producer
 - network_gas.demand_carrier = natural_gas
-- network_gas.profile = flat
+- network_gas.profile = self: hydrogen_output_curve
 - network_gas.type = consumer
 - free_co2_factor = 0.0
 - takes_part_in_ets = 1.0


### PR DESCRIPTION
#### Context
In a recent project we have added dispatchable hydrogen producers: the ATR and the SMR. These producers therefore have variable hydrogen production per hour. The network gas consumption however did not show this, it showed constant production.

#### Implemented changes
The network gas profile was marked as flat, which explain the constant production. It is now set to relate to the output of hydrogen, so that it matches the dispatchable production profile.

The consumption profile now matches the production profile.

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
