### PR TITLE
Rename the emissions group to direct_emissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',    ref: '5504fac', github: 'quintel/atlas'
+  gem 'atlas',    ref: 'b2d47a1', github: 'quintel/atlas'
   gem "ostruct"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'roo'
-  gem 'atlas',         ref: 'b2d47a1', github: 'quintel/atlas'
+  gem 'atlas',    ref: '5504fac', github: 'quintel/atlas'
   gem "ostruct"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 5504fac349b1b25fda2ef285b044b025fbfbdb1e
-  ref: 5504fac
+  revision: b2d47a1495f85638398d89acc17c6a2da7d2acac
+  ref: b2d47a1
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: b2d47a1495f85638398d89acc17c6a2da7d2acac
-  ref: b2d47a1
+  revision: 5504fac349b1b25fda2ef285b044b025fbfbdb1e
+  ref: 5504fac
   specs:
     atlas (1.0.0)
       activemodel (>= 7)
@@ -28,18 +28,6 @@ GIT
   ref: 9fe7010
   specs:
     rubel (0.1.1)
-
-PATH
-  remote: ../atlas
-  specs:
-    atlas (1.0.0)
-      activemodel (>= 7)
-      activesupport (>= 7)
-      csv (>= 3)
-      gpgme (~> 2.0)
-      ostruct
-      turbine-graph (>= 0.1)
-      virtus (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,18 @@ GIT
   specs:
     rubel (0.1.1)
 
+PATH
+  remote: ../atlas
+  specs:
+    atlas (1.0.0)
+      activemodel (>= 7)
+      activesupport (>= 7)
+      csv (>= 3)
+      gpgme (~> 2.0)
+      ostruct
+      turbine-graph (>= 0.1)
+      virtus (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:

--- a/config/direct_emissions_csv.yml
+++ b/config/direct_emissions_csv.yml
@@ -8,7 +8,7 @@
 # pair with a blank/"-" cell there sorts last; ties keep mapping-file order) — the column need not
 # appear in `schema:`. Each exported pair expands into one row per energy or molecule node whose own
 # `sector_label` and `use` attributes match the pair (never derived from group or config names) AND
-# which belongs to the node's `:emissions` group, sorted by node key. A pair with zero such nodes
+# which belongs to the node's `:direct_emissions` group, sorted by node key. A pair with zero such nodes
 # legally yields zero rows. A future export (e.g. a costs export) can reuse this mechanism by
 # declaring a different `require` column; rows for it stay out of this export by carrying "-" in
 # `emissions_sector`.

--- a/graphs/energy/nodes/agriculture/agriculture_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.788659793814433
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_burner_hydrogen.converter.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_burner_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.760824742268041
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_chp_engine_biogas.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_chp_engine_biogas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, heat_production,
     must_run_electricity_production, wacc_proven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/agriculture/agriculture_chp_engine_network_gas_dispatchable.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_chp_engine_network_gas_dispatchable.ad
@@ -4,7 +4,7 @@
 
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
+    direct_emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
     wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_chp_engine_network_gas_must_run.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_chp_engine_network_gas_must_run.ad
@@ -4,7 +4,7 @@
 
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, heat_production,
     must_run_electricity_production, wacc_proven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/agriculture/agriculture_chp_wood_pellets.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_chp_wood_pellets.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
+    direct_emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
     wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_flexibility_p2h_hydrogen_electricity.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_flexibility_p2h_hydrogen_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/agriculture/agriculture_flexibility_p2h_network_gas_electricity.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_flexibility_p2h_network_gas_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/agriculture/agriculture_geothermal.converter.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_geothermal.converter.ad
@@ -1,7 +1,7 @@
 - input.electricity = 0.0416666666666667
 - input.geothermal = 0.958333333333333
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_heat_backup_burner_network_gas.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_heat_backup_burner_network_gas.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 1.03
 - groups = [
-    emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_heatpump_water_water_electricity.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_heatpump_water_water_electricity.ad
@@ -1,7 +1,7 @@
 - input.ambient_heat = 0.7777777777777778
 - input.electricity = 0.2222222222222222
 - groups = [
-    emissions, heat_production, application_group, mv_net_demand, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, mv_net_demand, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
+++ b/graphs/energy/nodes/agriculture/agriculture_heatpump_water_water_ts_electricity.converter.ad
@@ -1,7 +1,7 @@
 - input.ambient_heat = 0.956521739130435
 - input.electricity = 0.0434782608695652
 - groups = [
-    emissions, heat_production, application_group, mv_net_demand, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, mv_net_demand, wacc_proven_tech,
     costs_building_and_installations_agriculture
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_appliances_coal.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_appliances_coal.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = buildings_appliances

--- a/graphs/energy/nodes/buildings/buildings_appliances_crude_oil.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_appliances_crude_oil.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = buildings_appliances

--- a/graphs/energy/nodes/buildings/buildings_appliances_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_appliances_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [emissions, application_group, lv_net_demand]
+- groups = [direct_emissions, application_group, lv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = buildings_appliances
 - merit_order.level = lv

--- a/graphs/energy/nodes/buildings/buildings_appliances_network_gas.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_appliances_network_gas.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - network_gas.profile = buildings_appliances
 - network_gas.type = consumer

--- a/graphs/energy/nodes/buildings/buildings_appliances_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_appliances_wood_pellets.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = buildings_appliances

--- a/graphs/energy/nodes/buildings/buildings_cooling_airconditioning_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_cooling_airconditioning_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_proven_tech,
     costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_cooling_collective_heatpump_water_water_ts_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_cooling_collective_heatpump_water_water_ts_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_proven_tech,
     costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_cooling_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_cooling_heatpump_air_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_cooling_heatpump_air_water_network_gas.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_cooling_heatpump_air_water_network_gas.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_cooling_heatpump_surface_water_water_ts_electricity.ad
+++ b/graphs/energy/nodes/buildings/buildings_cooling_heatpump_surface_water_water_ts_electricity.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_proven_tech,
     costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_lighting_efficient_fluorescent_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_lighting_efficient_fluorescent_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.light = 0.2
 - output.loss = elastic
-- groups = [emissions, application_group, lv_net_demand]
+- groups = [direct_emissions, application_group, lv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = buildings_appliances
 - merit_order.level = lv

--- a/graphs/energy/nodes/buildings/buildings_lighting_led_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_lighting_led_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.light = 0.45
 - output.loss = elastic
-- groups = [emissions, application_group, lv_net_demand]
+- groups = [direct_emissions, application_group, lv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = buildings_appliances
 - merit_order.level = lv

--- a/graphs/energy/nodes/buildings/buildings_lighting_standard_fluorescent_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_lighting_standard_fluorescent_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.light = 0.16
 - output.loss = elastic
-- groups = [emissions, application_group, lv_net_demand]
+- groups = [direct_emissions, application_group, lv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = buildings_appliances
 - merit_order.level = lv

--- a/graphs/energy/nodes/buildings/buildings_space_heater_coal.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.43
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_collective_heatpump_water_water_ts_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_collective_heatpump_water_water_ts_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, merit_order_csv_include, costs_building_and_installations_buildings,
     lt_delivery_system_buildings
     ]

--- a/graphs/energy/nodes/buildings/buildings_space_heater_combined_hydrogen.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_combined_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.086956522
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_crude_oil.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.85
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_district_heating_ht_steam_hot_water.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_district_heating_ht_steam_hot_water.ad
@@ -1,6 +1,6 @@
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, application_group, aggregator_producer, wacc_proven_tech,
+    direct_emissions, demand_driven, application_group, aggregator_producer, wacc_proven_tech,
     costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_district_heating_lt_steam_hot_water.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_district_heating_lt_steam_hot_water.ad
@@ -1,6 +1,6 @@
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, application_group, aggregator_producer, wacc_proven_tech,
+    direct_emissions, demand_driven, application_group, aggregator_producer, wacc_proven_tech,
     costs_building_and_installations_buildings, lt_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_district_heating_mt_steam_hot_water.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_district_heating_mt_steam_hot_water.ad
@@ -1,6 +1,6 @@
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, application_group, aggregator_producer, wacc_proven_tech,
+    direct_emissions, demand_driven, application_group, aggregator_producer, wacc_proven_tech,
     costs_building_and_installations_buildings, mt_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, merit_order_csv_include, costs_building_and_installations_buildings,
     ht_delivery_system_buildings
     ]

--- a/graphs/energy/nodes/buildings/buildings_space_heater_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_heatpump_air_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     lv_net_demand, wacc_proven_tech, merit_order_csv_include,
     costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]

--- a/graphs/energy/nodes/buildings/buildings_space_heater_heatpump_air_water_network_gas.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_heatpump_air_water_network_gas.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, costs_building_and_installations_buildings, lt_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_heatpump_surface_water_water_ts_electricity.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_heatpump_surface_water_water_ts_electricity.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, merit_order_csv_include, costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_hybrid_crude_oil_heatpump_air_water_electricity.ad
@@ -6,7 +6,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.crude_oil = 0.95
 - groups = [
-    emissions, cost_heat_pumps, demand_driven, heat_production, application_group,
+    direct_emissions, cost_heat_pumps, demand_driven, heat_production, application_group,
     aggregator_producer, lv_net_demand, wacc_proven_tech, merit_order_csv_include,
     mt_delivery_system_buildings, costs_building_and_installations_buildings
     ]

--- a/graphs/energy/nodes/buildings/buildings_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -5,7 +5,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.network_gas = 1.07
 - groups = [
-    emissions, cost_heat_pumps, demand_driven, heat_production, application_group,
+    direct_emissions, cost_heat_pumps, demand_driven, heat_production, application_group,
     aggregator_producer, lv_net_demand, wacc_proven_tech, merit_order_csv_include,
     mt_delivery_system_buildings, costs_building_and_installations_buildings
     ]

--- a/graphs/energy/nodes/buildings/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
@@ -7,7 +7,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.hydrogen = 1.08696
 - groups = [
-    emissions, cost_heat_pumps, demand_driven, heat_production, application_group,
+    direct_emissions, cost_heat_pumps, demand_driven, heat_production, application_group,
     aggregator_producer, lv_net_demand, wacc_proven_tech, merit_order_csv_include,
     mt_delivery_system_buildings, costs_building_and_installations_buildings
     ]

--- a/graphs/energy/nodes/buildings/buildings_space_heater_network_gas.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.067
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_solar_thermal.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_solar_thermal.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/buildings/buildings_space_heater_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/buildings/buildings_space_heater_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.82
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_proven_tech, costs_building_and_installations_buildings, ht_delivery_system_buildings
     ]
 - use = energetic

--- a/graphs/energy/nodes/bunkers/bunkers_plane_using_electricity.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_plane_using_electricity.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_aviation

--- a/graphs/energy/nodes/bunkers/bunkers_plane_using_hydrogen.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_plane_using_hydrogen.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_aviation

--- a/graphs/energy/nodes/bunkers/bunkers_plane_using_kerosene_mix.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_plane_using_kerosene_mix.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_aviation

--- a/graphs/energy/nodes/bunkers/bunkers_ship_using_ammonia.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_ship_using_ammonia.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_navigation

--- a/graphs/energy/nodes/bunkers/bunkers_ship_using_electricity.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_ship_using_electricity.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_navigation

--- a/graphs/energy/nodes/bunkers/bunkers_ship_using_heavy_fuel_oil.converter.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_ship_using_heavy_fuel_oil.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_navigation

--- a/graphs/energy/nodes/bunkers/bunkers_ship_using_hydrogen.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_ship_using_hydrogen.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_navigation

--- a/graphs/energy/nodes/bunkers/bunkers_ship_using_lng_mix.converter.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_ship_using_lng_mix.converter.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_navigation

--- a/graphs/energy/nodes/bunkers/bunkers_ship_using_methanol_mix.ad
+++ b/graphs/energy/nodes/bunkers/bunkers_ship_using_methanol_mix.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group, bunkers]
+- groups = [direct_emissions, application_group, bunkers]
 - free_co2_factor = 0.0
 - sector_label = bunkers_international_navigation

--- a/graphs/energy/nodes/energy/energy_biogas_fermentation_wet_biomass.converter.ad
+++ b/graphs/energy/nodes/energy/energy_biogas_fermentation_wet_biomass.converter.ad
@@ -1,7 +1,7 @@
 - output.biogas = 0.54
 - output.loss = elastic
 - groups = [
-    emissions, bio_footprint_calculation, wacc_proven_tech, costs_production_biomass,
+    direct_emissions, bio_footprint_calculation, wacc_proven_tech, costs_production_biomass,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_blastfurnace_transformation_cokes.converter.ad
+++ b/graphs/energy/nodes/energy/energy_blastfurnace_transformation_cokes.converter.ad
@@ -1,5 +1,5 @@
 - output.loss = elastic
-- groups = [emissions, sankey_conversion_group]
+- groups = [direct_emissions, sankey_conversion_group]
 - use = energetic
 - graph_methods = [input, output]
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_chemical_fertilizers_transformation_external_coupling_node.ad
+++ b/graphs/energy/nodes/energy/energy_chemical_fertilizers_transformation_external_coupling_node.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, sankey_conversion_group, industry_transformation,
+    direct_emissions, preset_demand, sankey_conversion_group, industry_transformation,
     non_final_electricity_demand_converters, methanol_production, hydrogen_production,
     biomass_products_production, natural_gas_production, ammonia_production,
     oil_and_oil_products_production

--- a/graphs/energy/nodes/energy/energy_chemical_other_transformation_external_coupling_node.ad
+++ b/graphs/energy/nodes/energy/energy_chemical_other_transformation_external_coupling_node.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, sankey_conversion_group, industry_transformation,
+    direct_emissions, preset_demand, sankey_conversion_group, industry_transformation,
     non_final_electricity_demand_converters, methanol_production, hydrogen_production,
     biomass_products_production, natural_gas_production, ammonia_production,
     oil_and_oil_products_production

--- a/graphs/energy/nodes/energy/energy_chemical_refineries_transformation_external_coupling_node.ad
+++ b/graphs/energy/nodes/energy/energy_chemical_refineries_transformation_external_coupling_node.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, sankey_conversion_group, industry_transformation,
+    direct_emissions, preset_demand, sankey_conversion_group, industry_transformation,
     non_final_electricity_demand_converters, methanol_production, hydrogen_production,
     biomass_products_production, natural_gas_production, ammonia_production,
     oil_and_oil_products_production

--- a/graphs/energy/nodes/energy/energy_chp_coal_gas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_coal_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, must_run_electricity_production, central_production, electricity_production,
+    direct_emissions, must_run_electricity_production, central_production, electricity_production,
     heat_production, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_chp_combined_cycle_ht_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_combined_cycle_ht_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_combined_cycle_mt_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_combined_cycle_mt_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_engine_ht_biogas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_engine_ht_biogas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, heat_production,
     must_run_electricity_production, wacc_proven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_engine_ht_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_engine_ht_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
+    direct_emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
     wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_chp_local_engine_mt_biogas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_engine_mt_biogas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, heat_production,
     must_run_electricity_production, wacc_proven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_engine_mt_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_engine_mt_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
+    direct_emissions, preset_demand, electricity_production, heat_production, dispatchable_production,
     wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_ccs_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_ccs_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
     dispatchable_production, wacc_unproven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_ccs_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_ccs_must_run.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair,
     must_run_electricity_production, heat_production, wacc_unproven_tech,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
     dispatchable_production, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_ht_wood_pellets_must_run.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair,
     must_run_electricity_production, heat_production, wacc_proven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_ccs_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_ccs_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
     dispatchable_production, wacc_unproven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_ccs_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_ccs_must_run.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair,
     must_run_electricity_production, heat_production, wacc_unproven_tech,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair, heat_production,
     dispatchable_production, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_chp_local_mt_wood_pellets_must_run.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, electricity_production, ccs_technology_pair,
     must_run_electricity_production, heat_production, wacc_proven_tech, costs_production_chp_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_supercritical_ccs_ht_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_chp_supercritical_ccs_ht_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, heat_production, hv_net_supply, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_supercritical_ccs_mt_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_chp_supercritical_ccs_mt_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     ccs_technology_pair, heat_production, hv_net_supply, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_supercritical_ht_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_chp_supercritical_ht_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, heat_production, hv_net_supply, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_supercritical_mt_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_chp_supercritical_mt_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, heat_production, hv_net_supply, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_cofiring_ht_coal.ad
+++ b/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_cofiring_ht_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_cofiring_mt_coal.ad
+++ b/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_cofiring_mt_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_ht_coal.ad
+++ b/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_ht_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_ht_lignite.ad
+++ b/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_ht_lignite.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_mt_coal.ad
+++ b/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_mt_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_mt_lignite.ad
+++ b/graphs/energy/nodes/energy/energy_chp_ultra_supercritical_mt_lignite.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     heat_production, hv_net_supply, wacc_proven_tech, primary_heat_infrastructure,
     costs_production_chp_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_cokesoven_transformation_coal.converter.ad
+++ b/graphs/energy/nodes/energy/energy_cokesoven_transformation_coal.converter.ad
@@ -1,5 +1,5 @@
 - output.loss = elastic
-- groups = [emissions, sankey_conversion_group]
+- groups = [direct_emissions, sankey_conversion_group]
 - use = energetic
 - graph_methods = [output]
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_compressor_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_compressor_network_gas.ad
@@ -3,7 +3,7 @@
 - output.compressed_network_gas = 0.931
 - output.loss = elastic
 - groups = [
-    emissions, non_final_electricity_demand_converters, mv_net_demand, wacc_proven_tech,
+    direct_emissions, non_final_electricity_demand_converters, mv_net_demand, wacc_proven_tech,
     costs_production_other, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_greengas_gasification_dry_biomass.ad
+++ b/graphs/energy/nodes/energy/energy_greengas_gasification_dry_biomass.ad
@@ -1,7 +1,7 @@
 - output.greengas = 0.602
 - output.loss = elastic
 - groups = [
-    emissions, bio_footprint_calculation, wacc_proven_tech, costs_production_biomass,
+    direct_emissions, bio_footprint_calculation, wacc_proven_tech, costs_production_biomass,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_greengas_gasification_wet_biomass.ad
+++ b/graphs/energy/nodes/energy/energy_greengas_gasification_wet_biomass.ad
@@ -1,7 +1,7 @@
 - output.greengas = 0.68
 - output.loss = elastic
 - groups = [
-    emissions, bio_footprint_calculation, wacc_unproven_tech, costs_production_biomass,
+    direct_emissions, bio_footprint_calculation, wacc_unproven_tech, costs_production_biomass,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_greengas_upgrade_biogas.converter.ad
+++ b/graphs/energy/nodes/energy/energy_greengas_upgrade_biogas.converter.ad
@@ -1,7 +1,7 @@
 - input.biogas = 1.0
 - output.greengas = 0.995
 - output.loss = elastic
-- groups = [emissions, wacc_proven_tech, costs_production_biomass, sankey_conversion_group]
+- groups = [direct_emissions, wacc_proven_tech, costs_production_biomass, sankey_conversion_group]
 - use = energetic
 - availability = 0.98
 - typical_input_capacity = 4.74

--- a/graphs/energy/nodes/energy/energy_heat_backup_burner_ht_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_heat_backup_burner_ht_network_gas.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 1.03
 - groups = [
-    emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_backup_burner_lt_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_heat_backup_burner_lt_network_gas.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 1.03
 - groups = [
-    emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_backup_burner_mt_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_heat_backup_burner_mt_network_gas.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 1.03
 - groups = [
-    emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, heat_production, central_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_boiler_ht_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_boiler_ht_electricity.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, central_production, non_final_electricity_demand_converters,
+    direct_emissions, heat_production, central_production, non_final_electricity_demand_converters,
     wacc_proven_tech, preset_demand, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_boiler_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_boiler_lt_electricity.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, central_production, non_final_electricity_demand_converters,
+    direct_emissions, heat_production, central_production, non_final_electricity_demand_converters,
     wacc_proven_tech, preset_demand, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_boiler_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_boiler_mt_electricity.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, central_production, non_final_electricity_demand_converters,
+    direct_emissions, heat_production, central_production, non_final_electricity_demand_converters,
     wacc_proven_tech, preset_demand, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_ht_coal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_ht_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_ht_crude_oil.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_ht_crude_oil.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_ht_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_ht_hydrogen.ad
@@ -2,7 +2,7 @@
 
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, central_production, preset_demand, wacc_proven_tech,
+    direct_emissions, heat_production, central_production, preset_demand, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_ht_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_ht_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, heat_production, central_production, wacc_proven_tech,
+    direct_emissions, preset_demand, heat_production, central_production, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_ht_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_ht_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_ht_wood_pellets.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_ht_wood_pellets.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_lt_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_lt_hydrogen.ad
@@ -2,7 +2,7 @@
 
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, central_production, preset_demand, wacc_proven_tech,
+    direct_emissions, heat_production, central_production, preset_demand, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_mt_coal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_mt_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_mt_crude_oil.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_mt_crude_oil.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_mt_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_mt_hydrogen.ad
@@ -2,7 +2,7 @@
 
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, central_production, preset_demand, wacc_proven_tech,
+    direct_emissions, heat_production, central_production, preset_demand, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_mt_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_mt_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, heat_production, central_production, wacc_proven_tech,
+    direct_emissions, preset_demand, heat_production, central_production, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_mt_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_mt_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     primary_heat_infrastructure, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_burner_mt_wood_pellets.ad
+++ b/graphs/energy/nodes/energy/energy_heat_burner_mt_wood_pellets.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, central_production, heat_production, wacc_proven_tech,
     costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_boiler_ht_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_boiler_ht_electricity.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.995
 - groups = [
-    emissions, heat_production, central_production, mv_net_flexibility, p2h, wacc_proven_tech,
+    direct_emissions, heat_production, central_production, mv_net_flexibility, p2h, wacc_proven_tech,
     costs_storage_and_conversion_p2h, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_boiler_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_boiler_mt_electricity.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.995
 - groups = [
-    emissions, heat_production, central_production, mv_net_flexibility, p2h, wacc_proven_tech,
+    direct_emissions, heat_production, central_production, mv_net_flexibility, p2h, wacc_proven_tech,
     costs_storage_and_conversion_p2h, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_heatpump_ht_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_heatpump_ht_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.2222222222222222
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, central_production, wacc_proven_tech,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, central_production, wacc_proven_tech,
     costs_storage_and_conversion_p2h, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_heatpump_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_flexibility_p2h_heatpump_mt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.2222222222222222
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, central_production, wacc_proven_tech,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, central_production, wacc_proven_tech,
     costs_storage_and_conversion_p2h, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_lt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.27
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_drink_water_water_ts_mt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.385
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_lt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.286
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_surface_water_water_ts_mt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.37
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_lt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.27
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_waste_water_water_ts_mt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.385
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_ht_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_ht_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.2222222222222222
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, heat_production, central_production, non_final_electricity_demand_converters,
+    direct_emissions, heat_production, central_production, non_final_electricity_demand_converters,
     wacc_proven_tech, preset_demand, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_lt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_lt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.2222222222222222
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, heat_production, central_production, non_final_electricity_demand_converters,
+    direct_emissions, heat_production, central_production, non_final_electricity_demand_converters,
     wacc_proven_tech, preset_demand, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_mt_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_heat_heatpump_water_water_mt_electricity.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.2222222222222222
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, heat_production, central_production, non_final_electricity_demand_converters,
+    direct_emissions, heat_production, central_production, non_final_electricity_demand_converters,
     wacc_proven_tech, preset_demand, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_solar_ht_solar_thermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_solar_ht_solar_thermal.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.6
 - groups = [
-    emissions, preset_demand, heat_production, central_production, primary_energy_demand,
+    direct_emissions, preset_demand, heat_production, central_production, primary_energy_demand,
     wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_solar_lt_solar_thermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_solar_lt_solar_thermal.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.6
 - groups = [
-    emissions, preset_demand, heat_production, central_production, primary_energy_demand,
+    direct_emissions, preset_demand, heat_production, central_production, primary_energy_demand,
     wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_solar_mt_solar_thermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_solar_mt_solar_thermal.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.6
 - groups = [
-    emissions, preset_demand, heat_production, central_production, primary_energy_demand,
+    direct_emissions, preset_demand, heat_production, central_production, primary_energy_demand,
     wacc_proven_tech, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_heat_well_deep_ht_geothermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_well_deep_ht_geothermal.ad
@@ -2,7 +2,7 @@
 - input.geothermal = 0.95
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_well_deep_mt_geothermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_well_deep_mt_geothermal.ad
@@ -2,7 +2,7 @@
 - input.geothermal = 0.95
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_well_shallow_heatpump_mt_geothermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_well_shallow_heatpump_mt_geothermal.ad
@@ -2,7 +2,7 @@
 - input.geothermal = 0.79
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_heat_well_shallow_lt_geothermal.ad
+++ b/graphs/energy/nodes/energy/energy_heat_well_shallow_lt_geothermal.ad
@@ -2,7 +2,7 @@
 - input.geothermal = 0.95
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, central_production,
+    direct_emissions, preset_demand, heat_production, central_production,
     non_final_electricity_demand_converters, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_hydrogen_ammonia_reformer_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_ammonia_reformer_dispatchable.ad
@@ -2,7 +2,7 @@
 - output.hydrogen = 0.685
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_ammonia_reformer_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_ammonia_reformer_must_run.ad
@@ -2,7 +2,7 @@
 - output.hydrogen = 0.685
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_ccs_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_ccs_must_run.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.7107843137254902
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_dispatchable.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.7531132230050795
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_proven_tech,
+    direct_emissions, hydrogen_production, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_autothermal_reformer_must_run.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.7531132230050795
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, ccs_technology_pair, wacc_proven_tech,
+    direct_emissions, hydrogen_production, ccs_technology_pair, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.461
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_biomass_gasification_ccs.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.44799999999999995
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_electrolysis_solar_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_electrolysis_solar_electricity.ad
@@ -2,7 +2,7 @@
 - output.hydrogen = 0.66
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group, preset_demand
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_electrolysis_wind_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_electrolysis_wind_electricity.ad
@@ -2,7 +2,7 @@
 - output.hydrogen = 0.66
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group, preset_demand
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_flexibility_p2g_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_flexibility_p2g_electricity.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.residual_heat = 0.195
 - groups = [
-    emissions, hv_net_flexibility, hydrogen_production, p2g, wacc_unproven_tech,
+    direct_emissions, hv_net_flexibility, hydrogen_production, p2g, wacc_unproven_tech,
     costs_storage_and_conversion_electrolysis, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_hybrid_electrolysis_wind_electricity.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_hybrid_electrolysis_wind_electricity.ad
@@ -2,7 +2,7 @@
 - output.hydrogen = 0.66
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_unproven_tech, costs_storage_and_conversion_electrolysis,
+    direct_emissions, hydrogen_production, wacc_unproven_tech, costs_storage_and_conversion_electrolysis,
     sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_liquid_hydrogen_regasifier.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_liquid_hydrogen_regasifier.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.986
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_proven_tech,
+    direct_emissions, hydrogen_production, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_lohc_reformer.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_lohc_reformer.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.694
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_proven_tech,
+    direct_emissions, hydrogen_production, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_solar_pv_solar_radiation.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.17
 - output.loss = elastic
 - groups = [
-    emissions, primary_energy_demand, sustainable_production, wacc_proven_tech,
+    direct_emissions, primary_energy_demand, sustainable_production, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, preset_demand
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_ccs_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_ccs_must_run.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.745449777078416
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
+    direct_emissions, hydrogen_production, ccs_technology_pair, wacc_unproven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_dispatchable.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.8130081300813008
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, wacc_proven_tech,
+    direct_emissions, hydrogen_production, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_steam_methane_reformer_must_run.ad
@@ -3,7 +3,7 @@
 - output.hydrogen = 0.8130081300813008
 - output.loss = elastic
 - groups = [
-    emissions, hydrogen_production, ccs_technology_pair, wacc_proven_tech,
+    direct_emissions, hydrogen_production, ccs_technology_pair, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, sankey_conversion_group
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_hydrogen_wind_turbine_offshore.ad
+++ b/graphs/energy/nodes/energy/energy_hydrogen_wind_turbine_offshore.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.97
 - output.loss = elastic
 - groups = [
-    emissions, primary_energy_demand, sustainable_production, wacc_proven_tech,
+    direct_emissions, primary_energy_demand, sustainable_production, wacc_proven_tech,
     costs_production_dedicated_hydrogen_production, preset_demand
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_national_gas_network_natural_gas.converter.ad
+++ b/graphs/energy/nodes/energy/energy_national_gas_network_natural_gas.converter.ad
@@ -1,5 +1,5 @@
 - output.loss = elastic
-- groups = [emissions, sankey_conversion_group, network_gas_production]
+- groups = [direct_emissions, sankey_conversion_group, network_gas_production]
 - use = energetic
 - free_co2_factor = 0.0
 - sector_label = energy_fuels_production

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_ccs_coal.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_ccs_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_unproven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_ccs_network_gas_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_ccs_network_gas_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_unproven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_coal.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_coal_gas.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_coal_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, must_run_electricity_production, central_production, electricity_production,
+    direct_emissions, must_run_electricity_production, central_production, electricity_production,
     costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_hydrogen.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.6
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_unproven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_network_gas_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_network_gas_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_combined_cycle_network_gas_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_power_combined_cycle_network_gas_must_run.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production,
+    direct_emissions, preset_demand, central_production, electricity_production,
     must_run_electricity_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_engine_diesel.ad
+++ b/graphs/energy/nodes/energy/energy_power_engine_diesel.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_engine_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_power_engine_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_geothermal.ad
+++ b/graphs/energy/nodes/energy/energy_power_geothermal.ad
@@ -2,7 +2,7 @@
 - output.electricity = 0.25
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_hybrid_wind_turbine_offshore.ad
+++ b/graphs/energy/nodes/energy/energy_power_hybrid_wind_turbine_offshore.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.97
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_hydro_mountain.ad
+++ b/graphs/energy/nodes/energy/energy_power_hydro_mountain.ad
@@ -2,7 +2,7 @@
 - output.electricity = 0.95
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, dispatchable_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_hydro_river.ad
+++ b/graphs/energy/nodes/energy/energy_power_hydro_river.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.98
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_nuclear_gen2_uranium_oxide.ad
+++ b/graphs/energy/nodes/energy/energy_power_nuclear_gen2_uranium_oxide.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_unproven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_nuclear_gen3_uranium_oxide.ad
+++ b/graphs/energy/nodes/energy/energy_power_nuclear_gen3_uranium_oxide.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_unproven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_nuclear_small_modular_reactor_uranium_oxide.ad
+++ b/graphs/energy/nodes/energy/energy_power_nuclear_small_modular_reactor_uranium_oxide.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.28
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_unproven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_solar_csp_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_power_solar_csp_solar_radiation.ad
@@ -2,7 +2,7 @@
 - output.electricity = 0.35
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_solar_pv_offshore.ad
+++ b/graphs/energy/nodes/energy/energy_power_solar_pv_offshore.ad
@@ -2,7 +2,7 @@
 - output.electricity = 0.17
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_solar_pv_solar_radiation.ad
+++ b/graphs/energy/nodes/energy/energy_power_solar_pv_solar_radiation.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.17
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_supercritical_ccs_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_power_supercritical_ccs_waste_mix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_supercritical_coal.ad
+++ b/graphs/energy/nodes/energy/energy_power_supercritical_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_supercritical_waste_mix.ad
+++ b/graphs/energy/nodes/energy/energy_power_supercritical_waste_mix.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.0
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_turbine_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_power_turbine_hydrogen.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.34
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_unproven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_turbine_network_gas_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_power_turbine_network_gas_dispatchable.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_turbine_network_gas_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_power_turbine_network_gas_must_run.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production,
+    direct_emissions, preset_demand, central_production, electricity_production,
     must_run_electricity_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_ccs_coal.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_ccs_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_unproven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_coal.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_cofiring_coal.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_cofiring_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_crude_oil.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_crude_oil.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_lignite.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_lignite.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_network_gas.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_network_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, dispatchable_production,
+    direct_emissions, preset_demand, central_production, electricity_production, dispatchable_production,
     hv_net_supply, wacc_proven_tech, costs_production_power_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
+++ b/graphs/energy/nodes/energy/energy_power_ultra_supercritical_oxyfuel_ccs_lignite.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_wind_turbine_coastal.ad
+++ b/graphs/energy/nodes/energy/energy_power_wind_turbine_coastal.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.97
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_wind_turbine_inland.ad
+++ b/graphs/energy/nodes/energy/energy_power_wind_turbine_inland.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.97
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_wind_turbine_offshore.ad
+++ b/graphs/energy/nodes/energy/energy_power_wind_turbine_offshore.ad
@@ -1,7 +1,7 @@
 - output.electricity = 0.97
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
+    direct_emissions, preset_demand, central_production, electricity_production, primary_energy_demand,
     sustainable_production, volatile_production, hv_net_supply, wacc_proven_tech,
     costs_production_power_plants
     ]

--- a/graphs/energy/nodes/energy/energy_power_wood_pellets_ccs_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_power_wood_pellets_ccs_dispatchable.ad
@@ -5,7 +5,7 @@
 - output.electricity = 0.361
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_unproven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_wood_pellets_ccs_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_power_wood_pellets_ccs_must_run.ad
@@ -5,7 +5,7 @@
 - output.electricity = 0.361
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     must_run_electricity_production, hv_net_supply, wacc_unproven_tech,
     costs_production_power_plants, sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_wood_pellets_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_power_wood_pellets_dispatchable.ad
@@ -5,7 +5,7 @@
 - output.electricity = 0.46
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     dispatchable_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_power_wood_pellets_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_power_wood_pellets_must_run.ad
@@ -5,7 +5,7 @@
 - output.electricity = 0.46
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
+    direct_emissions, preset_demand, central_production, electricity_production, ccs_technology_pair,
     must_run_electricity_production, hv_net_supply, wacc_proven_tech, costs_production_power_plants,
     sankey_conversion_group
     ]

--- a/graphs/energy/nodes/energy/energy_production_bio_ethanol.ad
+++ b/graphs/energy/nodes/energy/energy_production_bio_ethanol.ad
@@ -3,7 +3,7 @@
 - output.bio_ethanol = 0.47
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, biomass_products_production
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_bio_ethanol_to_jet.ad
+++ b/graphs/energy/nodes/energy/energy_production_bio_ethanol_to_jet.ad
@@ -4,7 +4,7 @@
 - output.biodiesel = 0.1733
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_bio_lng.ad
+++ b/graphs/energy/nodes/energy/energy_production_bio_lng.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.bio_lng = 0.432
 - output.loss = elastic
-- groups = [emissions, bio_footprint_calculation, sankey_conversion_group]
+- groups = [direct_emissions, bio_footprint_calculation, sankey_conversion_group]
 - free_co2_factor = 0.0
 - sector_label = energy_fuels_production

--- a/graphs/energy/nodes/energy/energy_production_bio_oil.ad
+++ b/graphs/energy/nodes/energy/energy_production_bio_oil.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.bio_oil = 0.998
 - output.loss = elastic
-- groups = [emissions, bio_footprint_calculation, sankey_conversion_group]
+- groups = [direct_emissions, bio_footprint_calculation, sankey_conversion_group]
 - free_co2_factor = 0.0
 - sector_label = energy_fuels_production

--- a/graphs/energy/nodes/energy/energy_production_biomethanol_to_jet.ad
+++ b/graphs/energy/nodes/energy/energy_production_biomethanol_to_jet.ad
@@ -4,7 +4,7 @@
 - output.bionaphtha = 0.14402
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_fischer_tropsch_biogenic_waste_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_production_fischer_tropsch_biogenic_waste_ccs.ad
@@ -4,7 +4,7 @@
 - output.bionaphtha = 0.14484
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, biomass_products_production
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_fischer_tropsch_dry_biomass_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_production_fischer_tropsch_dry_biomass_ccs.ad
@@ -4,7 +4,7 @@
 - output.bionaphtha = 0.14484
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, biomass_products_production
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_fischer_tropsch_non_biogenic_waste_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_production_fischer_tropsch_non_biogenic_waste_ccs.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - output.naphtha = 0.14484
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, oil_and_oil_products_production
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_fischer_tropsch_synthetic_dispatchable.ad
+++ b/graphs/energy/nodes/energy/energy_production_fischer_tropsch_synthetic_dispatchable.ad
@@ -8,7 +8,7 @@
 - output.kerosene = 0.525
 - output.loss = elastic
 - groups = [
-    emissions, co2_emissions_primary, costs_production_liquid_fuels, wacc_unproven_tech,
+    direct_emissions, co2_emissions_primary, costs_production_liquid_fuels, wacc_unproven_tech,
     mv_net_flexibility, sankey_conversion_group, application_group, synthetic_products_production,
     oil_and_oil_products_production, non_final_electricity_demand_converters
     ]

--- a/graphs/energy/nodes/energy/energy_production_fischer_tropsch_synthetic_must_run.ad
+++ b/graphs/energy/nodes/energy/energy_production_fischer_tropsch_synthetic_must_run.ad
@@ -8,7 +8,7 @@
 - output.kerosene = 0.525
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, co2_emissions_primary, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, co2_emissions_primary, costs_production_liquid_fuels,
     wacc_unproven_tech, sankey_conversion_group, application_group, synthetic_products_production,
     oil_and_oil_products_production, non_final_electricity_demand_converters
     ]

--- a/graphs/energy/nodes/energy/energy_production_fractionation_bio_pyrolysis_oil.ad
+++ b/graphs/energy/nodes/energy/energy_production_fractionation_bio_pyrolysis_oil.ad
@@ -5,7 +5,7 @@
 - output.bionaphtha = 0.244
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_fractionation_bio_pyrolysis_oil_burner_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_production_fractionation_bio_pyrolysis_oil_burner_hydrogen.ad
@@ -1,7 +1,7 @@
 - input.hydrogen = 1.0
 - output.loss = elastic
 - output.steam_hot_water = 0.9
-- groups = [emissions, application_group, wacc_proven_tech, costs_production_liquid_fuels]
+- groups = [direct_emissions, application_group, wacc_proven_tech, costs_production_liquid_fuels]
 - use = energetic
 - availability = 1.0
 - full_load_hours = 2190.0

--- a/graphs/energy/nodes/energy/energy_production_fractionation_pyrolysis_oil.ad
+++ b/graphs/energy/nodes/energy/energy_production_fractionation_pyrolysis_oil.ad
@@ -5,7 +5,7 @@
 - output.loss = elastic
 - output.naphtha = 0.169
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
     oil_and_oil_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_fractionation_pyrolysis_oil_burner_hydrogen.ad
+++ b/graphs/energy/nodes/energy/energy_production_fractionation_pyrolysis_oil_burner_hydrogen.ad
@@ -1,7 +1,7 @@
 - input.hydrogen = 1.0
 - output.loss = elastic
 - output.steam_hot_water = 0.9
-- groups = [emissions, application_group, wacc_proven_tech, costs_production_liquid_fuels]
+- groups = [direct_emissions, application_group, wacc_proven_tech, costs_production_liquid_fuels]
 - use = energetic
 - availability = 1.0
 - full_load_hours = 2190.0

--- a/graphs/energy/nodes/energy/energy_production_hvo_bio_kerosene.ad
+++ b/graphs/energy/nodes/energy/energy_production_hvo_bio_kerosene.ad
@@ -5,7 +5,7 @@
 - output.bionaphtha = 0.082
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_hvo_biodiesel.ad
+++ b/graphs/energy/nodes/energy/energy_production_hvo_biodiesel.ad
@@ -4,7 +4,7 @@
 - output.bionaphtha = 0.07
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, preset_demand, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_methanol_synthesis_biogenic_waste_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_production_methanol_synthesis_biogenic_waste_ccs.ad
@@ -2,7 +2,7 @@
 - output.biomethanol = 0.61
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, biomass_products_production
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_production_methanol_synthesis_dry_biomass_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_production_methanol_synthesis_dry_biomass_ccs.ad
@@ -2,7 +2,7 @@
 - output.biomethanol = 0.61
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, biomass_products_production
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_production_methanol_synthesis_non_biogenic_waste_ccs.ad
+++ b/graphs/energy/nodes/energy/energy_production_methanol_synthesis_non_biogenic_waste_ccs.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.methanol = 0.61
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, methanol_production
     ]
 - use = non_energetic

--- a/graphs/energy/nodes/energy/energy_production_methanol_synthesis_synthetic.ad
+++ b/graphs/energy/nodes/energy/energy_production_methanol_synthesis_synthetic.ad
@@ -7,7 +7,7 @@
 - output.methanol = 0.787
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, synthetic_products_production, methanol_production,
     non_final_electricity_demand_converters, co2_emissions_primary
     ]

--- a/graphs/energy/nodes/energy/energy_production_methanol_to_jet.ad
+++ b/graphs/energy/nodes/energy/energy_production_methanol_to_jet.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - output.naphtha = 0.1415
 - groups = [
-    emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
+    direct_emissions, preset_demand, wacc_unproven_tech, costs_production_liquid_fuels,
     sankey_conversion_group, application_group, oil_and_oil_products_production
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_pyrolysis_biogenic_waste.ad
+++ b/graphs/energy/nodes/energy/energy_production_pyrolysis_biogenic_waste.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.178
 - groups = [
-    emissions, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_pyrolysis_dry_biomass.ad
+++ b/graphs/energy/nodes/energy/energy_production_pyrolysis_dry_biomass.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.178
 - groups = [
-    emissions, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, wacc_unproven_tech, sankey_conversion_group, application_group,
     biomass_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_pyrolysis_non_biogenic_waste.ad
+++ b/graphs/energy/nodes/energy/energy_production_pyrolysis_non_biogenic_waste.ad
@@ -3,7 +3,7 @@
 - output.pyrolysis_oil = 0.623
 - output.steam_hot_water = 0.178
 - groups = [
-    emissions, wacc_unproven_tech, sankey_conversion_group, application_group,
+    direct_emissions, wacc_unproven_tech, sankey_conversion_group, application_group,
     oil_and_oil_products_production, costs_production_liquid_fuels
     ]
 - use = energetic

--- a/graphs/energy/nodes/energy/energy_production_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/energy/energy_production_wood_pellets.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.wood_pellets = 0.9
-- groups = [emissions, bio_footprint_calculation, sankey_conversion_group]
+- groups = [direct_emissions, bio_footprint_calculation, sankey_conversion_group]
 - free_co2_factor = 0.0
 - sector_label = energy_fuels_production

--- a/graphs/energy/nodes/energy/energy_regasification_lng.ad
+++ b/graphs/energy/nodes/energy/energy_regasification_lng.ad
@@ -5,7 +5,7 @@
 
 - output.loss = elastic
 - output.natural_gas = 0.985
-- groups = [emissions, wacc_proven_tech, costs_production_other, sankey_conversion_group]
+- groups = [direct_emissions, wacc_proven_tech, costs_production_other, sankey_conversion_group]
 - use = energetic
 - availability = 0.99
 - full_load_hours = 8700.0

--- a/graphs/energy/nodes/energy/energy_torrefaction_wood.converter.ad
+++ b/graphs/energy/nodes/energy/energy_torrefaction_wood.converter.ad
@@ -3,7 +3,7 @@
 - output.torrefied_biomass_pellets = 0.86
 - input.network_gas = 0.053
 - input.dry_biomass = 0.947
-- groups = [emissions, bio_footprint_calculation, sankey_conversion_group]
+- groups = [direct_emissions, bio_footprint_calculation, sankey_conversion_group]
 - network_gas.profile = flat
 - network_gas.type = consumer
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/energy/energy_treatment_natural_gas.ad
+++ b/graphs/energy/nodes/energy/energy_treatment_natural_gas.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - output.natural_gas = 0.986016667985657
-- groups = [emissions, sankey_conversion_group]
+- groups = [direct_emissions, sankey_conversion_group]
 - use = energetic
 - free_co2_factor = 0.0
 - sector_label = energy_fuels_production

--- a/graphs/energy/nodes/households/households_appliances_clothes_dryer_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_clothes_dryer_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_computer_media_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_computer_media_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_dishwasher_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_dishwasher_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_fridge_freezer_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_fridge_freezer_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_other_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_other_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_television_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_television_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_vacuum_cleaner_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_vacuum_cleaner_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_appliances_washing_machine_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_appliances_washing_machine_electricity.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
+- groups = [direct_emissions, preset_demand, useful_demand, useful_demand_electric, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_appliances

--- a/graphs/energy/nodes/households/households_cooker_halogen_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_cooker_halogen_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.6
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_cooking

--- a/graphs/energy/nodes/households/households_cooker_induction_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_cooker_induction_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.85
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_cooking

--- a/graphs/energy/nodes/households/households_cooker_network_gas.converter.ad
+++ b/graphs/energy/nodes/households/households_cooker_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.4
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - network_gas.type = consumer
 - network_gas.profile = households_appliances
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/households/households_cooker_resistive_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_cooker_resistive_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.55
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_cooking

--- a/graphs/energy/nodes/households/households_cooker_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/households/households_cooker_wood_pellets.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.3
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_cooking

--- a/graphs/energy/nodes/households/households_cooling_airconditioning_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_cooling_airconditioning_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_households,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_cooling_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_cooling_heatpump_air_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_households,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_cooling_heatpump_ground_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_cooling_heatpump_ground_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_households,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_cooling_heatpump_surface_water_water_ts_electricity.ad
+++ b/graphs/energy/nodes/households/households_cooling_heatpump_surface_water_water_ts_electricity.ad
@@ -3,7 +3,7 @@
 - output.cooling = 1.0
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, application_group, lv_net_demand, wacc_households,
+    direct_emissions, heat_production, application_group, lv_net_demand, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_final_demand_for_cooling_network_gas.ad
+++ b/graphs/energy/nodes/households/households_final_demand_for_cooling_network_gas.ad
@@ -2,6 +2,6 @@
 # application nodes for households cooling using network gas
 
 - use = energetic
-- groups = [emissions]
+- groups = [direct_emissions]
 - free_co2_factor = 0.0
 - sector_label = households_cooling

--- a/graphs/energy/nodes/households/households_lighting_efficient_fluorescent_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_lighting_efficient_fluorescent_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.light = 0.25
 - output.loss = elastic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_lighting

--- a/graphs/energy/nodes/households/households_lighting_incandescent_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_lighting_incandescent_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.light = 0.05
 - output.loss = elastic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_lighting

--- a/graphs/energy/nodes/households/households_lighting_led_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_lighting_led_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.light = 0.5
 - output.loss = elastic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = households_lighting

--- a/graphs/energy/nodes/households/households_space_heater_coal.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.43
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_combined_hydrogen.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_combined_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.1
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_combined_network_gas.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_combined_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.07
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_crude_oil.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.85
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_district_heating_ht_steam_hot_water.ad
+++ b/graphs/energy/nodes/households/households_space_heater_district_heating_ht_steam_hot_water.ad
@@ -1,6 +1,6 @@
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
     costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_district_heating_lt_steam_hot_water.ad
+++ b/graphs/energy/nodes/households/households_space_heater_district_heating_lt_steam_hot_water.ad
@@ -1,6 +1,6 @@
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
     costs_building_and_installations_households, lt_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_district_heating_mt_steam_hot_water.ad
+++ b/graphs/energy/nodes/households/households_space_heater_district_heating_mt_steam_hot_water.ad
@@ -1,6 +1,6 @@
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
     costs_building_and_installations_households, mt_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, ht_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_heatpump_air_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, ht_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_heatpump_ground_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_heatpump_ground_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, lt_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_heatpump_pvt_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_heatpump_pvt_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, lt_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_heatpump_surface_water_water_ts_electricity.ad
+++ b/graphs/energy/nodes/households/households_space_heater_heatpump_surface_water_water_ts_electricity.ad
@@ -4,7 +4,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity.ad
+++ b/graphs/energy/nodes/households/households_space_heater_hybrid_crude_oil_heatpump_air_water_electricity.ad
@@ -6,7 +6,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.crude_oil = 0.95
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, mt_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.network_gas = 1.07
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, mt_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
@@ -7,7 +7,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.hydrogen = 1.08696
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_space_heating_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households, mt_delivery_system_households
     ]

--- a/graphs/energy/nodes/households/households_space_heater_network_gas.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_space_heater_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/households/households_space_heater_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.82
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households, ht_delivery_system_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_coal.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.43
 - groups = [
-    emissions, demand_driven, aggregator_producer, wacc_households, heat_production,
+    direct_emissions, demand_driven, aggregator_producer, wacc_households, heat_production,
     application_group, costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_combined_hydrogen.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_combined_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.72
 - groups = [
-    emissions, demand_driven, heat_production, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_combined_network_gas.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_combined_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_crude_oil.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.85
 - groups = [
-    emissions, demand_driven, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, application_group, aggregator_producer, wacc_households,
     heat_production, costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_district_heating_ht_steam_hot_water.ad
+++ b/graphs/energy/nodes/households/households_water_heater_district_heating_ht_steam_hot_water.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_district_heating_lt_steam_hot_water.ad
+++ b/graphs/energy/nodes/households/households_water_heater_district_heating_lt_steam_hot_water.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_district_heating_mt_steam_hot_water.ad
+++ b/graphs/energy/nodes/households/households_water_heater_district_heating_mt_steam_hot_water.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, etmoses, application_group, aggregator_producer, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_heatpump_air_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_heatpump_ground_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_heatpump_ground_water_electricity.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_heatpump_pvt_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_heatpump_pvt_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_heatpump_surface_water_water_ts_electricity.ad
+++ b/graphs/energy/nodes/households/households_water_heater_heatpump_surface_water_water_ts_electricity.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, demand_driven, heat_production, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity.ad
+++ b/graphs/energy/nodes/households/households_water_heater_hybrid_crude_oil_heatpump_air_water_electricity.ad
@@ -6,7 +6,7 @@
 - output.useable_heat.electricity = 1.0
 - output.useable_heat.crude_oil = 0.95
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_hybrid_heatpump_air_water_electricity.converter.ad
@@ -4,7 +4,7 @@
 - output.useable_heat.electricity = 1
 - output.useable_heat.network_gas = 0.9
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_hybrid_hydrogen_heatpump_air_water_electricity.converter.ad
@@ -7,7 +7,7 @@
 - output.useable_heat.electricity = 1
 - output.useable_heat.hydrogen = 0.951659795
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_network_gas.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.67
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
+    direct_emissions, demand_driven, heat_production, etmoses, application_group, aggregator_producer,
     wacc_households, costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_resistive_electricity.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_resistive_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.95
 - groups = [
-    emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
+    direct_emissions, demand_driven, heat_production, etmoses, merit_household_hot_water_producers,
     application_group, aggregator_producer, lv_net_demand, wacc_households, merit_order_csv_include,
     costs_building_and_installations_households
     ]

--- a/graphs/energy/nodes/households/households_water_heater_solar_thermal.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_solar_thermal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 1.0
 - groups = [
-    emissions, heat_production, application_group, wacc_households,
+    direct_emissions, heat_production, application_group, wacc_households,
     costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/households/households_water_heater_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/households/households_water_heater_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.82
 - groups = [
-    emissions, demand_driven, application_group, aggregator_producer, wacc_households,
+    direct_emissions, demand_driven, application_group, aggregator_producer, wacc_households,
     heat_production, costs_building_and_installations_households
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_aluminium_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_aluminium_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [emissions, heat_production, wacc_proven_tech, costs_building_and_installations_industry]
+- groups = [direct_emissions, heat_production, wacc_proven_tech, costs_building_and_installations_industry]
 - availability = 0.0
 - free_co2_factor = 0.0
 - full_load_hours = 2190.0

--- a/graphs/energy/nodes/industry/industry_aluminium_external_coupling_node.ad
+++ b/graphs/energy/nodes/industry/industry_aluminium_external_coupling_node.ad
@@ -10,7 +10,7 @@
 - output.loss = elastic
 - output.not_defined = 0.016190
 - groups = [
-    emissions, application_group, mv_net_demand, costs_building_and_installations_industry,
+    direct_emissions, application_group, mv_net_demand, costs_building_and_installations_industry,
     wacc_proven_tech
     ]
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_coal.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_hydrogen.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, fertilizers_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_external_coupling_node_non_energetic.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_external_coupling_node_non_energetic.ad
@@ -1,6 +1,6 @@
 - use = non_energetic
 - groups = [
-    emissions, chemical_industry, fertilizers_industry, non_energetic_use,
+    direct_emissions, chemical_industry, fertilizers_industry, non_energetic_use,
     useful_demand_non_energetic, useful_demand, application_group
     ]
 - free_co2_factor = 1.0

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_flexibility_p2h_hydrogen_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_flexibility_p2h_hydrogen_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
     costs_storage_and_conversion_p2h, fertilizers_industry
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_flexibility_p2h_network_gas_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_flexibility_p2h_network_gas_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech,
     costs_storage_and_conversion_p2h, fertilizers_industry
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_chemicals_fertilizers_steam_methane_reformer_hydrogen.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_fertilizers_steam_methane_reformer_hydrogen.converter.ad
@@ -3,7 +3,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.12285714285714285
 - graph_methods = [input]
-- groups = [emissions, wacc_proven_tech, costs_building_and_installations_industry]
+- groups = [direct_emissions, wacc_proven_tech, costs_building_and_installations_industry]
 - availability = 0.9
 - free_co2_factor = 0.0
 - full_load_hours = 7500.0

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_bionaphtha.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_bionaphtha.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_coal.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_hydrogen.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_naphtha.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_naphtha.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_flexibility_p2h_hydrogen_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_flexibility_p2h_hydrogen_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, other_chemical_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, other_chemical_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_chemicals_other_flexibility_p2h_network_gas_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_flexibility_p2h_network_gas_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, other_chemical_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, other_chemical_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_chemicals_other_heater_electricity.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_heater_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     mv_net_demand, wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_heatpump_water_water_electricity.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_heatpump_water_water_electricity.converter.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.26316
 - output.useable_heat = 1
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     mv_net_demand, wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_other_steam_recompression_electricity.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_other_steam_recompression_electricity.converter.ad
@@ -2,7 +2,7 @@
 - input.electricity = 0.092592593
 - output.useable_heat = 1
 - groups = [
-    emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, other_chemical_industry, application_group,
     mv_net_demand, wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_coal.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, chemical_industry, refineries_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, refineries_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, chemical_industry, refineries_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, refineries_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_hydrogen.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, chemical_industry, refineries_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, refineries_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, chemical_industry, refineries_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, refineries_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, chemical_industry, refineries_industry, application_group,
+    direct_emissions, heat_production, chemical_industry, refineries_industry, application_group,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_flexibility_p2h_hydrogen_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, refineries_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, refineries_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_chemicals_refineries_flexibility_p2h_network_gas_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_chemicals_refineries_flexibility_p2h_network_gas_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, refineries_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, refineries_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_chp_combined_cycle_gas_power_fuelmix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
     mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chp_engine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_chp_engine_gas_power_fuelmix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
     mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chp_turbine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_chp_turbine_gas_power_fuelmix.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
     mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chp_turbine_hydrogen.ad
+++ b/graphs/energy/nodes/industry/industry_chp_turbine_hydrogen.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.4147157190635451
 - groups = [
-    emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
     mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chp_ultra_supercritical_coal.ad
+++ b/graphs/energy/nodes/industry/industry_chp_ultra_supercritical_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
     mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_chp_wood_pellets.ad
+++ b/graphs/energy/nodes/industry/industry_chp_wood_pellets.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
+    direct_emissions, preset_demand, electricity_production, dispatchable_production, heat_production,
     mv_net_supply, wacc_proven_tech, costs_production_chp_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_backup_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_heat_backup_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_burner_coal.ad
+++ b/graphs/energy/nodes/industry/industry_heat_burner_coal.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_burner_crude_oil.ad
+++ b/graphs/energy/nodes/industry/industry_heat_burner_crude_oil.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_burner_hydrogen.ad
+++ b/graphs/energy/nodes/industry/industry_heat_burner_hydrogen.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_burner_lignite.ad
+++ b/graphs/energy/nodes/industry/industry_heat_burner_lignite.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - groups = [
-    emissions, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_combined_cycle_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_heat_combined_cycle_gas_power_fuelmix.ad
@@ -7,7 +7,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_engine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_heat_engine_gas_power_fuelmix.ad
@@ -7,7 +7,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_turbine_gas_power_fuelmix.ad
+++ b/graphs/energy/nodes/industry/industry_heat_turbine_gas_power_fuelmix.ad
@@ -7,7 +7,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_turbine_hydrogen.ad
+++ b/graphs/energy/nodes/industry/industry_heat_turbine_hydrogen.ad
@@ -7,7 +7,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_ultra_supercritical_coal.ad
+++ b/graphs/energy/nodes/industry/industry_heat_ultra_supercritical_coal.ad
@@ -9,7 +9,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_well_geothermal.converter.ad
+++ b/graphs/energy/nodes/industry/industry_heat_well_geothermal.converter.ad
@@ -2,7 +2,7 @@
 - input.geothermal = 0.9566
 - output.steam_hot_water = 1.0
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech,
     non_final_electricity_demand_converters, costs_production_heat_plants, sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_heat_wood_pellets.ad
+++ b/graphs/energy/nodes/industry/industry_heat_wood_pellets.ad
@@ -7,7 +7,7 @@
 - output.loss = elastic
 - output.steam_hot_water = 0.9
 - groups = [
-    emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
+    direct_emissions, preset_demand, heat_production, wacc_proven_tech, costs_production_heat_plants,
     sankey_conversion_group
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_food_burner_coal.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_burner_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_food_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_food_burner_hydrogen.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_burner_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_food_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_food_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, food_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_food_flexibility_p2h_hydrogen_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_flexibility_p2h_hydrogen_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, food_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, food_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_other_food_flexibility_p2h_network_gas_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_flexibility_p2h_network_gas_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, food_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, food_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_other_food_heater_electricity.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_food_heater_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, food_industry, other_industry, application_group, mv_net_demand,
+    direct_emissions, heat_production, food_industry, other_industry, application_group, mv_net_demand,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_metals_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_metals_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.useable_heat = 0.9
-- groups = [emissions, heat_production, wacc_proven_tech, costs_building_and_installations_industry]
+- groups = [direct_emissions, heat_production, wacc_proven_tech, costs_building_and_installations_industry]
 - presentation_group = traditional_heat
 - availability = 0.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/industry/industry_other_metals_external_coupling_node.ad
+++ b/graphs/energy/nodes/industry/industry_other_metals_external_coupling_node.ad
@@ -12,7 +12,7 @@
 - input.network_gas = 0.0
 - input.crude_oil = 0.0
 - groups = [
-    emissions, application_group, costs_building_and_installations_industry, wacc_proven_tech
+    direct_emissions, application_group, costs_building_and_installations_industry, wacc_proven_tech
     ]
 - free_co2_factor = 0.0
 - full_load_hours = 2190.0

--- a/graphs/energy/nodes/industry/industry_other_paper_burner_coal.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_burner_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_paper_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.83
 - groups = [
-    emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_paper_burner_hydrogen.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_burner_hydrogen.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_paper_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_paper_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, paper_industry, other_industry, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_other_paper_flexibility_p2h_hydrogen_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_flexibility_p2h_hydrogen_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, paper_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, paper_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_other_paper_flexibility_p2h_network_gas_electricity.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_flexibility_p2h_network_gas_electricity.ad
@@ -2,7 +2,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, paper_industry,
+    direct_emissions, heat_production, mv_net_flexibility, p2h, wacc_proven_tech, paper_industry,
     costs_storage_and_conversion_p2h
     ]
 - presentation_group = p2h

--- a/graphs/energy/nodes/industry/industry_other_paper_heater_electricity.converter.ad
+++ b/graphs/energy/nodes/industry/industry_other_paper_heater_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.995
 - groups = [
-    emissions, heat_production, paper_industry, other_industry, application_group, mv_net_demand,
+    direct_emissions, heat_production, paper_industry, other_industry, application_group, mv_net_demand,
     wacc_proven_tech, costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/industry/industry_refinery_transformation_crude_oil.converter.ad
+++ b/graphs/energy/nodes/industry/industry_refinery_transformation_crude_oil.converter.ad
@@ -1,5 +1,5 @@
 - output.loss = elastic
-- groups = [emissions, chemical_industry, sankey_conversion_group]
+- groups = [direct_emissions, chemical_industry, sankey_conversion_group]
 - use = energetic
 - graph_methods = [output]
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/industry/industry_steel_blastfurnace_bof.ad
+++ b/graphs/energy/nodes/industry/industry_steel_blastfurnace_bof.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
+- groups = [direct_emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
 - graph_methods = [input, output]
 - merit_order.group = industry_metals_electricity
 - merit_order.level = mv

--- a/graphs/energy/nodes/industry/industry_steel_cyclonefurnace_bof.ad
+++ b/graphs/energy/nodes/industry/industry_steel_cyclonefurnace_bof.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
+- groups = [direct_emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
 - input.coal = 0.759493670886076
 - input.electricity = 0.11967779056386653
 - input.network_gas = 0.12082853855005755

--- a/graphs/energy/nodes/industry/industry_steel_dri_hydrogen.ad
+++ b/graphs/energy/nodes/industry/industry_steel_dri_hydrogen.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
+- groups = [direct_emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
 - input.coal = 0.06183190106895829
 - input.electricity = 0.21127646195766087
 - input.hydrogen = 0.6262837979459234

--- a/graphs/energy/nodes/industry/industry_steel_dri_network_gas.ad
+++ b/graphs/energy/nodes/industry/industry_steel_dri_network_gas.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
+- groups = [direct_emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
 - input.coal = 0.05955986270946901
 - input.electricity = 0.2035130224106602
 - input.network_gas = 0.7369271148798708

--- a/graphs/energy/nodes/industry/industry_steel_external_coupling_node.ad
+++ b/graphs/energy/nodes/industry/industry_steel_external_coupling_node.ad
@@ -4,7 +4,7 @@
 
 - use = energetic
 - groups = [
-    emissions, application_group, mv_net_demand, wacc_proven_tech,
+    direct_emissions, application_group, mv_net_demand, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - input.coal = 0.0

--- a/graphs/energy/nodes/industry/industry_steel_scrap_hbi_eaf.ad
+++ b/graphs/energy/nodes/industry/industry_steel_scrap_hbi_eaf.ad
@@ -1,5 +1,5 @@
 - use = energetic
-- groups = [emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
+- groups = [direct_emissions, application_group, mv_net_demand, costs_building_and_installations_industry]
 - graph_methods = [input, output]
 - output.loss = elastic
 - merit_order.group = industry_metals_electricity

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_coal.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_coal.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_cokes.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_cokes.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_crude_oil.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_crude_oil.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_electricity.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_electricity.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, application_group, other_non_specified_industry
+    direct_emissions, preset_demand, useful_demand, application_group, other_non_specified_industry
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_hydrogen.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_hydrogen.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_network_gas.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_network_gas.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_useable_heat.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_useable_heat.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_wood_pellets.demand.ad
+++ b/graphs/energy/nodes/industry/industry_useful_demand_for_other_non_specified_wood_pellets.demand.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - groups = [
-    emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
+    direct_emissions, preset_demand, useful_demand, other_non_specified_industry, application_group
     ]
 - free_co2_factor = 0.0
 - sector_label = industry_other

--- a/graphs/energy/nodes/other/other_burner_coal.converter.ad
+++ b/graphs/energy/nodes/other/other_burner_coal.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.8
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/other/other_burner_crude_oil.converter.ad
+++ b/graphs/energy/nodes/other/other_burner_crude_oil.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.788659793814433
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/other/other_burner_network_gas.converter.ad
+++ b/graphs/energy/nodes/other/other_burner_network_gas.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.9
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/other/other_burner_wood_pellets.converter.ad
+++ b/graphs/energy/nodes/other/other_burner_wood_pellets.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.useable_heat = 0.760824742268041
 - groups = [
-    emissions, heat_production, application_group, wacc_proven_tech,
+    direct_emissions, heat_production, application_group, wacc_proven_tech,
     costs_building_and_installations_industry
     ]
 - use = energetic

--- a/graphs/energy/nodes/other/other_heater_district_heating_ht_steam_hot_water.ad
+++ b/graphs/energy/nodes/other/other_heater_district_heating_ht_steam_hot_water.ad
@@ -1,4 +1,4 @@
 - use = energetic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = other_heating

--- a/graphs/energy/nodes/transport/transport_bicycle_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bicycle_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 28.57142857142857
-- groups = [emissions, application_group, passenger_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = electric_bikes
 - merit_order.level = mv

--- a/graphs/energy/nodes/transport/transport_bicycle_using_human_energy.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bicycle_using_human_energy.converter.ad
@@ -1,5 +1,5 @@
 - use = energetic
 - output.loss = elastic
-- groups = [emissions, application_group]
+- groups = [direct_emissions, application_group]
 - free_co2_factor = 0.0
 - sector_label = transport_bicycles

--- a/graphs/energy/nodes/transport/transport_bus_using_compressed_natural_gas.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_compressed_natural_gas.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.3821186912365564
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_buses

--- a/graphs/energy/nodes/transport/transport_bus_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_diesel_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.2439068221129006
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_buses

--- a/graphs/energy/nodes/transport/transport_bus_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.passenger_kms = 2.8361075544174135
 - groups = [
-    emissions, inheritable_nou, application_group, passenger_transport, mv_net_demand,
+    direct_emissions, inheritable_nou, application_group, passenger_transport, mv_net_demand,
     wacc_proven_tech
     ]
 - use = energetic

--- a/graphs/energy/nodes/transport/transport_bus_using_gasoline_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_gasoline_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.128615087898015
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_buses

--- a/graphs/energy/nodes/transport/transport_bus_using_hydrogen.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_hydrogen.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.890738369611609
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_buses

--- a/graphs/energy/nodes/transport/transport_bus_using_lng_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_lng_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.3821186912365564
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_buses

--- a/graphs/energy/nodes/transport/transport_car_using_compressed_natural_gas.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_compressed_natural_gas.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.6321178680961683
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 15.0
 - sector_label = transport_cars

--- a/graphs/energy/nodes/transport/transport_car_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_diesel_mix.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.passenger_kms = 0.6986565910536597
 - output.loss = elastic
-- groups = [emissions, inheritable_nou, application_group, passenger_transport]
+- groups = [direct_emissions, inheritable_nou, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0
 - sector_label = transport_cars

--- a/graphs/energy/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.loss = elastic
 - output.passenger_kms = 2.0422269584645436
 - groups = [
-    emissions, inheritable_nou, application_group, passenger_transport, lv_net_demand,
+    direct_emissions, inheritable_nou, application_group, passenger_transport, lv_net_demand,
     wacc_proven_tech
     ]
 - use = energetic

--- a/graphs/energy/nodes/transport/transport_car_using_gasoline_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_gasoline_mix.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.6321178680961683
-- groups = [emissions, inheritable_nou, application_group, passenger_transport]
+- groups = [direct_emissions, inheritable_nou, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0
 - sector_label = transport_cars

--- a/graphs/energy/nodes/transport/transport_car_using_hydrogen.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_hydrogen.converter.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - output.passenger_kms = 1.3545382887775037
-- groups = [emissions, inheritable_nou, application_group, passenger_transport, wacc_unproven_tech]
+- groups = [direct_emissions, inheritable_nou, application_group, passenger_transport, wacc_unproven_tech]
 - use = energetic
 - graph_methods = [demand]
 - full_load_hours = 0.0

--- a/graphs/energy/nodes/transport/transport_car_using_lpg.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_lpg.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.6637237615009768
-- groups = [emissions, inheritable_nou, application_group, passenger_transport]
+- groups = [direct_emissions, inheritable_nou, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 13.0
 - sector_label = transport_cars

--- a/graphs/energy/nodes/transport/transport_freight_train_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_freight_train_using_diesel_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.freight_tonne_kms = 2.7027027027027026
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_trains

--- a/graphs/energy/nodes/transport/transport_freight_train_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_freight_train_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.freight_tonne_kms = 7.142857142857142
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, freight_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = freight_trains
 - merit_order.level = mv

--- a/graphs/energy/nodes/transport/transport_freight_train_using_hydrogen.converter.ad
+++ b/graphs/energy/nodes/transport/transport_freight_train_using_hydrogen.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 3.928571428571428
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - free_co2_factor = 0.0
 - sector_label = transport_trains

--- a/graphs/energy/nodes/transport/transport_motorcycle_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_motorcycle_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 9.104792424818495
-- groups = [emissions, application_group, passenger_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = electric_bikes
 - merit_order.level = mv

--- a/graphs/energy/nodes/transport/transport_motorcycle_using_gasoline_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_motorcycle_using_gasoline_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.8906889761774772
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_motorcycles

--- a/graphs/energy/nodes/transport/transport_passenger_train_using_coal.converter.ad
+++ b/graphs/energy/nodes/transport/transport_passenger_train_using_coal.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.500500901
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_trains

--- a/graphs/energy/nodes/transport/transport_passenger_train_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_passenger_train_using_diesel_mix.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.5015027027027028
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_trains

--- a/graphs/energy/nodes/transport/transport_passenger_train_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_passenger_train_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 3.703706666666667
-- groups = [emissions, application_group, passenger_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = passenger_trains
 - merit_order.level = mv

--- a/graphs/energy/nodes/transport/transport_passenger_train_using_hydrogen.converter.ad
+++ b/graphs/energy/nodes/transport/transport_passenger_train_using_hydrogen.converter.ad
@@ -1,6 +1,6 @@
 - output.loss = elastic
 - output.passenger_kms = 2.037038666666667
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - use = energetic
 - free_co2_factor = 0.0
 - sector_label = transport_trains

--- a/graphs/energy/nodes/transport/transport_plane_using_bio_ethanol.converter.ad
+++ b/graphs/energy/nodes/transport/transport_plane_using_bio_ethanol.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.17969198877075998
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_domestic_aviation

--- a/graphs/energy/nodes/transport/transport_plane_using_electricity.ad
+++ b/graphs/energy/nodes/transport/transport_plane_using_electricity.ad
@@ -4,6 +4,6 @@
 - merit_order.group = electric_planes
 - merit_order.level = mv
 - merit_order.type = consumer
-- groups = [emissions, application_group, passenger_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - sector_label = transport_domestic_aviation

--- a/graphs/energy/nodes/transport/transport_plane_using_gasoline.converter.ad
+++ b/graphs/energy/nodes/transport/transport_plane_using_gasoline.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.3051009051128605
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_domestic_aviation

--- a/graphs/energy/nodes/transport/transport_plane_using_hydrogen.ad
+++ b/graphs/energy/nodes/transport/transport_plane_using_hydrogen.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.519286631
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_domestic_aviation

--- a/graphs/energy/nodes/transport/transport_plane_using_kerosene_mix.ad
+++ b/graphs/energy/nodes/transport/transport_plane_using_kerosene_mix.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 0.2857010428736964
-- groups = [emissions, application_group, passenger_transport]
+- groups = [direct_emissions, application_group, passenger_transport]
 - free_co2_factor = 0.0
 - sector_label = transport_domestic_aviation

--- a/graphs/energy/nodes/transport/transport_ship_using_ammonia.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_ammonia.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.freight_tonne_kms = 3.73393801965231
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0
 - sector_label = transport_domestic_navigation

--- a/graphs/energy/nodes/transport/transport_ship_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_diesel_mix.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.freight_tonne_kms = 3.17460317460317
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0
 - sector_label = transport_domestic_navigation

--- a/graphs/energy/nodes/transport/transport_ship_using_electricity.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_electricity.ad
@@ -4,7 +4,7 @@
 - merit_order.group = electric_ships
 - merit_order.level = mv
 - merit_order.type = consumer
-- groups = [emissions, application_group, freight_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, freight_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0
 - sector_label = transport_domestic_navigation

--- a/graphs/energy/nodes/transport/transport_ship_using_hydrogen.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_hydrogen.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.freight_tonne_kms = 3.40136054421769
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0
 - sector_label = transport_domestic_navigation

--- a/graphs/energy/nodes/transport/transport_ship_using_lng_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_lng_mix.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.freight_tonne_kms = 3.17460317460317
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0
 - sector_label = transport_domestic_navigation

--- a/graphs/energy/nodes/transport/transport_ship_using_methanol_mix.ad
+++ b/graphs/energy/nodes/transport/transport_ship_using_methanol_mix.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.freight_tonne_kms = 2.34275
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - free_co2_factor = 0.0
 - technical_lifetime = 25.0
 - sector_label = transport_domestic_navigation

--- a/graphs/energy/nodes/transport/transport_tram_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_tram_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - use = energetic
 - output.loss = elastic
 - output.passenger_kms = 1.6339869281045751
-- groups = [emissions, application_group, passenger_transport, mv_net_demand]
+- groups = [direct_emissions, application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = passenger_trains
 - merit_order.level = mv

--- a/graphs/energy/nodes/transport/transport_truck_using_compressed_natural_gas.converter.ad
+++ b/graphs/energy/nodes/transport/transport_truck_using_compressed_natural_gas.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.9713473673525779
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_truck_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_truck_using_diesel_mix.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.9713473673525779
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_truck_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_truck_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.freight_tonne_kms = 1.7491695887192016
 - output.loss = elastic
 - groups = [
-    emissions, inheritable_nou, application_group, freight_transport, mv_net_demand,
+    direct_emissions, inheritable_nou, application_group, freight_transport, mv_net_demand,
     wacc_proven_tech
     ]
 - use = energetic

--- a/graphs/energy/nodes/transport/transport_truck_using_gasoline_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_truck_using_gasoline_mix.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.881317856730362
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 11.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_truck_using_hydrogen.converter.ad
+++ b/graphs/energy/nodes/transport/transport_truck_using_hydrogen.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 1.3427448901638577
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_truck_using_lng_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_truck_using_lng_mix.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 1.0792748526139753
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_van_using_compressed_natural_gas.converter.ad
+++ b/graphs/energy/nodes/transport/transport_van_using_compressed_natural_gas.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.022717905586307756
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_van_using_diesel_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_van_using_diesel_mix.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.02160428276344953
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_van_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_van_using_electricity.converter.ad
@@ -1,7 +1,7 @@
 - output.freight_tonne_kms = 0.046885890252592606
 - output.loss = elastic
 - groups = [
-    emissions, inheritable_nou, application_group, freight_transport, mv_net_demand,
+    direct_emissions, inheritable_nou, application_group, freight_transport, mv_net_demand,
     wacc_proven_tech
     ]
 - use = energetic

--- a/graphs/energy/nodes/transport/transport_van_using_gasoline_mix.converter.ad
+++ b/graphs/energy/nodes/transport/transport_van_using_gasoline_mix.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.01890374741801834
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_van_using_hydrogen.converter.ad
+++ b/graphs/energy/nodes/transport/transport_van_using_hydrogen.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.031037138617913417
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/energy/nodes/transport/transport_van_using_lpg.converter.ad
+++ b/graphs/energy/nodes/transport/transport_van_using_lpg.converter.ad
@@ -1,6 +1,6 @@
 - output.freight_tonne_kms = 0.01890374741801834
 - output.loss = elastic
-- groups = [emissions, application_group, freight_transport]
+- groups = [direct_emissions, application_group, freight_transport]
 - use = energetic
 - technical_lifetime = 12.0
 - free_co2_factor = 0.0

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/agriculture/agriculture_non_specified_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/buildings/buildings_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/buildings/buildings_non_specified_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/bunkers/bunkers_international_aviation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/bunkers/bunkers_international_aviation_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - use = energetic
 - sector_label = bunkers_international_aviation

--- a/graphs/molecules/nodes/bunkers/bunkers_international_navigation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/bunkers/bunkers_international_navigation_energetic_other_ghg.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - use = energetic
 - sector_label = bunkers_international_navigation

--- a/graphs/molecules/nodes/energy/energy_ccus_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_ccus_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/energy/energy_electricity_and_heat_production_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_electricity_and_heat_production_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/energy/energy_fuels_production_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_fuels_production_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_fugitive_emissions_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/energy/energy_hydrogen_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_hydrogen_production_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/energy/energy_methanol_production_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/households/households_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/households/households_non_specified_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_aluminium_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_chemical_other_captured_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemical_other_captured_co2.ad
@@ -1,5 +1,5 @@
 - groups = [
-    emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
+    direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
     captured_energetic_emissions_industry
     ]
 - presentation_group = co2_capture

--- a/graphs/molecules/nodes/industry/industry_chemicals_fertilizers_captured_combustion_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_fertilizers_captured_combustion_co2.ad
@@ -1,5 +1,5 @@
 - groups = [
-    emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
+    direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
     captured_energetic_emissions_industry
     ]
 - use = energetic

--- a/graphs/molecules/nodes/industry/industry_chemicals_fertilizers_captured_processes_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_fertilizers_captured_processes_co2.ad
@@ -1,5 +1,5 @@
 - groups = [
-    emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
+    direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
     captured_non_energetic_emissions_industry
     ]
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_chemicals_refineries_captured_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_chemicals_refineries_captured_co2.ad
@@ -1,5 +1,5 @@
 - groups = [
-    emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
+    direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
     captured_energetic_emissions_industry
     ]
 - presentation_group = co2_capture

--- a/graphs/molecules/nodes/industry/industry_external_coupling_node_captured_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_external_coupling_node_captured_co2.ad
@@ -3,7 +3,7 @@
 # Because these emissions are out of scope of the ETM, the captured flow is not subtracted from
 # the total emissions.
 
-- groups = [emissions, ccus_captured, preset_demand]
+- groups = [direct_emissions, ccus_captured, preset_demand]
 - use = non_energetic
 - sector_label = industry_non_specified
 

--- a/graphs/molecules/nodes/industry/industry_fertilizers_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_fertilizers_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_food_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_food_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_food_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_food_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_non_specified_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/industry/industry_other_food_captured_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_food_captured_co2.ad
@@ -1,5 +1,5 @@
 - groups = [
-    emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
+    direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
     captured_energetic_emissions_industry
     ]
 - presentation_group = p2kerosene

--- a/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_other_metals_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_other_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_other_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_other_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_other_paper_captured_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_other_paper_captured_co2.ad
@@ -1,5 +1,5 @@
 - groups = [
-    emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
+    direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech,
     captured_energetic_emissions_industry
     ]
 - presentation_group = co2_capture

--- a/graphs/molecules/nodes/industry/industry_paper_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_paper_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_paper_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_paper_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_refineries_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_refineries_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/industry/industry_refineries_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_refineries_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_steel_captured_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_captured_co2.ad
@@ -1,3 +1,3 @@
-- groups = [emissions, ccus_captured, captured_energetic_emissions_industry]
+- groups = [direct_emissions, ccus_captured, captured_energetic_emissions_industry]
 - use = energetic
 - sector_label = industry_steel

--- a/graphs/molecules/nodes/industry/industry_steel_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/industry/industry_steel_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/industry/industry_steel_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/lulucf/lulucf_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_emissions_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/lulucf/lulucf_emissions_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_emissions_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/lulucf/lulucf_removals_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/lulucf/lulucf_removals_non_energetic_co2.ad
@@ -2,7 +2,7 @@
 
 # ccus_captured group added to ensure emissions are reported under CO2 capture to account for CO2 removals
 
-- groups = [preset_demand, emissions, ccus_captured]
+- groups = [preset_demand, direct_emissions, ccus_captured]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/molecules/molecules_direct_air_capture_co2.ad
+++ b/graphs/molecules/nodes/molecules/molecules_direct_air_capture_co2.ad
@@ -1,4 +1,4 @@
-- groups = [emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech]
+- groups = [direct_emissions, ccus_captured, costs_co2_ccus, wacc_unproven_tech]
 - use = non_energetic
 - presentation_group = co2_capture
 - typical_input_capacity = 120163.4

--- a/graphs/molecules/nodes/molecules/molecules_other_utilisation_delayed_emitted_co2.ad
+++ b/graphs/molecules/nodes/molecules/molecules_other_utilisation_delayed_emitted_co2.ad
@@ -1,4 +1,4 @@
-- groups = [emissions]
+- groups = [direct_emissions]
 - graph_methods = [demand]
 - use = non_energetic
 - sector_label = energy_ccus

--- a/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/other/other_indirect_emissions_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/other/other_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/other/other_non_specified_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/other/other_other_transportation_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/other/other_other_transportation_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/transport/transport_non_specified_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/transport/transport_non_specified_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = energetic

--- a/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_co2.ad
+++ b/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_co2.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.co2 = 1.0
 - scaling_exempt = true
 - use = non_energetic

--- a/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_other_ghg.ad
+++ b/graphs/molecules/nodes/waste/waste_non_specified_non_energetic_other_ghg.ad
@@ -1,6 +1,6 @@
 # Attribute scaling_exempt set to true to avoid scaling of value read from emissions.csv
 
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - input.other_ghg = 1.0
 - scaling_exempt = true
 - use = non_energetic


### PR DESCRIPTION
#### Context
Rename the `emissions` group to `direct_emissions`.

Goes with:
- https://github.com/quintel/etengine/pull/1785
- https://github.com/quintel/etsource/pull/3464
- https://github.com/quintel/documentation/pull/347

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review