### PR TITLE
Direct emissions import of Dutch regional emissions.csv from regional data pipeline

### DIFF
--- a/datasets/ES01_groningen/emissions.csv
+++ b/datasets/ES01_groningen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,174.33428
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.37685
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,16.40796
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.74387
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1028.50233
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,290.72267
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.87433
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.88068
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2788.46364
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,4.78519
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,27.4765
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,111.96913
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.249
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.20694
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,118.89197
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,8.45476
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,134.44234
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,23.88967
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,918.33106
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.11319
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.79642
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,105.02983
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,55.08724
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,6.75596
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,4.32945
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4.61953
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2106.85276
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.81642
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.8389
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,137.01329
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,41.10954
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,10.71082
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,21.38802
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,621.00026
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,12.87119
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01881
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,34.26248
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,14.38984
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,62.76958
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,16.4366
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,21.30994
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1061.35599
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.37688
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.76469
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,96.26775
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,35.95656
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,817.35578
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,143.74978

--- a/datasets/ES02_friesland/emissions.csv
+++ b/datasets/ES02_friesland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,261.78011
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,22.10988
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,21.87271
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.54267
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2597.64405
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,268.1587
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.6214
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09321
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1675.67455
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.56145
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,3.68634
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.03827
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01232
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,1.57165
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,11.71931
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,12.09241
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,1027.45993
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,23.49323
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.19491
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,35.83956
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.05902
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00111
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,25.57637
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00017
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,423.5949
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.26739
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.72442
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,16.80041
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,18.66387
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,9.96838
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,21.83087
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00945
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,36.91226
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,15.92341
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,14.61447
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,11.66642
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.8237
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1232.07321
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,12.95127
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,16.15289
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,29.4359
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,28.1605
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,30.74222
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,58.66305

--- a/datasets/ES03_drenthe/emissions.csv
+++ b/datasets/ES03_drenthe/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,335.40918
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,17.00108
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.6024
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.73816
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1092.59278
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,229.35443
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.81277
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0607
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,199.21347
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.77229
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,23.44275
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,173.61537
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,1.2337
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.02316
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,79.25073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.95259
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,87.04106
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,8.81286
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,737.94353
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,17.087
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.59321
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,14.43538
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.25943
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.00635
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,466.26132
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.82584
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.92468
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,16.53348
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,14.21371
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,8.3466
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,16.67564
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00954
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,27.07177
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,12.14805
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,10.10305
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,8.52923
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.39131
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,995.02288
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.10022
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.52267
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,291.66103
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,42.35067
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2914.19249
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,218.40151

--- a/datasets/ES04_twente/emissions.csv
+++ b/datasets/ES04_twente/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,387.29203
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.38144
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,12.2031
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.68807
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1037.78377
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,296.8975
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.08501
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1547
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,242.73035
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.85991
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,53.64037
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,111.7073
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.3735
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,178.30578
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01011
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,187.89984
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,9.23537
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,873.75794
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.06406
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.50958
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,238.43265
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.29219
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,28.49071
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,1.12651
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,32.6377
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,684.96534
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.75956
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.97093
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,24.36582
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,18.15689
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,7.45691
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,20.04979
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.04788
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,35.86982
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,15.51412
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,13.38643
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,11.30114
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.77683
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,934.16613
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.77734
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.18148
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,218.78194
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,35.07596
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2012.02069
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,64.30997

--- a/datasets/ES05_west_overijssel/emissions.csv
+++ b/datasets/ES05_west_overijssel/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,365.72621
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.40076
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,10.88402
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.52576
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1468.02085
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,236.68957
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.42436
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94581
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1431.22233
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.21978
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.35242
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00772
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.009
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.3236
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,8.55902
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,9.03222
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,661.14736
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,15.85486
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.71943
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,13.93761
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00611
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4.05744
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00069
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,245.3295
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.51766
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50809
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,14.03032
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,15.48111
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,10.83957
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,18.82967
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00767
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,26.9583
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,13.22278
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,145.4167
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,12.05225
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,8.85693
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,951.62814
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,9.96409
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.55573
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,17.23832
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,20.63702
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,23.26696
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,37.00924

--- a/datasets/ES06_flevoland/emissions.csv
+++ b/datasets/ES06_flevoland/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,52.76245
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.66823
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.68491
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.50114
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,361.84039
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,85.0758
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55733
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6802
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1223.1597
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.61212
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.75937
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00435
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00704
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,4.13386
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,6.43358
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,265.21843
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.87048
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.33271
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,21.90196
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,6e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,68.49043
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.28086
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24587
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,6.02985
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,12.69441
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.05778
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,17.86284
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00526
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,13.0204
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,10.8075
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.85915
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,4.10221
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.23778
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,720.41051
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.04195
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.06258
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,34.00742
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,34.86517
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,300.85986
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,174.46494

--- a/datasets/ES07_achterhoek/emissions.csv
+++ b/datasets/ES07_achterhoek/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,387.4301
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.51398
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,13.92711
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.46489
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,938.01119
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,137.34431
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84587
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57846
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,5.16396
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.27601
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.03687
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00585
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00477
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,5.56532
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,4.36025
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,452.66183
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.87558
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.81961
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,54.75489
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,265.92006
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.47961
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02025
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,33.1102
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,11.63727
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4.12802
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,18.71877
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01248
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,17.52905
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,7.32459
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,6.54175
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,5.5227
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.83888
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,554.68983
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.06249
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.52931
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,28.36049
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,18.90633
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,141.41586
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,35.18999

--- a/datasets/ES08_arnhem_nijmegen/emissions.csv
+++ b/datasets/ES08_arnhem_nijmegen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,185.32805
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,18.16969
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.479
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.92404
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,303.00509
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,350.80526
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.14232
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.41037
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4240.78366
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,18.20391
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,18.198
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01301
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01961
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,12.44068
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,13.31436
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,930.90588
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,22.03558
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.53982
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,73.67021
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,12.95749
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,13.74877
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.19908
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,14.47834
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,687.40569
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.97605
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.80474
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,239.82683
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,167.21913
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,9.9901
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,28.34657
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.04583
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,38.98392
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,18.42362
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,16.0456
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,12.29501
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,2.84659
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1274.44432
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,13.27882
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,16.90541
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,33.62658
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,37.38695
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,207.67071
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,78.23063

--- a/datasets/ES09_foodvalley/emissions.csv
+++ b/datasets/ES09_foodvalley/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,526.31582
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.9114
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.74864
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.36416
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,473.91301
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,147.7642
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.89607
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74328
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,7.02713
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.1248
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,21.86859
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00575
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00593
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,5.46412
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,5.41551
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,394.29053
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,9.72538
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.59718
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.97772
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,3.90784
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.47769
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.13154
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.58495
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,225.02419
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.66506
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41036
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,37.9977
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,10.64327
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.88566
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,13.28594
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00116
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,17.21031
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,9.09729
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,6.4228
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,5.42228
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.04191
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,633.95821
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.65957
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.84864
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.14475
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,51.48754
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,10.95626
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,354.1129

--- a/datasets/ES10_noord_veluwe/emissions.csv
+++ b/datasets/ES10_noord_veluwe/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,280.5867
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.26586
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.2311
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.00399
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,224.76567
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,70.16195
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42162
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36317
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,28.42014
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.25761
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.04034
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0033
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00303
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,3.14303
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.76481
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,236.49876
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.84673
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.81941
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,46.29277
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,69.95267
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58495
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26267
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,7.62522
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,5.43673
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.51666
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.89319
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00829
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,9.89959
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,4.64449
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.69448
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.11896
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.53193
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,432.77409
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.26237
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.91209
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.72195
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,38.28905
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,10.06604
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,53.63976

--- a/datasets/ES11_fruitdelta_rivierenland/emissions.csv
+++ b/datasets/ES11_fruitdelta_rivierenland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,162.95032
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,31.58628
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.07898
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.462
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,386.32795
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,94.67214
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62549
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55456
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.71056
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.1075
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.46601
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00408
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01201
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,3.88476
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,3.70478
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,324.20889
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.6507
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.4389
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.97326
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.11803
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.05047
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00892
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,51.15275
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,86.62781
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.08872
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.55334
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,289.87042
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,87.95994
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.78846
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,13.84945
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00107
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,12.23581
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,6.2011
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.56634
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.85501
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.71021
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,640.22892
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.00681
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.22481
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,39.99976
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,10.88166
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,404.65675
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,22.39929

--- a/datasets/ES12_stedendriehoek/emissions.csv
+++ b/datasets/ES12_stedendriehoek/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,191.10694
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.99394
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.99377
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.42695
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,430.84027
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,173.26875
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.05579
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58822
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,66.02665
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.5336
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,1.65242
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.16627
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00648
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00552
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,6.165
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,5.04008
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,501.9803
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.86091
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.89356
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,123.44738
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,2.155
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,4.16186
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.01125
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.47832
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,510.62948
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.24309
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.66298
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.90168
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,9.91421
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,6.0433
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,11.44313
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -65,14 +65,14 @@ Industry,Other metals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.02165
 Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.02532
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,19.41789
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,8.46662
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,7.24666
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,6.1178
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.96968
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,797.27974
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.10838
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.95054
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,28.36141
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,21.80338
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,127.59453
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,42.4717

--- a/datasets/ES13_amersfoort/emissions.csv
+++ b/datasets/ES13_amersfoort/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,41.39825
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21795
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.52221
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.72849
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,142.45799
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,133.2661
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.80939
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74133
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,97.02898
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.74878
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00471
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00494
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,5.48285
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,4.51031
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,338.30717
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.88803
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.11595
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,21.40418
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,38.05485
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.58005
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00351
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.65334
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,537.10385
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,97.73938
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.06324
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21779
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.65218
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,8.86837
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.83825
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,8.68889
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00383
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,14.11246
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,7.57668
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,5.2667
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,4.44627
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.86775
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,485.55729
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.01567
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.67009
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,11.18099
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,13.462
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,41.22246
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,70.86767

--- a/datasets/ES14_u16/emissions.csv
+++ b/datasets/ES14_u16/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,91.45329
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,16.43261
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.00557
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.98383
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,717.58537
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,394.6271
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.42985
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.12421
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1296.64337
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.65446
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,3.1612
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01564
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01559
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,14.87096
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,14.33175
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,995.22919
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,25.0124
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.96901
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,31.35962
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,7.15471
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.2652
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02203
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,6.21638
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,434.79836
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,227.92795
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.49818
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47644
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,101.08884
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,137.08618
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,39.2739
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,45.68124
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00669
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,46.83902
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,23.92561
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,17.48008
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,14.7571
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,2.74019
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1885.77593
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,18.4199
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,24.71102
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,79.98297
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,35.92784
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,415.73697
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,33.55034

--- a/datasets/ES15_noord_holland_noord/emissions.csv
+++ b/datasets/ES15_noord_holland_noord/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,68.17601
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,55.0182
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.32189
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.81825
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,550.93449
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,246.45582
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.49018
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.07452
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,93.13351
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.24225
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,13.48337
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,5.75424
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.35342
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00094
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01198
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.04941
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,11.39681
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,10.06426
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,921.81556
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.48072
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.33181
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,27.87522
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,188.59862
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.13784
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64472
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,19.72281
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,19.66726
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,7.52423
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,21.05236
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00892
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,35.8965
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,16.79835
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,14.31285
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,11.32573
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,7.33218
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1041.39576
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.72039
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.59828
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,20.8781
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,36.73362
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,25.47487
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,90.02014

--- a/datasets/ES16_noord_holland_zuid/emissions.csv
+++ b/datasets/ES16_noord_holland_zuid/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,19.08461
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,28.48892
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.80731
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.53567
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,355.88378
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1252.49496
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.55976
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.76279
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6494.73306
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,8.41683
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,30.5408
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,11.7025
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.04152
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00729
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.03705
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.33555
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,35.56379
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,33.96926
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,2547.83249
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,58.66482
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,33.66519
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,17.91978
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,38.39875
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,12.18611
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,1.00418
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2.08847
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2277.00147
+Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.03976
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7202.49993
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,31.15132
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.02495
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,79.22281
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,64.48306
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,36.57246
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,121.24083
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,39.80325
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.09503
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00473
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,110.98791
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,55.04449
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,52.56212
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,35.27253
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,9.90693
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,3089.74773
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,33.16639
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,37.79494
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,47.7251
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,92.80858
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,70.28361
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,299.96014

--- a/datasets/ES17_alblasserwaard/emissions.csv
+++ b/datasets/ES17_alblasserwaard/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.19126
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18993
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.71403
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.01098
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,232.89901
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,34.89758
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21167
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15809
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,21.12055
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.16377
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00142
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00133
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.35189
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.21612
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,104.56049
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.46457
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.57078
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.7038
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02944
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,47.03883
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48255
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07773
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.64261
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.41626
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.53865
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.51422
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00134
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.25806
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.04291
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.58908
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.34154
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.23397
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,171.69249
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.67693
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.46162
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.5707
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.20516
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.04506
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.11019

--- a/datasets/ES18_drechtsteden/emissions.csv
+++ b/datasets/ES18_drechtsteden/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.12636
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.5283
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20524
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21185
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.95158
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,137.3499
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83309
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50286
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,283.4116
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.48952
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,9.96391
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00531
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00469
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,5.04933
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,4.28143
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,369.31457
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.67536
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.49748
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.47549
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.68102
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,78.57901
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,468.34993
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.78465
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,31.39123
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,60.89893
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,8.48543
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.55035
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,9.28995
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.06643
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,15.90386
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,7.19219
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,5.93524
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,5.01067
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.82372
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,489.28373
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.0472
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.40972
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,11.42649
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,12.64425
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,9.09631
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,12.50381

--- a/datasets/ES19_goeree_overflakkee/emissions.csv
+++ b/datasets/ES19_goeree_overflakkee/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.59426
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.10144
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1059
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.50287
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,58.31545
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.09973
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09159
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07097
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.50257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01078
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00089
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00081
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.84376
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.74177
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,70.98525
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.64747
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.13018
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.8294
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12742
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03267
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.96689
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.4743
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.36444
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.39063
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.65759
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.24607
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.9918
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.8373
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14271
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,116.57869
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.23605
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.50015
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.61619
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.87325
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.511
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.79008

--- a/datasets/ES20_hoeksche_waard/emissions.csv
+++ b/datasets/ES20_hoeksche_waard/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.69634
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.18866
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1857
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.64052
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,44.58045
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.70779
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15563
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12303
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.08795
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.10628
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.08203
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00162
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0313
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.53866
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.33308
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,121.51099
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.90929
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.78566
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,390.45567
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.56568
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10674
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.13164
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.57119
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.66344
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.05433
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00259
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.8463
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.15532
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.80861
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.52688
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.24685
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,181.22521
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.8753
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.44548
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.49074
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.57216
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.98601
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.17422

--- a/datasets/ES21_holland_rijnland/emissions.csv
+++ b/datasets/ES21_holland_rijnland/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,24.1804
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,19.90356
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.40279
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.38373
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,235.64927
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,243.01152
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.46904
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.86952
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,136.38463
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.79902
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.09031
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,7.06639
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01019
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01074
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,9.69496
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,8.89107
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,674.53484
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,16.42558
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.25253
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,10.45321
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,7.06789
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,3.15404
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,211.0356
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.11549
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38422
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,39.72892
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,16.55378
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,7.06013
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,16.7639
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00588
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,30.53619
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,14.14722
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,11.39595
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,9.62073
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.62028
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,758.22812
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.78235
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.64258
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,19.71638
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,19.73022
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,20.19614
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.25939

--- a/datasets/ES22_midden_holland/emissions.csv
+++ b/datasets/ES22_midden_holland/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,46.69008
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,29.25496
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.86179
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.21844
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,228.35031
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,97.74423
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5903
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39393
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,25.73959
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.5017
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.05183
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00422
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00402
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,4.00984
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,3.67129
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,299.34508
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.07152
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.32088
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,41.31505
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,1.35321
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.09411
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.383
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,216.14688
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.48704
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32196
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,10.08843
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,15.11271
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4.65301
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,10.52344
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01551
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,12.62976
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,6.16724
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.71336
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.97913
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.70633
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,471.40858
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.70756
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.84317
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.30037
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.80048
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,9.29759
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.74188

--- a/datasets/ES23_rotterdam_den_haag/emissions.csv
+++ b/datasets/ES23_rotterdam_den_haag/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,103.6758
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,455.00353
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.54913
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.13006
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,139.13484
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1120.24153
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.89469
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.71186
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,8832.79539
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,34.13726
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,28.48253
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,3.88083
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.02567
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.11201
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.04151
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.77291
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,39.74257
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,39.77879
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,2623.34079
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,63.12451
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,35.36822
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,89.10114
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,188.48507
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,9.86969
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,26.85926
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,10.24763
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,12.49947
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3528.90647
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.49723
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.50198
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,166.08862
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,69.89742
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,34.60981
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,112.2013
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,9004.85044
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,32.22182
+Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,88.04124
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.20694
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01917
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,124.35022
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,59.62277
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,46.40687
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,39.17777
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,17.32367
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,3072.80537
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,32.92695
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,37.48594
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,77.3655
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,59.00811
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,77.99952
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,77.21077

--- a/datasets/ES24_zeeland/emissions.csv
+++ b/datasets/ES24_zeeland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,85.3783
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,27.08842
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.90298
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.95795
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,351.84444
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,182.41183
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19653
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69752
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2517.32185
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,10.66722
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01095
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,108.83033
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,9.49572
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,4.93062
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00733
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00615
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,6.97151
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,5.61515
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,624.50202
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,13.87279
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.6506
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,43.30614
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,232.72867
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.88714
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,37.04997
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,7.56405
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2534.13953
+Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,88.14345
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6151.52609
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.7961
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.93298
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.25668
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,11.31747
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.6184
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,28.46482
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,826.4524
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,3.50748
+Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.01533
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00776
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,21.95813
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,9.43265
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,8.19466
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,6.91813
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.08032
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,823.48498
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.69794
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.51504
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,87.11616
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,22.38574
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,699.56712
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,89.34236

--- a/datasets/ES25_hart_van_brabant/emissions.csv
+++ b/datasets/ES25_hart_van_brabant/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,203.80338
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,19.81333
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.7985
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.2179
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,303.37881
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,188.87015
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.15732
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.90452
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,23.31144
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.49524
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.02725
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00804
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.02345
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,7.83305
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,6.89379
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,567.23454
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,13.70796
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.41092
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,83.12788
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,7.01248
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0684
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.26207
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,246.83455
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.42019
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44555
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,129.8109
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,105.63869
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.39994
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,24.94453
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01819
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,24.07042
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,11.53578
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,8.98296
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,7.58362
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.32119
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,645.56552
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.08231
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.45057
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,28.90841
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,24.22607
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,133.0597
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,72.14003

--- a/datasets/ES26_metropoolregio_eindhoven/emissions.csv
+++ b/datasets/ES26_metropoolregio_eindhoven/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1036.04449
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,44.15379
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,11.13045
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.38881
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,925.80382
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,378.93686
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.55473
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.66942
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,204.96166
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.00435
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.06439
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01358
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01271
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,12.91503
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,11.61082
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,1015.86351
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,23.91892
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.18386
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,85.61673
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,156.53578
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00291
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.8866
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,166.24643
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,2e-05
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,443.63493
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.94648
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.08706
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,54.53839
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,22.81968
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,8.15719
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,28.35603
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.03887
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,40.67842
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,19.50453
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,15.18098
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,12.81614
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,2.23385
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1161.07785
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,12.70906
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,19.04288
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,198.6853
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,41.6058
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1770.06914
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,110.60983

--- a/datasets/ES27_noordoost_brabant/emissions.csv
+++ b/datasets/ES27_noordoost_brabant/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,878.34116
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.16386
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,13.46061
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.95875
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1081.20649
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,305.28938
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.0186
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.48031
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,107.35691
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.30079
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.97977
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01077
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00992
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,10.23981
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,9.06694
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,812.78842
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,19.19727
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.52371
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,144.3538
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,21.3736
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,19.91564
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.04154
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4.69586
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00137
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,426.82199
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.78358
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.87435
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,13.31745
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,33.51797
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,12.3041
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,27.17015
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.02719
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,32.25228
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,15.23117
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,107.19755
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,16.94479
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,4.20223
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1051.10545
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.58818
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.89182
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,142.73361
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,40.25219
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1221.07737
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,179.8082

--- a/datasets/ES28_west_brabant/emissions.csv
+++ b/datasets/ES28_west_brabant/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,279.29345
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,88.20277
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.55223
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.51527
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,647.70997
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,324.04409
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.07364
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.41715
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6450.70365
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,26.40434
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,44.22459
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01263
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01142
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,12.03806
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,10.43117
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,919.97803
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,22.12094
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.80022
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,189.15325
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,19.11073
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,11.40354
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,18.45578
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3248.57025
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.95624
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.22801
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,82.75303
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,123.39666
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,10.88477
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,30.26219
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.09915
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,37.84108
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,17.52289
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,14.1221
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,11.92221
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,2.00689
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1346.50991
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,13.63378
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,20.66542
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,88.68995
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,29.72521
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,809.95909
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,108.92873

--- a/datasets/ES29_noord_en_midden_limburg/emissions.csv
+++ b/datasets/ES29_noord_en_midden_limburg/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1315.65862
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,106.94369
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,11.44329
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.6736
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,697.37469
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,267.31353
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.77215
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.00898
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3719.11674
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,12.93811
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.06786
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,12.41192
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0415
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,19.82032
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00839
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,30.36576
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,7.66367
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,777.30878
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,18.09129
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.59398
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,687.42274
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,49.37953
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.07961
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.2528
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00181
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,726.37422
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.91469
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.96675
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,183.81402
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,181.8628
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,6.09922
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,20.56996
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.15541
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,29.63846
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,12.87388
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,11.06092
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,9.33789
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.47444
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1076.33816
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.61716
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.04802
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,122.33692
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,32.79652
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1152.77628
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,85.38638

--- a/datasets/ES30_zuid_limburg/emissions.csv
+++ b/datasets/ES30_zuid_limburg/emissions.csv
@@ -1,66 +1,66 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,38.61646
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22813
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.30498
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.9493
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,154.60166
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,334.5673
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.39401
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1574
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,97.13991
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.41521
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.08817
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0128
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00948
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,12.81166
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,8.65686
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,985.36246
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,22.56809
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.38053
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,157.29586
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,39.48849
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,457.85003
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,378.87835
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,1471.25567
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8068.3081
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.72734
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.66629
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,808.70692
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,155.13596
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4714.62261
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,23.10418
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,7e-05
 Industry,Other metals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.13758
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,38.34847
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,14.5423
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,14.31146
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,12.08207
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.66552
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,900.97086
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.47698
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.33539
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,246.12622
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,27.182
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2550.16109
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,122.22288

--- a/datasets/GM0014_groningen/emissions.csv
+++ b/datasets/GM0014_groningen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.25579
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0834
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.30999
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.61628
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,70.85504
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,148.82252
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.9026
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40207
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,314.80539
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.84763
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.32303
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00399
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00378
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,3.79526
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,3.44551
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,280.55426
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.39168
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.82667
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,31.85739
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.03566
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,524.31497
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.19715
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15421
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.38587
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,6.77365
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,6.38961
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,8.03212
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00571
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,11.95393
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,5.78795
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.46115
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.7662
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.66289
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,300.14764
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.50509
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.50772
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.90525
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,13.01379
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,31.2721
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,59.91419

--- a/datasets/GM0034_almere/emissions.csv
+++ b/datasets/GM0034_almere/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.22183
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.89105
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00789
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06134
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,8.43231
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.61228
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14925
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.30241
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,109.79376
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.20613
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00908
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00146
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00353
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.3901
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,3.22955
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,64.86211
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.05689
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.20945
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,17.99579
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.86722
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04723
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.70128
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,6.35688
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.91276
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,5.53901
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.3784
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,5.42518
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.634
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.37946
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.62134
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,150.82565
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.58219
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.48587
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.65279
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.12283
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.21193
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,77.76015

--- a/datasets/GM0037_stadskanaal/emissions.csv
+++ b/datasets/GM0037_stadskanaal/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.97342
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03514
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.51232
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.3584
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,28.65316
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.98134
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07209
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04328
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.82744
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.07379
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.01744
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45103
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,55.78147
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.33168
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.76214
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,17.74022
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00245
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.9957
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23559
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02339
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.81923
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.88636
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.01545
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.94489
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.12728
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.75767
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.79389
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.67022
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08678
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,54.22804
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62461
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45594
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.50517
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.93751
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.66154
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.35482

--- a/datasets/GM0047_veendam/emissions.csv
+++ b/datasets/GM0047_veendam/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.26352
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0237
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12357
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22754
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,23.04735
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.35849
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0865
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05431
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.00342
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01438
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00058
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01878
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.55606
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45207
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,48.63682
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.11879
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63436
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,5.48376
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.22411
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.02902
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,97.30401
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27101
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02033
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.6362
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.78922
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12579
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.90285
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.75142
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.67439
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.65362
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.5518
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.68498
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,43.51908
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.49003
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53435
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.72555
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,9.33934
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.64846
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,61.82536

--- a/datasets/GM0050_zeewolde/emissions.csv
+++ b/datasets/GM0050_zeewolde/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.10845
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11724
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10107
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.50598
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,103.81101
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.40818
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02067
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04128
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00588
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00014
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.13622
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34008
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,11.9723
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25843
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4249
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.1096
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02978
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01864
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.15615
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.66989
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.01491
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.27306
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.42904
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.57128
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.16012
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.13517
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06543
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,88.74234
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85197
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.34881
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.43979
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.60252
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.50055
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.10216

--- a/datasets/GM0059_achtkarspelen/emissions.csv
+++ b/datasets/GM0059_achtkarspelen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,21.01873
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20236
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.0432
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.48506
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,71.65995
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.51856
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05167
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03436
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00054
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.02248
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.53896
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.44472
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,47.91536
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.11828
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.73499
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.65872
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02828
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02621
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.64353
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.80329
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13762
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.92549
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.69756
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.68511
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.63352
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.53483
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07847
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,45.41944
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51932
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44299
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.62578
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.00066
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.44661
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.31571

--- a/datasets/GM0060_ameland/emissions.csv
+++ b/datasets/GM0060_ameland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.12012
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00517
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.30946
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12736
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,12.27017
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.48584
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.009
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00789
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00148
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,7e-05
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.06035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.06205
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.1561
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,8.02997
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15974
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10529
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.64067
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00171
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00135
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.07073
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.11079
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02192
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.10178
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.19544
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.09269
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.07294
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.06157
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.01062
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,5.89104
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06446
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08274
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.23267
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.25582
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.19822
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.45763

--- a/datasets/GM0072_harlingen/emissions.csv
+++ b/datasets/GM0072_harlingen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.00025
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19631
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22824
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08488
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.04711
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.33622
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0445
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02502
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,3.60886
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.30475
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.23376
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.1294
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55795
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31003
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.73563
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04403
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.031
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.94619
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.46453
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.04892
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.44043
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00303
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.95988
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.39268
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.35822
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.30242
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04497
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,19.38424
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.232
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29604
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.89728
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.52566
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.86347
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.20647

--- a/datasets/GM0074_heerenveen/emissions.csv
+++ b/datasets/GM0074_heerenveen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.07323
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16525
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67861
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.80787
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,162.13377
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,22.42848
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13575
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16151
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,13.73459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.12905
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00908
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00087
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0008
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.82884
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.72828
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,73.04256
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.66314
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.11312
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,18.91533
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00104
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.39885
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12002
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0835
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.96359
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.43191
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.42737
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.45912
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00339
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.6106
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.22341
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.81326
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.85934
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14012
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,93.63994
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00646
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.45385
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.11288
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.57746
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.04381
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,19.04094

--- a/datasets/GM0080_leeuwarden/emissions.csv
+++ b/datasets/GM0080_leeuwarden/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.14397
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2138
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.07508
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.19472
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,188.08082
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,83.01736
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.50001
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20352
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,28.94952
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.48207
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.05344
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00014
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00224
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00764
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.12826
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.84402
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,174.23202
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.8757
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.32116
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,88.3826
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.53524
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19292
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.49898
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.60904
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.34051
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,5.53478
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.70336
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.08185
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.50166
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.11196
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.35296
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,186.6385
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.18034
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.17972
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.87724
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.8062
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.04745
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,8.22663

--- a/datasets/GM0085_ooststellingwerf/emissions.csv
+++ b/datasets/GM0085_ooststellingwerf/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,24.44788
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25784
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.73886
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.77575
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,162.35212
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.3913
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04482
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03128
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.48434
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.36826
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.78255
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00062
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.66912
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,33.29543
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34458
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02782
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.59125
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.72372
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07794
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.61275
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.52553
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.61863
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56932
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.48063
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07085
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,48.78714
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.49788
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.70437
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.49825
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.01389
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.85819
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.76005

--- a/datasets/GM0086_opsterland/emissions.csv
+++ b/datasets/GM0086_opsterland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,32.48767
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14425
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.78559
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.87497
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,166.39681
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.82018
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0535
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04077
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,13.02226
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.09346
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.02092
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.52233
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.47003
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,50.40553
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.14754
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.80266
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.14652
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09556
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03586
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.84044
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.85634
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10158
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.7519
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.64518
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.7321
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.61397
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.51833
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08385
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,72.192
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68739
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1721
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.19596
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.83977
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.97633
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.16231

--- a/datasets/GM0088_schiermonnikoog/emissions.csv
+++ b/datasets/GM0088_schiermonnikoog/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
 Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00161
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0534
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01449
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.42285
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.45936
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00279
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00207
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,2e-05
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,2e-05
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.01801
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.01428
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,2.47415
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04961
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02909
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0766
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00021
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00024
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.02053
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.02946
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.00276
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.02622
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.05673
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.024
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.02117
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.01787
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.00275
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.92155
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01151
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05512
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10925
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.01181
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.09905

--- a/datasets/GM0090_smallingerland/emissions.csv
+++ b/datasets/GM0090_smallingerland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,16.82714
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15822
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.71916
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.46756
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,86.05297
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,26.65696
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16165
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10477
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6.12024
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05977
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00247
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00103
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.10177
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.98247
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.97956
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,79.96571
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.85939
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.12449
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,25.33371
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25655
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04426
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.11994
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.59335
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.68072
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.64302
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.09447
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.36185
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.15484
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.97494
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15597
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,87.48782
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.96804
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.47621
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.14495
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.8794
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.00966
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.88667

--- a/datasets/GM0093_terschelling/emissions.csv
+++ b/datasets/GM0093_terschelling/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
 Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00436
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.21931
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08262
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.71628
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.67445
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01016
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01031
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,9e-05
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,8e-05
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.08892
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.07091
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,9.2774
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.20842
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.123
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.4075
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00121
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00119
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.10135
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.14205
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.00933
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.13118
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.28007
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.11913
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.10452
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.08824
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.01364
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,7.32634
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08892
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12594
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.14189
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.24555
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.22894
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.26558

--- a/datasets/GM0096_vlieland/emissions.csv
+++ b/datasets/GM0096_vlieland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
 Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1e-05
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00649
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,9e-05
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.31171
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.652
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00395
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00215
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.7355
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01489
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,2e-05
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,2e-05
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.02108
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.01849
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,2.14864
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04647
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02724
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.6746
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0095
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00042
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.02403
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0365
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.00212
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.03175
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0664
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.03106
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.02478
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.02092
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.00356
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.90565
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01401
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03424
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05124
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0261
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06748

--- a/datasets/GM0098_weststellingwerf/emissions.csv
+++ b/datasets/GM0098_weststellingwerf/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,16.60008
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2454
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.76945
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.92873
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,219.81609
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.0105
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05465
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06274
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00317
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.12967
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.47746
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.59742
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,44.68098
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.02218
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.66303
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,5e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.56066
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05613
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01968
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.7112
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.74912
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09386
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.77087
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.50385
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.64014
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56123
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4738
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07332
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,55.99847
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55503
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.798
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.93166
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.93364
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.57133
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.94477

--- a/datasets/GM0106_assen/emissions.csv
+++ b/datasets/GM0106_assen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.7147
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00983
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.17142
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15884
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,12.58422
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,41.19372
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2484
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12692
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.032
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.15614
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01042
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00123
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00104
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.05111
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.99374
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.08566
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,76.61277
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.77759
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.26502
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.67456
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05097
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02399
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.2561
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.96932
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.09954
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.91312
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.12997
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.68313
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.16809
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.98613
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.19277
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,82.95679
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.87753
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09823
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.83146
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.04058
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.8119
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.88804

--- a/datasets/GM0109_coevorden/emissions.csv
+++ b/datasets/GM0109_coevorden/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,35.29377
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16048
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.4962
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.99575
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,161.71705
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.48703
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08181
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05419
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -22,20 +22,20 @@ Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00873
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00067
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.35649
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.63496
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.10876
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,55.04864
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.28478
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.88897
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,21.16152
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1195
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08025
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.48411
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.0084
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.40307
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.95321
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00437
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.99995
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.86174
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.74637
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.6301
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09869
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,88.50308
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.87879
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.42298
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.63657
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.58024
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.48166
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.0042

--- a/datasets/GM0114_emmen/emissions.csv
+++ b/datasets/GM0114_emmen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,48.62281
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.38361
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.58842
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.90437
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,112.41064
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,53.75154
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.32395
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16702
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,31.41682
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.27789
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01389
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,173.61537
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.90116
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00295
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,79.24381
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.12222
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,80.45952
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.77515
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,169.95891
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.92382
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.45599
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.25943
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.00635
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,251.78975
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.26667
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10346
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.85492
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.09214
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.59333
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.09348
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00259
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.34192
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.64319
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.36677
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.99808
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.30272
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,153.99828
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.79875
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.86237
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.46237
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.48106
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,6.52262
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.26174

--- a/datasets/GM0118_hoogeveen/emissions.csv
+++ b/datasets/GM0118_hoogeveen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,33.69787
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18968
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20182
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.39664
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,67.58894
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,27.35622
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1658
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11002
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.23685
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03583
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.02271
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.33254
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00105
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00089
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.99909
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.81464
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,75.76724
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.80894
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.13011
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,13.43984
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,52.5925
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6741
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10318
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.16905
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.60134
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.34761
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,5.10783
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00241
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.14682
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.36847
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.17438
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.99144
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15673
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,97.03912
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00072
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.57627
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.13378
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.82887
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.15328
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.92753

--- a/datasets/GM0119_meppel/emissions.csv
+++ b/datasets/GM0119_meppel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.32822
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08438
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.33149
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19482
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,40.93735
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.65741
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11785
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05892
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.49062
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.07423
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.03527
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00056
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00906
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.53681
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.50756
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.22643
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.97528
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.67367
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.68397
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.31446
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02233
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.72386
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.9698
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.2498
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.9829
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.6908
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.82867
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.631
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.5327
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09491
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,41.86359
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.45285
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82954
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.50227
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.47261
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.84793
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.09542

--- a/datasets/GM0141_almelo/emissions.csv
+++ b/datasets/GM0141_almelo/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,15.74256
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05054
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.50688
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15166
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,34.32648
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,42.58418
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25829
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16259
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.14552
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02895
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00481
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00135
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00117
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.28151
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.07252
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,98.30763
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.29728
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.33076
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,93.08331
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,28.49071
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,32.63769
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,58.7708
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.52755
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29492
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.48661
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.10879
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.53463
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.54074
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01667
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.03637
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.80168
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.50635
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.2717
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.20635
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,84.05592
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00222
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.42497
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.44667
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.26078
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.42364
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.76696

--- a/datasets/GM0147_borne/emissions.csv
+++ b/datasets/GM0147_borne/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.05626
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06995
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.30628
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07798
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.84648
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.13753
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03709
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02713
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.21993
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03328
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00041
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.38868
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34644
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,28.9853
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.703
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48152
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.49995
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0195
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01096
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.44326
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.68096
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.23732
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68116
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.22422
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58197
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.45687
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.3857
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06665
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,39.40867
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40841
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64643
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02984
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00138
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.18133
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03012

--- a/datasets/GM0148_dalfsen/emissions.csv
+++ b/datasets/GM0148_dalfsen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,34.65536
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.51038
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.99776
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.6593
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,156.60108
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.83463
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04142
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04202
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.06767
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01024
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.47957
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.42621
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.74428
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.94348
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.72036
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.19457
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01239
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0399
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.54684
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.83766
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13753
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.77132
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.51049
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.71597
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56371
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4759
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.082
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,58.55614
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.63119
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.66228
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.72864
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.94209
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.92581
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.39411

--- a/datasets/GM0150_deventer/emissions.csv
+++ b/datasets/GM0150_deventer/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,30.8151
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17092
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.38254
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.39666
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,81.08643
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,52.96697
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.31918
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19442
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,38.68435
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.2947
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.03981
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0017
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00162
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.61874
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.48426
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,123.26802
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.86738
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.75946
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.97772
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00611
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4.05738
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,71.74953
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.0707
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14898
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.24149
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.91816
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.17414
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.88734
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00499
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.09854
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.49334
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.90275
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.60635
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.28556
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,173.44943
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.79722
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.11016
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.6551
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.67282
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.47277
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.14963

--- a/datasets/GM0153_enschede/emissions.csv
+++ b/datasets/GM0153_enschede/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.33963
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08098
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.99548
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.29895
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,37.59954
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,77.43908
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.46605
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24661
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,167.12847
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.20829
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,30.34863
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.003
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00256
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.85513
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.33561
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,197.93304
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.90744
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.62198
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,22.8975
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,79.89984
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78617
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24356
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.15612
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.59132
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.65383
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.2377
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00918
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,8.99281
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.9235
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.35607
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.83327
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.44936
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,171.39139
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.18253
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.98008
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,9.99089
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.3191
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,7.7064
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.22022

--- a/datasets/GM0158_haaksbergen/emissions.csv
+++ b/datasets/GM0158_haaksbergen/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,29.26804
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16213
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.96516
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.31061
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,70.49516
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.19491
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06184
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04016
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.44692
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35275
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,34.51581
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83906
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.52553
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.47995
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.77298
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13473
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06099
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.54618
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.69315
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12147
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.72267
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0008
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.40767
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59257
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.52533
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4435
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06787
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,41.51486
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48043
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53493
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.6642
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.00783
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.47772
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.99348

--- a/datasets/GM0160_hardenberg/emissions.csv
+++ b/datasets/GM0160_hardenberg/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,127.15216
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.08618
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.9114
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.99446
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,252.4734
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,23.71242
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14104
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09673
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00584
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00108
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.23919
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.03056
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.29898
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,82.73004
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.02971
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.45164
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,58.99829
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23769
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05884
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.44645
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.76953
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.24143
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.60796
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00107
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.24594
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.51228
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.21137
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.02267
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1732
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,107.84708
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.13391
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.51977
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.2225
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.79694
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.38404
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.53418

--- a/datasets/GM0163_hellendoorn/emissions.csv
+++ b/datasets/GM0163_hellendoorn/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,35.52797
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15175
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.99438
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.37361
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,89.50415
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.57771
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07022
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04796
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.67563
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.52374
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,54.33504
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.31477
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.80917
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,35.59796
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05963
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02908
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.84802
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.02928
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10031
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.10273
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,9e-05
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.12803
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.87981
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.79417
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.67046
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10076
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,59.3668
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70346
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50913
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.65395
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.04794
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.18332
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.67456

--- a/datasets/GM0164_hengelo/emissions.csv
+++ b/datasets/GM0164_hengelo/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.58032
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16075
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.47986
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10934
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.22885
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,66.17883
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.69116
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23683
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,68.80491
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.48946
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,23.28291
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00157
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00131
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.50412
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.19567
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,121.63233
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.75874
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.42227
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,15.43092
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.29219
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,1.10405
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,365.94856
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.46944
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08366
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.98357
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.35101
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.61436
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.32718
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00276
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.71247
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.00856
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.75867
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.48471
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.23004
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,99.71775
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19474
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.50769
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,182.37324
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,9.30968
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1980.71562
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,26.76684

--- a/datasets/GM0166_kampen/emissions.csv
+++ b/datasets/GM0166_kampen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.10349
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.3426
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22525
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.61118
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,135.98097
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,18.06924
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10863
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0874
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,9.05771
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0711
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00094
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00088
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.89501
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.80212
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,64.26248
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.56775
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.98044
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,18.28519
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1326
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05038
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.032
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.5809
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.72471
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.58663
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.81901
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.34746
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.05204
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.88816
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15432
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,78.9041
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.90246
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.06939
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.68438
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.29753
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.75452
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.69906

--- a/datasets/GM0168_losser/emissions.csv
+++ b/datasets/GM0168_losser/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,10.64864
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37563
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.7795
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34052
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,65.37862
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.54011
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04573
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02419
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,62.05961
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.2075
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,99.05257
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,98.4891
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.33942
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,32.62737
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79404
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.51297
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.61577
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23783
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01717
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.61847
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.66708
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07004
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.56392
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.35932
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.57018
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.50729
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.42827
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0653
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,37.55474
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43347
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.61129
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.52696
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.83011
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.77711
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.76517

--- a/datasets/GM0171_noordoostpolder/emissions.csv
+++ b/datasets/GM0171_noordoostpolder/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,38.2583
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.25182
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.40808
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.93555
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,110.19602
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.23338
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15878
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11875
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00078
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00079
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.73851
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.72202
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,58.28827
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.38222
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0194
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,16.42647
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.89543
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03222
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02441
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.85088
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.42469
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.73632
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.8229
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00294
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.32609
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.21288
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.86808
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.73286
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13891
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,159.4425
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.45073
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.46839
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,28.50103
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.43678
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,294.89381
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,17.026

--- a/datasets/GM0173_oldenzaal/emissions.csv
+++ b/datasets/GM0173_oldenzaal/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.35242
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10609
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.2141
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03132
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.3738
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,16.57691
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09991
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06625
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00064
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.60565
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45874
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,46.27706
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.10605
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5897
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,10.45321
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,17.31227
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68706
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03823
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.69048
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.90185
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.39998
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.07592
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00187
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.90762
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.77062
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.71191
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.60101
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08826
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,41.84525
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.52608
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45086
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.28814
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.76402
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.57835
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.56439

--- a/datasets/GM0175_ommen/emissions.csv
+++ b/datasets/GM0175_ommen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,40.86444
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12766
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.13988
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.46843
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,113.9573
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.89371
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04769
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02743
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.28761
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04351
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.32848
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.9042
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.4752
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.64836
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44269
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.09461
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02133
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02346
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.37465
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.532
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.31956
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.53005
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.03462
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.45455
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,135.74211
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.88474
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,7.39459
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,47.62672
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51262
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.73419
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.48092
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.73078
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.05181
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.56053

--- a/datasets/GM0177_raalte/emissions.csv
+++ b/datasets/GM0177_raalte/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,81.94995
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45628
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.92523
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.69346
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,172.66968
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.35232
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08046
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05379
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0006
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.66956
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.55137
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,48.82449
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.24024
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.86104
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.76646
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21753
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02788
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.82304
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.08356
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09648
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.99649
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.1089
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.92622
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.78703
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.66443
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10608
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,75.85858
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83187
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79661
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.51483
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.61304
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.97125
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.63141

--- a/datasets/GM0180_staphorst/emissions.csv
+++ b/datasets/GM0180_staphorst/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.12871
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38103
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.83832
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.56711
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,130.43651
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.67806
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02837
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03542
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00027
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.25343
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.2702
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,20.18242
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51267
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41985
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.81978
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06891
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01966
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.30901
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.53158
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10552
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.63693
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.79823
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.4539
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.29789
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.25149
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05199
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,61.45727
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48408
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.15542
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.39833
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.32012
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.40886
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.45324

--- a/datasets/GM0183_tubbergen/emissions.csv
+++ b/datasets/GM0183_tubbergen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,56.98586
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41514
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.32072
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.59808
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,153.09627
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.58216
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03386
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03423
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,49.64769
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.166
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,79.24208
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,78.81267
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.30573
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.04037
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.7362
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.52281
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.92125
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02495
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01578
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.45241
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.60081
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04834
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.55554
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.15485
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.51359
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.43098
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.36385
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05882
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,43.2015
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.46097
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40263
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.92999
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.79009
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.67683
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.76362

--- a/datasets/GM0184_urk/emissions.csv
+++ b/datasets/GM0184_urk/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.10781
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00587
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00362
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01113
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.6742
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.65291
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02822
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0323
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00027
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.25813
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.31629
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,16.26608
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43507
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37072
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,20.38549
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05172
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04486
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.29479
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.62402
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04212
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.5799
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.81305
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.53132
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.30342
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.25616
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06085
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,14.6933
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19169
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16366
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.09079
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.2639
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.35645

--- a/datasets/GM0189_wierden/emissions.csv
+++ b/datasets/GM0189_wierden/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,38.9536
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21457
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.58537
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.33067
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,70.87344
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.11091
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03694
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0376
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.21148
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.032
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.43567
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35991
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.89068
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84351
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57758
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,6.47103
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,33.75765
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29945
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02484
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.51078
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70769
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.23944
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.72767
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00116
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.37224
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.60459
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.51211
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43234
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06924
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,56.39641
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58366
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.91509
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15459
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15215
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.70231
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.08924

--- a/datasets/GM0193_zwolle/emissions.csv
+++ b/datasets/GM0193_zwolle/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.94958
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42338
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.51566
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34368
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,54.36929
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,81.96737
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.49325
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28349
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1382.87968
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.76311
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.3086
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00194
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0021
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.84723
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.9159
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,137.89
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.19733
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.0848
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,8.95989
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,3e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00069
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,30.58532
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62311
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05112
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.13381
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.76628
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4.63511
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,6.43936
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0016
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.81822
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.21843
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.17133
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.83309
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.36861
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,195.56555
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.02498
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.73838
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.27376
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.30099
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.19026
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.4751

--- a/datasets/GM0197_aalten/emissions.csv
+++ b/datasets/GM0197_aalten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,44.6494
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13597
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.14799
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.3557
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,81.99303
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.48568
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0636
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03965
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.51894
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.39051
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,41.4391
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00845
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63902
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.09988
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1059
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02969
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.61457
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.7675
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12941
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.12566
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.63449
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.65601
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.60998
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.51496
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07513
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,41.22943
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47697
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36713
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.38079
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.18918
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.46498
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.13003

--- a/datasets/GM0200_apeldoorn/emissions.csv
+++ b/datasets/GM0200_apeldoorn/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,33.92968
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.91229
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.32677
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34441
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,69.34445
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,94.89404
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58117
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.288
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,5.00856
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03595
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0334
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00303
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00265
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.88648
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.42122
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,231.81136
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.45002
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.93891
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,44.30168
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,2.155
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,4.16186
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.01125
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.47827
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,103.5851
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.02733
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29183
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.41512
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.75791
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.82586
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,6.21462
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -65,14 +65,14 @@ Industry,Other metals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.02165
 Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01043
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,9.09154
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,4.0673
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.39292
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.86438
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.46583
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,386.7045
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.80151
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.29622
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,21.53648
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.7868
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,116.40758
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.98369

--- a/datasets/GM0202_arnhem/emissions.csv
+++ b/datasets/GM0202_arnhem/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.80219
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1904
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.18054
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05108
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.75621
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,111.38179
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6749
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41751
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,86.14727
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.61826
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.31875
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00268
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01021
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.55235
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,4.72736
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,189.28228
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.2972
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.47264
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,6.47103
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,12.72699
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.19405
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,14.33506
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,191.14423
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.57323
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.70076
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.95475
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.68088
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.20879
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,10.62915
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01632
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,8.03914
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.99869
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.00017
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.53281
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.45797
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,292.35228
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.93389
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.39169
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.85798
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.58557
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.52886
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.37425

--- a/datasets/GM0203_barneveld/emissions.csv
+++ b/datasets/GM0203_barneveld/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,185.44833
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.35534
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.54031
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.36682
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,168.52294
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,22.02807
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13354
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19361
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.10151
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01536
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,21.84401
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00087
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00096
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.8241
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.87627
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,60.81454
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.53603
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1532
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02491
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00273
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,36.67898
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17294
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.104
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.9482
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.7225
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.27615
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.47978
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.59565
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.47201
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.96868
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.81779
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16859
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,149.39192
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.38065
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.60901
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.43099
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,38.54626
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.34096
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,331.27212

--- a/datasets/GM0209_beuningen/emissions.csv
+++ b/datasets/GM0209_beuningen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,10.85261
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49484
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20839
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.11374
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,19.75921
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.0478
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06593
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13084
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,5.86055
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.43359
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.38196
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.35502
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79436
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54146
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.78718
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00641
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07449
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.57581
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.76389
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05223
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.85796
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.36567
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.64164
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.50966
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43027
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07349
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,72.0274
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.67461
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.18982
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,22.75557
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,11.63496
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,191.45946
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,60.09499

--- a/datasets/GM0213_brummen/emissions.csv
+++ b/datasets/GM0213_brummen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.59543
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17501
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.59903
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.25723
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,35.38766
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.47035
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06351
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03332
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.50257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01078
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.16627
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40504
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.31136
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,34.2249
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.80128
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48898
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,204.65317
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.11393
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49326
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.4764
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.61375
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08533
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.79923
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.27574
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.52304
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.4761
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.40193
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0599
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,45.33549
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4928
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42595
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.62103
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.12245
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.07866
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.77721

--- a/datasets/GM0214_buren/emissions.csv
+++ b/datasets/GM0214_buren/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,34.3479
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58679
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.73944
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.56034
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,73.7242
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.93867
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03602
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03607
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.07613
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01152
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.43623
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.40396
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,39.424
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.92659
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.67732
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.53439
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09003
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00802
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.48002
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.80144
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07108
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.681
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.37399
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.67859
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.51277
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43289
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07772
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,54.56063
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61126
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6248
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15319
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.80548
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.05768

--- a/datasets/GM0216_culemborg/emissions.csv
+++ b/datasets/GM0216_culemborg/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.95921
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01547
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.24883
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10308
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.07314
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.24281
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07426
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05412
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.08459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.42337
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.42949
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,31.28902
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.73985
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4861
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.68935
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11194
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01224
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.48606
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.84489
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12702
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.89999
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.3335
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.72148
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49766
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.42013
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08263
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,40.01043
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43225
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57268
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.61734
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.1319
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.91014
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.06067

--- a/datasets/GM0221_doesburg/emissions.csv
+++ b/datasets/GM0221_doesburg/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.31061
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00241
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09074
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04402
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.95817
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.8892
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02359
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01449
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00022
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00017
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.20682
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.15662
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,15.69059
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.36521
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22523
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.82931
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02085
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00898
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.23623
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.30817
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06483
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.27241
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.65143
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.26309
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.24311
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.20524
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03013
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,13.05593
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16532
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12143
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.06535
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.00384

--- a/datasets/GM0222_doetinchem/emissions.csv
+++ b/datasets/GM0222_doetinchem/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,33.92328
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09629
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.83332
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22275
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,46.0619
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,35.06959
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21073
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10916
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.65797
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.25084
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.03393
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.001
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00094
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.94985
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.86321
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,74.98271
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.7596
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.19629
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,60.34039
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.35879
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31057
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.12423
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.69629
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.57006
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.27206
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.99173
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.45007
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.1165
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.94257
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16608
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,91.12223
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.9527
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.06091
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.06726
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.489
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.10158
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.59296

--- a/datasets/GM0225_druten/emissions.csv
+++ b/datasets/GM0225_druten/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,35.1121
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36484
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.23074
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12853
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,33.17904
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.15897
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04342
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.024
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.28965
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.28534
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,23.63401
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55611
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41192
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.09845
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29441
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01695
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,15.85924
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,13.28189
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05972
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.46871
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.91232
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.47934
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.34047
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.28743
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0549
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,28.35026
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.32327
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41096
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.25842
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.81992
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.6261
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.85093

--- a/datasets/GM0226_duiven/emissions.csv
+++ b/datasets/GM0226_duiven/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,6.57561
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7601
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12487
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0924
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.32885
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.13127
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0443
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07103
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,50.58648
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.36305
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,11.23275
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.29298
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.38363
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,14.94683
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48926
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.46474
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.86259
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17808
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20604
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.33506
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.7546
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03526
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.82872
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.92281
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.64445
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.34439
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.29074
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07381
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,48.7573
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.44209
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79148
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.73478
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,15.12513
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,7.27177
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.1488

--- a/datasets/GM0228_ede/emissions.csv
+++ b/datasets/GM0228_ede/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,207.78852
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.65744
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.73812
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.46935
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,197.14813
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,47.55328
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28896
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22732
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.14552
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02895
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01683
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00192
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00196
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.82558
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.79435
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,135.92436
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.32586
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.17506
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.47769
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.09922
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.57874
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,118.95086
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4794
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11001
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.0815
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.52602
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.18142
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.51316
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.75002
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.01425
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.14588
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.8116
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.34522
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,241.67707
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.53961
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.60333
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.80143
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.1635
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.50869
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.84705

--- a/datasets/GM0230_elburg/emissions.csv
+++ b/datasets/GM0230_elburg/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,18.73737
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2366
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.33944
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16229
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.91328
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.12467
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04204
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03111
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40404
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34669
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.25166
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.74772
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5072
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.66295
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13991
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01442
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.51382
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.68148
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06059
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.62269
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.2726
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58239
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47493
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.40094
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0667
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,56.13238
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56144
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.65353
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.2986
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.77058
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.99108
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.49643

--- a/datasets/GM0232_epe/emissions.csv
+++ b/datasets/GM0232_epe/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,33.09029
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63322
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.04146
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.30763
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,53.96309
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.70512
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07072
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05156
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.41449
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.06271
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00052
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.66437
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.47955
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,55.15496
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.32541
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74454
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,79.1457
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,32.73688
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.86138
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0251
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.78738
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.94253
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.50446
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.93413
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01418
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.09257
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.80557
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.78094
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.65928
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09226
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,88.28194
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.91844
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.12544
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.26741
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.03905
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.09628
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.94665

--- a/datasets/GM0233_ermelo/emissions.csv
+++ b/datasets/GM0233_ermelo/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,82.0823
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.52973
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.28799
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08852
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,25.77218
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.43098
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0754
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11233
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,27 +23,27 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.50522
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.39977
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.02371
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.93476
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54826
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,17.91978
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.96728
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10078
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03962
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.57733
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.78604
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06693
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68183
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00321
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.5913
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.67155
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.59386
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.50135
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07691
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,57.80929
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62397
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6751
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.87239
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.16879
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,42.14475

--- a/datasets/GM0243_harderwijk/emissions.csv
+++ b/datasets/GM0243_harderwijk/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,43.13074
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11393
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07339
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02589
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.08546
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,22.21943
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1323
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08694
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,27.41843
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.25042
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.03981
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00078
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.69239
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.70857
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,50.30509
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.21823
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82399
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.99109
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,22.9847
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24333
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08691
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.75307
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.39302
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.17038
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.35451
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00036
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.18081
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.1903
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.81387
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.68708
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13632
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,68.10657
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70568
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.08051
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.69079
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,28.88618
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.76982
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.64681

--- a/datasets/GM0244_hattem/emissions.csv
+++ b/datasets/GM0244_hattem/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.20779
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00453
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.05595
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06192
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.35247
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.94055
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02967
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01683
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00024
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.22736
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.18188
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,19.20445
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.44997
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28232
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.92007
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00798
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01741
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.25968
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.35863
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03023
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.30781
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.71611
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.30553
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.26725
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.22562
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03499
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,35.70131
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34043
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78072
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.73256
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.68727
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.97877
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.37858

--- a/datasets/GM0246_heerde/emissions.csv
+++ b/datasets/GM0246_heerde/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.31909
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31382
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.39396
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1873
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,25.39525
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.25354
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0437
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02705
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.35467
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.27782
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.29342
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.72592
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47584
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,92.3244
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34398
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0761
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.40877
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.54674
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0495
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.59625
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.1171
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.4667
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.4169
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.35195
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05345
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,51.33731
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.50569
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.68757
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.048
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.74303
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.48438
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.71706

--- a/datasets/GM0252_heumen/emissions.csv
+++ b/datasets/GM0252_heumen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.86951
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13813
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.28368
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10529
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.36697
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.37237
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02045
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02118
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00214
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.26941
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.26605
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,23.73064
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.53373
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3817
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.8197
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08422
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0051
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.3724
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.52493
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03974
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.42381
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00981
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.84855
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.44692
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.31668
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.26735
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05119
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,38.73801
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39371
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.56393
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1034
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.25737
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.36348
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.19684

--- a/datasets/GM0262_lochem/emissions.csv
+++ b/datasets/GM0262_lochem/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,70.95789
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13972
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.36342
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.75013
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,131.55456
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.57109
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08838
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06448
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00065
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00054
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.617
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.48905
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,53.31577
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.26958
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82483
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,36.5219
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22935
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06062
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.34415
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.96454
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10633
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.95098
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00071
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.94336
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.82153
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.72525
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.61228
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09409
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,78.06637
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83565
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74786
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.11936
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.43042
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.99624
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.82747

--- a/datasets/GM0263_maasdriel/emissions.csv
+++ b/datasets/GM0263_maasdriel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,15.13214
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.57623
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.27029
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.20465
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,39.58352
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.9303
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0481
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05164
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00107
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00041
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41166
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.37697
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.83922
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84524
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62793
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.05291
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30963
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05821
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,34.11712
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,13.46006
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0711
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.11414
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.2966
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.63326
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.48388
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.40851
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07253
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,68.01197
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.64362
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.05297
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02903
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.62725
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.33268

--- a/datasets/GM0267_nijkerk/emissions.csv
+++ b/datasets/GM0267_nijkerk/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,50.64306
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18919
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.6463
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.25527
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,40.97578
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,16.49555
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09957
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0869
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.66411
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.65213
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,48.20483
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19507
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.84486
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.39312
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06622
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07635
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.75735
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.28177
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13086
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.36476
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.09175
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.09549
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.78063
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.65903
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12547
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,72.99573
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.7611
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.9648
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.11101
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.28453
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.44725
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.73641

--- a/datasets/GM0268_nijmegen/emissions.csv
+++ b/datasets/GM0268_nijmegen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.23815
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50265
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12053
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01587
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.44762
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,108.32264
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.65703
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31244
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4092.6829
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,16.8021
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.04515
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00304
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00287
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.89249
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.62341
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,211.08215
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.90196
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.69342
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,17.42201
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,10.62
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,1.02178
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00503
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.07686
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,144.05422
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.9802
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22663
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.61048
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,5.17075
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.70853
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.97653
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01043
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,9.11046
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,4.40696
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.39998
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.87034
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.50473
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,178.39219
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.16108
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.28556
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.38131
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.24416
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.87263

--- a/datasets/GM0269_oldebroek/emissions.csv
+++ b/datasets/GM0269_oldebroek/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,22.39467
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18648
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.49347
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.31334
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,54.08278
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.16514
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03739
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02966
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41854
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35141
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.21369
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78474
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53104
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.68795
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01792
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02575
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.49961
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.69094
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05131
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.5709
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.31828
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59032
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49198
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.41534
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06761
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,71.42579
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.64066
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.86682
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07263
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.45543
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.79875

--- a/datasets/GM0273_putten/emissions.csv
+++ b/datasets/GM0273_putten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,97.27998
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.8054
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.64098
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22404
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,67.68784
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.89363
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04181
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03721
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.00171
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00719
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40883
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.36059
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,31.82717
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78623
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5453
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,10.69909
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04694
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01441
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.4664
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70903
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0457
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.61803
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.28769
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.60573
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.48056
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4057
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06937
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,68.2831
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.64966
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82681
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.34956
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.09957

--- a/datasets/GM0274_renkum/emissions.csv
+++ b/datasets/GM0274_renkum/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.38649
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00579
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15574
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05452
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.0405
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.48881
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0925
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04152
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00069
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.65662
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45588
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,53.9693
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.25213
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.68684
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,203.97234
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4919
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.26862
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.56426
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.89657
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08642
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.73142
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.06814
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.76582
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.77182
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.65159
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08771
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,73.90895
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.75792
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.80403
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.82965
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.73496
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.92164
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.9808

--- a/datasets/GM0275_rheden/emissions.csv
+++ b/datasets/GM0275_rheden/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.60173
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01848
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.18248
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12408
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.93633
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.92701
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12575
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05827
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.81023
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.27388
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00093
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00069
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.88722
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.62645
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,72.5633
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.64743
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.81433
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.06641
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,18.62977
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25768
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04554
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.05977
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.2336
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.80266
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.17446
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.79448
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.05234
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.04289
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.88043
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12052
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,83.04846
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.92108
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74875
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10928
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0053
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.22144
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.08797

--- a/datasets/GM0277_rozendaal/emissions.csv
+++ b/datasets/GM0277_rozendaal/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0119
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01913
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00068
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06833
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.85594
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00519
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00129
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,3e-05
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,3e-05
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.02556
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.02984
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,3.16571
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06092
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05283
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.03381
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0003
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4e-05
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.02913
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.05862
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.00258
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.04203
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0805
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.05013
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.03004
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.02536
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.00574
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,2.48934
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03677
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0383
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01008
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.00503
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.00024

--- a/datasets/GM0279_scherpenzeel/emissions.csv
+++ b/datasets/GM0279_scherpenzeel/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,28.93715
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05827
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.16572
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04282
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,11.36221
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.96212
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02403
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01576
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00018
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00016
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.17057
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.14854
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,12.52988
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30976
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22416
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.27426
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02105
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00642
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.1944
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.29185
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05294
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.27976
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.53725
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.24953
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.2005
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.16926
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02858
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,9.07731
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11859
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11598
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21789
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.13584
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0234

--- a/datasets/GM0281_tiel/emissions.csv
+++ b/datasets/GM0281_tiel/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.41711
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13641
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.08787
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0571
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.61383
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.71943
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11898
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07347
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.12689
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0192
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.46254
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00068
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.62877
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.61761
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,48.12436
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.12336
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.73254
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.05047
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,22.85905
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.32803
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.25451
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,125.62763
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,13.66675
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.74739
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.51225
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.98044
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.0375
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.73909
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.62396
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.11882
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,61.42516
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62768
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.12404
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.33334
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.17548
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.16338
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.01337

--- a/datasets/GM0285_voorst/emissions.csv
+++ b/datasets/GM0285_voorst/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,29.41234
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.29246
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.95845
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.4876
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,99.30441
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.6974
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05862
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06157
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,56.59675
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.40619
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00048
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.45549
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.36416
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.1857
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.91364
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58629
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.9924
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21734
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01755
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.55333
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.71784
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05667
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.64325
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.43466
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.61174
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.53541
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.45201
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07006
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,87.24169
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.8258
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.11405
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.07075
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.41253
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.30694
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.02916

--- a/datasets/GM0289_wageningen/emissions.csv
+++ b/datasets/GM0289_wageningen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.22686
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36684
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.13672
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06415
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.49489
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,21.01652
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12748
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05413
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,5.54325
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04466
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00067
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.63384
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.60075
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,40.71923
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.03726
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63387
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00348
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.12654
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04642
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0125
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.75893
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.18104
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.55388
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.98486
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00027
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.9964
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.00918
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.74505
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.62899
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.11558
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,37.22588
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48297
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37616
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.22329
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06436

--- a/datasets/GM0293_westervoort/emissions.csv
+++ b/datasets/GM0293_westervoort/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.13437
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01369
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01246
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.51304
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.94229
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01178
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0125
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00023
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.29792
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.20883
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,8.90969
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42366
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25591
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.40973
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00139
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00652
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.34062
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.41104
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03105
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.31294
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.93835
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.3508
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.35019
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.29564
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04018
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,17.0983
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21745
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1225
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21789
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.02062
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.02193

--- a/datasets/GM0294_winterswijk/emissions.csv
+++ b/datasets/GM0294_winterswijk/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,27.52342
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11705
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.39548
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.50452
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,74.83625
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.61073
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08862
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0569
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.54606
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.42088
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,44.52541
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06305
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57992
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,10.15814
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21844
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06003
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,16.53445
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.82714
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.63896
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.94412
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.71994
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.70701
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.64187
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.54188
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08097
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,47.87083
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54082
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41404
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.00675
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.65936
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.79058
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.62552

--- a/datasets/GM0296_wijchen/emissions.csv
+++ b/datasets/GM0296_wijchen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,18.71046
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23931
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.55741
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19568
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,33.17862
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.94126
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07243
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07142
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.50257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01078
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.66853
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.6009
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,51.55061
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.23216
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79426
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,35.57611
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5862
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10015
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.12579
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.18144
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13993
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.24064
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00036
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.10567
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.00942
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.78582
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.66341
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.11561
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,69.24283
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.71932
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94146
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20679
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.23401
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.41441
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.51181

--- a/datasets/GM0297_zaltbommel/emissions.csv
+++ b/datasets/GM0297_zaltbommel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,12.54688
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,18.01963
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.44521
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.25397
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,40.12903
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.46399
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08112
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14223
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.40603
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.06143
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00846
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.42937
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45825
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.13106
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.86653
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64894
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00887
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.80934
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19789
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02379
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,19.73022
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,26.65077
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.43175
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.0666
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.35239
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.74738
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.50471
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.42608
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0856
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,69.49889
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.65018
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1887
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.58992
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.00079
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.02218
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.74494

--- a/datasets/GM0299_zevenaar/emissions.csv
+++ b/datasets/GM0299_zevenaar/emissions.csv
@@ -1,46 +1,46 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,22.34575
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18155
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.48501
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.30153
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,56.14975
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,18.00359
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1092
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06376
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00086
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.87929
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.64022
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,61.57801
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.48372
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.89362
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.49777
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,2.33749
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,32.35114
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.8866
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03681
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,107.25676
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,79.74367
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.0325
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.79442
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,9e-05
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.56906
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.07547
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.45576
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.82215
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.85971
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,96.21425
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.96211
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.06823
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.12577
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.37239
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.05452

--- a/datasets/GM0301_zutphen/emissions.csv
+++ b/datasets/GM0301_zutphen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.80222
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.52742
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.31069
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.09264
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.89085
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.6772
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14968
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06224
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.50428
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01797
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,1.61848
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00082
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00076
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.78195
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.69693
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,59.99418
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.37506
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.83416
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,31.81563
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.44978
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.69853
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.91653
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.3709
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.41515
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.30467
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.46291
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.17075
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.91915
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.77596
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13408
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,60.31243
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.72848
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55345
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.69839
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,13.2691
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.22444
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.19047

--- a/datasets/GM0302_nunspeet/emissions.csv
+++ b/datasets/GM0302_nunspeet/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,12.75387
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38919
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.33988
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12801
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.87167
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.38755
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06301
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04909
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.48665
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.41591
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.67299
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.92507
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5813
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,26.3819
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.03064
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02808
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06415
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.55531
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.8176
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09153
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.73743
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00473
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.53281
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.69866
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.57204
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.48293
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08002
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,75.31565
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.74052
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02858
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.35259
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.07488

--- a/datasets/GM0303_dronten/emissions.csv
+++ b/datasets/GM0303_dronten/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.1539
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.33565
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.155
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.70007
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,93.5186
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.12294
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04901
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05813
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.00171
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00719
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00214
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00068
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.4838
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.62403
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,39.1541
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.90167
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.90601
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,2.48886
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.0844
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10265
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02035
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.84943
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.23439
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0628
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.45217
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0008
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.52381
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.04827
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56868
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.48009
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12006
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,107.14656
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06798
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.46853
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.73621
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.67604
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.19926
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.6839

--- a/datasets/GM0307_amersfoort/emissions.csv
+++ b/datasets/GM0307_amersfoort/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,10.84427
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04784
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.42452
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10535
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.37719
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,73.3625
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.44966
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.46194
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,89.70401
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.65111
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00107
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00205
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00254
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.95468
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.31863
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,149.98109
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.37483
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.376
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,2.98663
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,38.05485
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.58005
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00351
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.65334
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,537.10385
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,61.12966
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.7639
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09693
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.3673
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.55948
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.62213
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.6959
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00053
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.14949
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.89497
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.29496
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.93746
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.44609
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,190.9201
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.94017
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.26703
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.90685
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.96301
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,32.26397
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,59.84869

--- a/datasets/GM0308_baarn/emissions.csv
+++ b/datasets/GM0308_baarn/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.32883
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00497
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07329
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04454
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,8.43206
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.28453
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08664
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06105
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.06767
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01024
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.48716
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35872
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,38.37577
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.89528
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43538
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.29366
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03969
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01388
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.61775
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70526
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.46499
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.71914
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.53439
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.6026
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.57263
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.48343
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06902
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,61.31006
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62877
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7332
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.10688
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03644

--- a/datasets/GM0310_de_bilt/emissions.csv
+++ b/datasets/GM0310_de_bilt/emissions.csv
@@ -1,47 +1,47 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.84712
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06488
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.25007
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13458
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.40662
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,18.16953
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10903
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07582
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.06767
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01024
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00085
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.81081
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.73071
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,66.70722
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.52105
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.84068
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.2652
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.32595
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03052
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01137
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.92477
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.2612
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.19556
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.14045
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.55381
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.07779
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.95307
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.8046
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12344
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,92.92472
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.95904
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.15081
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.22119
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.73645
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.00331
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.3949

--- a/datasets/GM0312_bunnik/emissions.csv
+++ b/datasets/GM0312_bunnik/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.99035
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04404
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.19082
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1615
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,26.56543
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.65377
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04642
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0352
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.27102
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.23515
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,20.13247
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47866
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.33644
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.49332
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.50382
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03075
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0024
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.3092
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.46223
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0406
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.44741
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00027
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.85362
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.39501
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.31857
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.26894
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04524
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,67.90662
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60292
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82158
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.4884
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.61171
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.05765
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.51206

--- a/datasets/GM0313_bunschoten/emissions.csv
+++ b/datasets/GM0313_bunschoten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.8004
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02633
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07129
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.14406
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.64992
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.55006
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05186
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04421
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.50771
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03235
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.36107
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.33316
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.17332
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61897
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40344
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.37111
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08218
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05842
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.62909
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.65489
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05046
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.66969
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.13726
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.55966
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.42442
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.35831
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0641
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,19.73929
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25447
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20738
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.81643
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.68486
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.32488

--- a/datasets/GM0317_eemnes/emissions.csv
+++ b/datasets/GM0317_eemnes/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.72365
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0058
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09363
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13189
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,17.10433
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.0727
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01257
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01625
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00016
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00017
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.14846
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.15159
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,11.47397
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.26716
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20336
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.00096
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00388
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00143
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.1694
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.29812
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0162
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.26022
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.46762
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.25465
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.17451
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.14733
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02917
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,45.6947
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.36024
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79912
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.03987
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01204

--- a/datasets/GM0321_houten/emissions.csv
+++ b/datasets/GM0321_houten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.64904
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.89764
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.30856
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.20218
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,25.76249
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.64902
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06459
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08671
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,11.05267
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0842
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0008
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.49962
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.72815
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,34.36695
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85062
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79317
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.6989
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05235
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01417
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.58114
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.43849
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06731
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.45871
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.57365
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.22319
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.58728
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.49579
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14009
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,59.93074
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6091
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.85763
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.52434
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.90561
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.13895
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.60045

--- a/datasets/GM0327_leusden/emissions.csv
+++ b/datasets/GM0327_leusden/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.85813
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01593
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.44584
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13482
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,25.53156
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.52411
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06383
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05222
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00056
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.53222
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46058
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,36.48787
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.90286
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58169
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.24874
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00687
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01242
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.6068
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.90556
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06126
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.80131
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.67634
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.77372
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.6256
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.52815
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08861
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,63.73899
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.69402
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.67653
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.25783
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.1025

--- a/datasets/GM0331_lopik/emissions.csv
+++ b/datasets/GM0331_lopik/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.67022
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04327
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.64819
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.40589
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,77.21264
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.5032
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03338
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02677
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00025
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.24479
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.23059
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,18.35612
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4573
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.33715
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.5514
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01682
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00833
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.08834
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.45908
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0538
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.44865
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00098
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.77103
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.38736
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.28774
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.24292
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04436
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,26.93412
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29688
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38527
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.50583
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.62192
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.50643
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.48542

--- a/datasets/GM0335_montfoort/emissions.csv
+++ b/datasets/GM0335_montfoort/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.1796
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03213
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.37236
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.20569
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,42.79815
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.34398
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03238
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02521
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05075
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00768
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00025
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00022
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.24225
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.20087
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,17.00334
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42544
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28802
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.99077
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16173
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02058
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.42364
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.39491
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10232
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.38787
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.76302
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.33744
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.28475
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.2404
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03865
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,24.06264
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27538
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21422
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.47643
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.3697
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.4986
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.40022

--- a/datasets/GM0339_renswoude/emissions.csv
+++ b/datasets/GM0339_renswoude/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,29.36117
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17265
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20994
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06977
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.20043
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.63
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00989
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01237
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,8e-05
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,9e-05
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.07184
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.08593
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,5.49047
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13611
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12604
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.83081
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00695
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00485
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.16828
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.16889
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.01292
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.17741
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.22627
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.14436
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.08444
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.07129
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.01653
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,20.42732
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17276
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21691
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.13189
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.2959
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03349

--- a/datasets/GM0340_rhenen/emissions.csv
+++ b/datasets/GM0340_rhenen/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.62479
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09603
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20497
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08339
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,21.50482
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.1814
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03749
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02657
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.32803
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.29943
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.22528
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60695
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42463
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.97772
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.10952
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23389
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00814
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,29.88414
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.58849
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.22128
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.51303
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00089
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.03321
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.503
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.38559
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.32552
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05761
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,36.41363
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42431
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34092
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.66942
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.27536
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.83009
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.03561

--- a/datasets/GM0342_soest/emissions.csv
+++ b/datasets/GM0342_soest/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.01745
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00423
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09526
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05259
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.2442
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.5923
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11523
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08605
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.74959
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05509
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00085
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00074
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.80482
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.67984
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,63.84321
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.48075
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.83857
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,18.41755
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,20.2636
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1601
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03275
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.04003
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.33672
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.58539
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.18985
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0033
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.53493
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.14204
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.94602
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.79865
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1308
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,54.64292
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6918
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.59305
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.99326
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.64322
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.6823
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.6541

--- a/datasets/GM0344_utrecht/emissions.csv
+++ b/datasets/GM0344_utrecht/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.73417
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.8304
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.4306
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13361
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.8779
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,143.45884
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.91819
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.00937
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1264.26837
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.23836
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,3.15184
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00508
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00585
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,4.83279
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,5.34482
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,278.16006
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.49492
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.93542
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,7.96435
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.85574
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0006
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,6.19604
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,370.85742
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,79.49332
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.11741
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24051
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.87928
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,10.51847
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,32.27006
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,27.57585
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00152
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,15.22181
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,8.97854
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,5.6807
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,4.79578
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.02831
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,496.3429
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.97405
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.5644
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,53.433
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,17.98679
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,393.85244
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.57094

--- a/datasets/GM0345_veenendaal/emissions.csv
+++ b/datasets/GM0345_veenendaal/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.28593
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01565
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10656
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01259
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.70381
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,28.89726
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17512
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12662
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.23685
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03583
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00668
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00099
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00105
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.94605
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.9581
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,65.38194
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.57835
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.01535
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,3.90784
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00741
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,40.66011
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6382
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0881
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.20488
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.88271
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.45623
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.97317
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.97977
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.60948
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.11203
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.93881
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.18433
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,66.74934
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.77958
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62155
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.17425
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.10047

--- a/datasets/GM0351_woudenberg/emissions.csv
+++ b/datasets/GM0351_woudenberg/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,14.82551
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11284
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.31839
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.11524
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,33.11874
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.87991
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0296
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01963
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00023
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.19444
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.20778
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,13.97195
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34819
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.27751
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.43165
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00662
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00195
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.22181
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.40833
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03781
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.35278
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.61243
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.34905
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.22856
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.19295
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03998
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,49.51123
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4462
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39378
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.46444
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.85578
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.18674
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.88902

--- a/datasets/GM0352_wijk_bij_duurstede/emissions.csv
+++ b/datasets/GM0352_wijk_bij_duurstede/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.61736
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04092
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.24946
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19798
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,28.64688
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.37504
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02654
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02611
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40144
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34628
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,27.50194
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68463
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43168
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.91059
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01931
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00219
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.94389
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.68308
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05851
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.58764
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.26442
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.5817
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47187
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39837
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06662
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,34.29952
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40998
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23066
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.18914
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.98412
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.44377
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.74581

--- a/datasets/GM0353_ijsselstein/emissions.csv
+++ b/datasets/GM0353_ijsselstein/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.52336
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0213
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.16175
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08356
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,12.89506
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.30267
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04873
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07205
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.09305
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01408
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40405
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46915
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,27.21034
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.66529
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49617
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,12.88656
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18192
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01159
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.46113
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.92278
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09869
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.94623
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.27264
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.7881
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47494
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.40096
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09026
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,22.334
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29242
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29745
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.4156
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.50417
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.29044
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.86261

--- a/datasets/GM0355_zeist/emissions.csv
+++ b/datasets/GM0355_zeist/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.31782
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0033
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10266
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02431
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.13366
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,44.73752
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2702
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11721
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00588
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00122
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00105
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.1629
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.9631
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,84.67403
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.99926
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.11252
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.49777
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.27811
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.31612
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01354
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.32929
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.89276
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.53061
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.70997
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,9e-05
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.66277
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.61788
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.36693
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.15399
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.18529
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,96.86641
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.12859
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1599
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.96379
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.68528
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.83361
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.61894

--- a/datasets/GM0356_nieuwegein/emissions.csv
+++ b/datasets/GM0356_nieuwegein/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.46838
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3214
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1297
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01161
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.54564
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,29.63588
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17938
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15297
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,16.58799
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.19308
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00118
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00104
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.1217
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.94698
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,58.62042
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.6942
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.90216
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.02034
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.70295
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60991
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0514
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.30016
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.86836
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.01225
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.0949
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.53302
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.59079
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.3185
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.11311
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.18219
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,125.76699
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.22954
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.68335
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.16039
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.04364

--- a/datasets/GM0358_aalsmeer/emissions.csv
+++ b/datasets/GM0358_aalsmeer/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.86627
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.58873
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.06645
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02109
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.36517
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,29.60719
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17958
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0913
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.54154
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03747
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00048
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00052
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.45213
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.47483
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.70918
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85489
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62638
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.78077
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05095
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01093
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.51535
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.93306
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08989
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.99883
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.42406
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.79765
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.53145
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.44867
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09135
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,35.38024
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43169
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49153
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.58249
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.74326
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0699

--- a/datasets/GM0361_alkmaar/emissions.csv
+++ b/datasets/GM0361_alkmaar/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.22492
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28637
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.38799
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.39442
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,61.58455
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,59.50131
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.35895
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21499
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,35.87296
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.36555
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,13.46734
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,6e-05
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00207
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00413
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.97319
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.60469
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,145.28122
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.40112
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.76326
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.47995
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,17.78827
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22943
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13894
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.25043
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.14724
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.25603
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.17936
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0008
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.21496
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.68896
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.31939
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.95809
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.30797
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,147.95086
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.78387
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.72696
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.60215
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.05498
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.05666
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.53144

--- a/datasets/GM0362_amstelveen/emissions.csv
+++ b/datasets/GM0362_amstelveen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.06474
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.22889
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.04363
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07496
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.25865
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,45.83752
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27707
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23793
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.29778
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05198
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00143
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00151
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.3624
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.37835
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,108.49799
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.33625
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.38781
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.6312
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18838
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0271
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.58169
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.70828
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.21296
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.72001
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.29115
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.31543
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.60144
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.35197
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.26519
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,111.61701
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.2221
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.3671
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.20223
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.8041
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.02269
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.1845

--- a/datasets/GM0363_amsterdam/emissions.csv
+++ b/datasets/GM0363_amsterdam/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.80069
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50539
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.18082
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.24795
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,36.60235
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,589.42645
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.46467
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.63903
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1350.07058
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.02448
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,15.20116
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,11.7025
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.04152
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01466
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01457
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,14.13086
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,13.31177
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,938.67515
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.1902
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.13909
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.49332
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,28.17912
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,12.18611
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.95715
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.53552
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.04742
+Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.03976
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,353.15223
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.27474
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.14364
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,19.66709
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,26.22153
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,15.71474
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,31.09323
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,39.80325
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.09503
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00027
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,43.9066
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,22.36189
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,16.38572
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,13.83321
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,2.5611
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,939.61773
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.71007
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.49688
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.7519
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,25.86064
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,20.53356
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.75311

--- a/datasets/GM0373_bergen/emissions.csv
+++ b/datasets/GM0373_bergen/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.13397
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02249
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.2288
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21235
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,19.49888
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.44893
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05116
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03733
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.16918
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0256
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00088
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.03658
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.63089
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.50466
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,56.67235
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.29274
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69682
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.99554
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.5982
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0079
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00567
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.71932
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.87345
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.18931
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.85611
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00018
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.98712
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.74628
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.74158
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.62606
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08547
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,55.93215
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.67244
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4308
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.2949
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04564

--- a/datasets/GM0375_beverwijk/emissions.csv
+++ b/datasets/GM0375_beverwijk/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.00897
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05549
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.05789
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01158
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.80911
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.79831
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12408
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15143
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.11843
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01792
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00074
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00067
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.70559
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.6095
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,52.11772
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.21391
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6206
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.21421
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05654
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.37454
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.1365
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.19776
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.14513
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.34888
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00036
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.22238
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.02387
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,11.97138
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.00488
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,3.71997
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,45.71671
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54541
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.61217
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,7.41682
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.0799
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.93913
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.86266

--- a/datasets/GM0376_blaricum/emissions.csv
+++ b/datasets/GM0376_blaricum/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.01414
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02636
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01139
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.6043
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.60003
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02184
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01126
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.08459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00019
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.1919
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.17115
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,15.84098
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37189
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26503
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.91922
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01373
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00183
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.21878
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.33634
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.28156
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.28786
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.60442
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.28751
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.22557
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.19043
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03293
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,32.5446
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28893
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31263
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.02049
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.72058
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.711
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.85328

--- a/datasets/GM0377_bloemendaal/emissions.csv
+++ b/datasets/GM0377_bloemendaal/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.04181
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01209
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03004
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01498
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.99182
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.42856
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06078
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02481
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.74735
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.56696
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00048
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.4561
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34977
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.67755
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.87386
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49099
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.75644
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00268
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00245
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.52005
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.68737
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4.33507
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.53693
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.43656
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58756
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.53612
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4526
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06729
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,29.27185
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37764
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20633
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.20281
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0212

--- a/datasets/GM0383_castricum/emissions.csv
+++ b/datasets/GM0383_castricum/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.21901
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11337
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12993
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1137
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,16.98002
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.36343
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06195
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04043
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.39574
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.21117
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00064
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.61229
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.52429
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,50.38399
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.16113
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6991
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.8744
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01052
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00547
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.70012
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.03082
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.33354
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.27811
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.92854
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.88074
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.71972
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.60761
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10087
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,57.73151
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.63527
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.60901
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.12892
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03482

--- a/datasets/GM0384_diemen/emissions.csv
+++ b/datasets/GM0384_diemen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.00024
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9e-05
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00886
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00485
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.56282
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.3823
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11756
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08363
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,383.98091
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.43344
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,9.05656
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.36636
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46557
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.8789
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56816
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44235
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.79293
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24656
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01637
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.41988
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.91979
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07523
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.1939
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.15394
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.78209
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.43064
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.36356
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08957
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,60.91909
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.536
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.87243
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.05627
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.10235

--- a/datasets/GM0385_edam_volendam/emissions.csv
+++ b/datasets/GM0385_edam_volendam/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.37332
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02543
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20861
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.27192
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,41.05664
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.45899
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0695
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0664
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00063
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00058
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.59527
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.52819
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,46.94595
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.10409
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.66301
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.85639
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06765
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07044
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.67991
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.03833
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09257
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.97363
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.87493
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.88728
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.69971
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.59071
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10162
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,51.55005
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60146
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43812
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.21626
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13422
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.42399
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.37503

--- a/datasets/GM0388_enkhuizen/emissions.csv
+++ b/datasets/GM0388_enkhuizen/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.16393
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12198
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00024
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01765
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.15742
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.72791
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05294
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02961
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.31323
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.27369
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,26.77567
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60379
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32859
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.97772
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.9963
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02731
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01582
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.35806
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.54065
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04505
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.4826
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00089
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.98657
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.45976
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.36818
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.31083
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05266
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,18.33754
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23582
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19359
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0613
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06316

--- a/datasets/GM0392_haarlem/emissions.csv
+++ b/datasets/GM0392_haarlem/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.06015
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11212
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.04567
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02063
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.87975
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,86.93874
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.52351
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3067
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,15.18463
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.20407
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00306
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00263
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.91237
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.40391
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,221.59545
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.01137
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.34062
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,10.45321
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,26.92426
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.50577
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0584
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,3.36249
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.72382
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.46851
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.37017
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00187
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,9.17309
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,4.03823
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.42335
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.89007
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.4625
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,149.86209
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.98203
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.10336
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,10.94414
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.07367
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,7.74801
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.50725

--- a/datasets/GM0394_haarlemmermeer/emissions.csv
+++ b/datasets/GM0394_haarlemmermeer/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.50675
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.63369
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.43467
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34508
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.305
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,114.30628
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.69154
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69613
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,57.57977
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.48273
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00481
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00208
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00258
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.11673
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.35505
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,145.9488
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.48507
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.67722
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,4.96717
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,79.61023
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.77935
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18947
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,3.31365
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.63153
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.77249
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,6.81646
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00116
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.24114
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.95614
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.32916
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.96633
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.4531
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,511.11371
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.44402
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.59728
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.30508
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.75199
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,6.49439
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,11.10625

--- a/datasets/GM0396_heemskerk/emissions.csv
+++ b/datasets/GM0396_heemskerk/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.62697
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.12188
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09268
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01864
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.22218
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.84712
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05955
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03518
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.27069
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04095
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00107
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00067
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.63248
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.57062
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,46.14282
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.08679
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5998
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.9542
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0114
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01284
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.72094
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.12129
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.51161
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.65793
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.99211
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.95855
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.74345
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.62763
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10978
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,55.65654
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60214
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42629
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.03326
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06677

--- a/datasets/GM0397_heemstede/emissions.csv
+++ b/datasets/GM0397_heemstede/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.20051
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04642
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01829
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00503
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.67691
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.96822
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07856
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0332
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05075
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00768
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00054
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.51153
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.38169
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,38.44708
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.90707
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4492
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.58156
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02721
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0101
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.58322
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.75015
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.33612
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.61819
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.61118
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.64118
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.60128
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.50762
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07343
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,24.95038
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33899
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2207
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.42912
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.44016
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.9287
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.65581

--- a/datasets/GM0399_heiloo/emissions.csv
+++ b/datasets/GM0399_heiloo/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.20986
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4171
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.05428
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04636
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.22698
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.25079
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04342
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02686
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,17.02911
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.12222
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40284
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.36009
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,34.88227
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.80065
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47922
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.88894
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09029
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00388
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.77863
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70797
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05509
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.56182
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0016
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.26883
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.60489
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47352
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39976
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06928
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,48.23489
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.46645
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40084
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.16541
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.04514
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.09078
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.18813

--- a/datasets/GM0400_den_helder/emissions.csv
+++ b/datasets/GM0400_den_helder/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.09415
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01077
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07388
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02712
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.36235
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.60083
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15517
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06382
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,5.75424
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.35342
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00127
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00089
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.20937
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.81611
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,91.39696
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.10956
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94693
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.03119
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18949
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01373
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.37877
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.60498
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.24285
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.41856
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.80915
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.37094
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.42155
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.20011
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15701
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,65.9125
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.8719
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.51571
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.11846
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.78379
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.11767
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.24251

--- a/datasets/GM0402_hilversum/emissions.csv
+++ b/datasets/GM0402_hilversum/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.30113
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0065
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07778
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0211
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.85988
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,59.16793
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.35646
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26323
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,43.25973
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.33729
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00173
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00149
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.64522
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.36216
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,135.31645
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.9941
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.42832
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,5.25246
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2276.29728
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,48.04709
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06856
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09458
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.89232
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.67864
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.76898
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.16314
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.18195
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.28824
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.93388
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.63263
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.26207
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,117.91987
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.34272
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09733
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.37923
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.84692
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.19992
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.45271

--- a/datasets/GM0405_hoorn/emissions.csv
+++ b/datasets/GM0405_hoorn/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.51574
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45376
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.05308
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00613
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.49613
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,28.06611
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10514
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.40946
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.07581
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00641
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00118
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00117
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.127
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.06646
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,82.45042
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.93296
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.18548
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,7.96435
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,12.57047
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05905
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06596
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.29084
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.09745
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.43044
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.9374
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00143
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.54972
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.7915
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.32474
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.11838
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.20518
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,50.10545
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70482
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64014
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05447
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.19269
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.20605

--- a/datasets/GM0406_huizen/emissions.csv
+++ b/datasets/GM0406_huizen/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0026
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03042
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00176
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.36405
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,16.17217
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09809
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0637
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00087
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.8262
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.60274
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,57.72736
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.41387
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.67075
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.07816
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.05695
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11124
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00787
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.94189
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.18529
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0963
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.05619
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.60229
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.01252
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.97116
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.81988
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.11596
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,43.86543
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56388
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42967
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.04884
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.6265
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.2482
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.14822

--- a/datasets/GM0415_landsmeer/emissions.csv
+++ b/datasets/GM0415_landsmeer/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.00419
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00466
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03275
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08709
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.65747
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.06687
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01254
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01318
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00022
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.20999
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.18167
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,16.98091
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39661
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23179
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.2794
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00488
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00251
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.23946
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.35712
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02665
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.28181
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.66141
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.30517
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.24684
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.20839
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03495
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,17.82117
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18752
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1003
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.05821
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01846

--- a/datasets/GM0417_laren/emissions.csv
+++ b/datasets/GM0417_laren/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0014
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01093
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00054
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.26454
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.34423
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03242
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02242
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00107
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00023
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00018
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.22117
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.16646
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,20.10322
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.45099
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26245
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.70806
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00487
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00173
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.25209
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.32713
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02276
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.30186
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.6966
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.27964
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.25997
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.21947
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03203
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,46.48348
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39946
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.56306
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.03951
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.00429

--- a/datasets/GM0420_medemblik/emissions.csv
+++ b/datasets/GM0420_medemblik/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.8332
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.38759
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.31736
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34185
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,57.39001
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.43557
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07487
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07643
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.93049
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.14078
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00075
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.71796
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.66409
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,60.94294
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.43435
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.07468
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,40.37547
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25461
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06705
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.81864
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.30602
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.883
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.39905
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.26137
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.11557
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.84393
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.71247
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12777
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,74.9786
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81536
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09654
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.38126
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,11.66973
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.02533
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.101

--- a/datasets/GM0431_oostzaan/emissions.csv
+++ b/datasets/GM0431_oostzaan/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.02306
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00023
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02199
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02954
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.99679
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.92803
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01776
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01347
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00015
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.14095
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.18166
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,13.2077
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27262
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22305
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.95024
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02803
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0069
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.16074
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.35698
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05321
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.32638
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.44395
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.30516
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.16568
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.13987
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03495
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,6.12291
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08434
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42332
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0801
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.02031

--- a/datasets/GM0432_opmeer/emissions.csv
+++ b/datasets/GM0432_opmeer/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.98806
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.94591
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.28243
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16511
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,34.22005
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.79359
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02301
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01919
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00214
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00019
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.19712
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.1775
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,16.29408
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.38998
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28295
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.14462
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06969
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0141
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.25346
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.34889
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02907
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.31417
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.62086
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.29818
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.2317
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.19561
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03415
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,17.56109
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19914
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18578
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.20395
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04041

--- a/datasets/GM0437_ouder_amstel/emissions.csv
+++ b/datasets/GM0437_ouder_amstel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.05648
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04209
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00676
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0911
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,17.12564
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.10296
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03702
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0902
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00024
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00024
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.22522
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.22162
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,17.40095
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.38726
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26546
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.06754
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0347
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01219
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.30423
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.43598
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03713
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.65547
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.70937
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.37228
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.26473
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.22349
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04264
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,106.25792
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.80715
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.29449
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01133
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.25251
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04416

--- a/datasets/GM0439_purmerend/emissions.csv
+++ b/datasets/GM0439_purmerend/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.67934
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53867
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.60435
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.37778
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,57.24375
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.70343
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14963
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10147
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,100.75501
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.7479
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00962
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00729
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00137
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.29889
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.30541
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.85869
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,65.02289
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.02374
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.34514
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.00133
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03153
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05548
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.51036
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.6755
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.88106
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.25686
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.11165
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.28609
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.53445
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.29542
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.26182
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,113.58644
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.25437
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.46137
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.83603
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.26419
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.16632
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.02641

--- a/datasets/GM0441_schagen/emissions.csv
+++ b/datasets/GM0441_schagen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.39069
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.66371
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.06149
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.46126
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,61.57843
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,16.92659
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10243
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07486
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.38066
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05759
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00085
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00075
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.80416
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.68917
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,67.97081
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.60233
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02129
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.62488
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.46897
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05137
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.36846
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.35517
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.44379
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.31701
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.53284
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.1577
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.94524
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.798
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13259
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,88.67983
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.99697
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.85372
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.37701
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.59124
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.34603
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.05622

--- a/datasets/GM0448_texel/emissions.csv
+++ b/datasets/GM0448_texel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.13573
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02781
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.8701
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.37642
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,43.04289
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.81002
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0352
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02808
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,33.0796
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.17772
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00022
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.24742
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.19817
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.61723
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5519
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31991
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.66793
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02786
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00553
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.28201
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.39034
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08978
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.43551
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.77929
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.33289
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.29083
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.24552
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03813
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,25.81263
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27074
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2704
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.63626
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.68177
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.65438
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.55269

--- a/datasets/GM0450_uitgeest/emissions.csv
+++ b/datasets/GM0450_uitgeest/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.12109
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01933
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07279
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08316
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.07431
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.96274
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01797
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01918
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00023
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.19626
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.20992
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,16.89107
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37388
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25842
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.25431
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03223
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00245
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.22411
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.41294
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02871
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.35903
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.61815
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.35263
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.23069
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.19475
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04039
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,53.08974
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.45463
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.46241
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.06858
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.02339

--- a/datasets/GM0451_uithoorn/emissions.csv
+++ b/datasets/GM0451_uithoorn/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.80459
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.29469
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03142
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03211
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.41891
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.62073
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07005
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04872
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.42489
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.44544
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.80705
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.76636
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50563
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.03116
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00632
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,23.9683
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00781
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05643
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.50966
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.87539
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10993
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.79109
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.33827
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.74827
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49943
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.42163
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0857
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,32.92938
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40365
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22622
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.36134
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.36242
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.2391
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.9047

--- a/datasets/GM0453_velsen/emissions.csv
+++ b/datasets/GM0453_velsen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0115
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00626
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.06113
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02325
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.13998
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,52.09022
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.40684
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18871
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4494.31905
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.85809
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,6.26357
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0012
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00337
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.14564
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.70122
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,90.42312
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.00721
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.07025
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,21 +43,21 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0391
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.65676
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6386.81895
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.93425
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.38707
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,34.9379
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.96221
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.35939
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,5.15641
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.60841
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.67503
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.34664
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.13686
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.19184
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,112.58008
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.16463
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.20539
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.52218
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.27732
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.881
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.26224

--- a/datasets/GM0473_zandvoort/emissions.csv
+++ b/datasets/GM0473_zandvoort/emissions.csv
@@ -2,40 +2,40 @@ etm_sector,etm_subsector,use,ghg,year,unit,value
 Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01224
 Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.22878
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.10829
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03081
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02159
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.3032
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.25418
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.14194
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54913
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29543
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.6454
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18052
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00139
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.34575
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.49953
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03724
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.40425
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.955
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.42699
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.3564
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.30088
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0489
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,16.83501
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22457
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12726
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.58388
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.98439
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01091

--- a/datasets/GM0479_zaanstad/emissions.csv
+++ b/datasets/GM0479_zaanstad/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.2386
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02705
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1073
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1766
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,30.58286
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,70.27829
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42567
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38174
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,38.30981
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.56157
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00268
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00248
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.55309
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.2617
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,186.47052
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.42407
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.43165
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.97326
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00325
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.3365
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,186.01256
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.29593
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31162
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.94367
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.44858
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.80674
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,51.28825
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00107
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,8.04145
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.79934
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.00103
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.53354
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.43514
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,144.08194
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.85687
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.92752
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.12318
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,23.90116
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.73873
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,167.50086

--- a/datasets/GM0482_alblasserdam/emissions.csv
+++ b/datasets/GM0482_alblasserdam/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.1157
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00066
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03044
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01519
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.80508
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.7623
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04102
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03467
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00454
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.33737
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.28904
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.17905
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58127
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.30974
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,153.87358
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.80428
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00582
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,53.16663
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.57098
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05914
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.54143
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0642
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.06263
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.48555
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.39657
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.33479
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05561
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,28.33351
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30789
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39041
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.79228
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.97071
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.57294
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.93186

--- a/datasets/GM0484_alphen_aan_den_rijn/emissions.csv
+++ b/datasets/GM0484_alphen_aan_den_rijn/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.67448
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62784
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.70243
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.44403
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,76.59913
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,46.72283
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28241
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17699
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,10.76329
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.1126
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00196
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00332
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.86012
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.11739
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,129.77486
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.15855
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.88827
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,2.79789
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,3.15143
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,40.82984
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.38824
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08918
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,30.40071
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.24106
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.1728
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.36186
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00205
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.85882
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.76839
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.18648
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.84588
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.31706
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,164.39635
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.94313
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.6537
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.27183
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.10591
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.2019
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.9751

--- a/datasets/GM0489_barendrecht/emissions.csv
+++ b/datasets/GM0489_barendrecht/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.58878
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.68599
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02609
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00436
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.45711
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.59491
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07639
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11218
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00668
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00079
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.39779
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.7175
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,31.29722
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.72248
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.75353
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.27296
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.30745
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.98131
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0174
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0306
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.45542
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.41557
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09118
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.04748
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.25292
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.2053
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.46758
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39474
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13804
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,68.50428
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60239
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.49916
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.18172
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.07166
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.23351

--- a/datasets/GM0498_drechterland/emissions.csv
+++ b/datasets/GM0498_drechterland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,6.4211
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.60454
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.08463
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19024
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.33221
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.70729
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04675
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02575
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.29846
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.31139
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,26.83878
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6186
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50148
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.62925
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04031
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00486
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.34409
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.6127
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05276
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.52678
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.94005
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.52308
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.35082
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.29617
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05991
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,34.71837
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.392
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34026
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.37366
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0432

--- a/datasets/GM0502_capelle_aan_den_ijssel/emissions.csv
+++ b/datasets/GM0502_capelle_aan_den_ijssel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.03231
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11152
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01881
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00106
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.21603
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,21.27353
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12488
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14654
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,7.02045
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0516
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0012
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00105
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.13671
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.95849
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,71.06737
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.78022
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.89916
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.82276
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0411
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04515
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.31191
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.88384
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.01256
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.84334
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.5803
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.61013
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.33615
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.12801
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.18441
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,56.40581
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.75174
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74436
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,9.71559
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.43166
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,8.79907
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,8.61275

--- a/datasets/GM0503_delft/emissions.csv
+++ b/datasets/GM0503_delft/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.59351
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42296
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15635
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00837
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.23443
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,60.90607
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.36942
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17923
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,154.50682
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.09688
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0692
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00185
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00167
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.75712
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.52871
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,121.77
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.81635
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.4258
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,19.91087
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,116.48568
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,1.45339
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.19696
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.77315
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,36.21303
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85107
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14142
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.1101
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.00573
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.71
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.78987
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00357
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.5344
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.56801
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.06541
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.74367
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.29411
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,141.40228
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.51894
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.41155
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.97089
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.11196

--- a/datasets/GM0505_dordrecht/emissions.csv
+++ b/datasets/GM0505_dordrecht/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.66611
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00092
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02576
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06954
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.36594
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,66.69624
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40454
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2205
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,283.1832
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.45496
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,9.95937
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00224
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00194
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.12953
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.77317
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,159.55908
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.64214
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.79027
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.47549
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.64362
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,78.57901
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,166.41232
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.92314
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,31.1454
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,3.57579
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.52207
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.51743
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.51907
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00223
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.70738
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.97868
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.50316
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.11323
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.34115
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,204.09296
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.14047
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.46447
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,7.19769
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.2127
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.7486
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.21996

--- a/datasets/GM0512_gorinchem/emissions.csv
+++ b/datasets/GM0512_gorinchem/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.04354
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00261
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.08948
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03758
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.22921
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.76537
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12595
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07499
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,21.10363
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.16121
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00059
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00061
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.56056
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.55916
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.91908
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.96219
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.59923
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.7038
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02944
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,31.44361
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24105
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03988
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.6681
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.10785
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.41149
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.08764
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00107
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.76561
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.93931
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.65892
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.55627
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10758
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,67.89825
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.64047
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.21625
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.17823
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.53277
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.35086
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.55047

--- a/datasets/GM0513_gouda/emissions.csv
+++ b/datasets/GM0513_gouda/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.59857
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00999
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00564
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00737
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.90308
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,42.83279
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2586
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12241
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.13706
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02767
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00135
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00115
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.28746
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.04811
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,89.07551
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.11824
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.04563
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,1.35321
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.09366
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.38299
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,113.21275
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.88189
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01841
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.37784
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,9.94335
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.01794
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.16785
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00642
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.05511
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.76068
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.51335
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.2776
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.20165
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,60.10781
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.82563
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5179
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.64326
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.64106
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.19789
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.8558

--- a/datasets/GM0518_s_gravenhage/emissions.csv
+++ b/datasets/GM0518_s_gravenhage/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.81355
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.40967
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.11538
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00823
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.15961
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,281.97676
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.70451
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.11599
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,388.0768
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.69198
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.55026
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00926
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01645
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,8.80283
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,10.42965
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,568.42691
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,13.51859
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.61288
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.58623
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,53.61003
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.91869
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25394
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,12.84815
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,15.88118
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,8.69232
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,16.93246
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00036
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,27.72623
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,13.57772
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,10.34729
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,8.73542
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.55505
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,472.06809
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.95093
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.73655
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,30.99234
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.07226
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,32.22656
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.98925

--- a/datasets/GM0523_hardinxveld_giessendam/emissions.csv
+++ b/datasets/GM0523_hardinxveld_giessendam/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.01939
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00745
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.06271
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0581
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.02338
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.38571
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0448
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03262
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.32964
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.26996
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.14279
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61188
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34671
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,23.97519
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25683
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02393
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.42098
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.53795
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07874
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.60461
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.03827
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.45349
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.38748
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.32712
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05194
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,51.00593
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.45243
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.92571
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.39086
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.3771
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.90354
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.4161

--- a/datasets/GM0531_hendrik_ido_ambacht/emissions.csv
+++ b/datasets/GM0531_hendrik_ido_ambacht/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.86399
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.18983
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01973
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00203
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.18344
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.4007
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04489
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0369
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.38053
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46984
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.21591
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.67396
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47911
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.01731
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02142
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01007
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.4452
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.93008
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08686
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.77839
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.19856
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.78927
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.44729
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.37762
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0904
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,41.53165
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40408
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55003
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03632
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.03824
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03131

--- a/datasets/GM0532_stede_broec/emissions.csv
+++ b/datasets/GM0532_stede_broec/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.17372
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.65119
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00132
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01574
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.37505
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.57944
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02778
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02069
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.37202
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.31881
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.46096
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.71256
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43142
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.30108
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00432
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00255
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.42434
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.6266
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04099
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.48602
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.17175
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.53555
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.43729
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.36917
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06134
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,20.68602
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.26887
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18268
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.1112
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.02073

--- a/datasets/GM0534_hillegom/emissions.csv
+++ b/datasets/GM0534_hillegom/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.26705
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48302
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02602
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01362
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.62074
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.01999
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06078
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03057
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00041
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.38806
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.32701
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.56206
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68938
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37322
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.99155
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0291
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01608
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.44248
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.6427
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04832
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.78375
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.22228
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.54933
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.45615
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.38509
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06291
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,18.89924
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25262
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18128
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.05536
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03539

--- a/datasets/GM0537_katwijk/emissions.csv
+++ b/datasets/GM0537_katwijk/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.25785
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.84165
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.06529
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02625
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.0714
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.25044
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14693
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09154
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.27915
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04223
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00118
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00104
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.12103
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.9513
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,70.86374
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.81809
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.95825
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.97772
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.93744
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09277
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03262
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.28004
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.86942
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.40539
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.79764
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00089
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.53091
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.59805
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.31772
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.11245
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.18302
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,63.30781
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83157
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48955
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.30342
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.37952
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.01488
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.87746

--- a/datasets/GM0542_krimpen_aan_den_ijssel/emissions.csv
+++ b/datasets/GM0542_krimpen_aan_den_ijssel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.01688
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00118
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01276
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00201
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.18734
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.21208
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06194
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03544
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.54152
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.41817
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.0375
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.91265
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43628
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.34358
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02885
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0165
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.61776
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.82378
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.14104
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.77999
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.70564
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.70247
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.63654
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.53738
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08045
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,25.91772
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.35589
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20895
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07263
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.08942
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.08602

--- a/datasets/GM0546_leiden/emissions.csv
+++ b/datasets/GM0546_leiden/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.11206
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02299
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.06448
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01508
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.37502
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,66.72031
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40172
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20548
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,125.20684
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.62371
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00228
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00201
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.17106
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.83608
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,140.80553
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.47123
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.70988
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,2.48886
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,4.27
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0026
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,28.24946
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.32585
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03149
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.50173
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.60812
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4.36199
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.34553
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00241
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.83819
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.08436
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.55198
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.15444
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.35325
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,140.03553
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.64733
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.67312
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,7.18772
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.73209
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,6.45548
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.88529

--- a/datasets/GM0547_leiderdorp/emissions.csv
+++ b/datasets/GM0547_leiderdorp/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0855
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00321
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09187
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03309
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.46294
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.47034
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06957
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03592
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.42641
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.40785
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.47144
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70443
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40856
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,2.98663
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.32157
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0485
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01194
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.48603
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.80147
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.47989
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68797
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00053
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.34307
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.68513
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.50123
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.42315
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07847
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,40.77051
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43072
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.59934
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.18571
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.39833
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.02355

--- a/datasets/GM0553_lisse/emissions.csv
+++ b/datasets/GM0553_lisse/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.22351
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11954
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03034
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02046
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.39568
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.9389
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07242
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03486
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,7.06639
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41236
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.32751
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.06128
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.7082
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36133
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.28083
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0552
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00877
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.47016
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.64376
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07559
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.59073
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.2988
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.55018
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.4847
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4092
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06301
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,20.14447
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.26865
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22861
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.11494
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.47516
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.86211
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.57524

--- a/datasets/GM0556_maassluis/emissions.csv
+++ b/datasets/GM0556_maassluis/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.24723
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4773
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.04612
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00653
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.68944
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.529
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0578
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0331
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.05247
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01487
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.69535
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.50349
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,40.83746
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06923
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49582
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,19.96362
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22548
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00875
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.99946
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.99169
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11728
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.86962
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.19014
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.8458
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.81735
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.69003
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09687
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,30.51024
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42672
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19207
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.08749
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0174

--- a/datasets/GM0569_nieuwkoop/emissions.csv
+++ b/datasets/GM0569_nieuwkoop/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.60006
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.58632
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.5289
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.29571
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,54.98133
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.47841
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05143
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03821
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00267
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.52263
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.42693
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,38.27528
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.94916
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6115
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.59072
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04133
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01853
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.63599
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.83906
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11984
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.72307
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.64611
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.71718
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.61432
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.51862
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08214
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,40.45553
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4761
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41192
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.57833
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.66655
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.27458
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.68687

--- a/datasets/GM0575_noordwijk/emissions.csv
+++ b/datasets/GM0575_noordwijk/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.43386
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.55952
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09819
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04279
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.29594
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.09666
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12117
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07298
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0423
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0064
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00081
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00072
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.77346
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.66168
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,56.60799
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.35576
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.76951
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.85287
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01422
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03141
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.88156
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.3001
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10162
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.32102
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.43616
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.11153
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.90916
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.76754
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1273
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,59.38402
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.72856
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57007
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.42789
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.24917
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.09612
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.11358

--- a/datasets/GM0579_oegstgeest/emissions.csv
+++ b/datasets/GM0579_oegstgeest/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.12237
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20803
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.04121
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0049
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.91679
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.04317
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04272
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02719
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.3618
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.36849
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,27.33078
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.63389
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38949
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.6762
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00833
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00199
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.41238
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.724
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03879
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.56922
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.13956
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.61901
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.42528
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.35903
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07089
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,29.67147
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.31456
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38395
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.04603
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01704

--- a/datasets/GM0589_oudewater/emissions.csv
+++ b/datasets/GM0589_oudewater/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.35715
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14256
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15311
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21127
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,48.95722
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.98308
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01809
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0166
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00019
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00016
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.18515
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.14726
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,13.73312
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33327
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.203
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.23044
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00447
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00384
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.21529
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.28998
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02451
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.26818
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.58315
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.24738
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.21763
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.18373
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02833
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,15.35451
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17123
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10898
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.38383
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.32389
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.37212
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.30861

--- a/datasets/GM0590_papendrecht/emissions.csv
+++ b/datasets/GM0590_papendrecht/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.07236
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01978
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00779
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.62471
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.4629
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08166
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05135
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.1861
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02816
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00056
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.5332
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.4569
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.63402
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.89879
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47979
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.76932
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02985
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01553
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.68739
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.90335
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11837
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.8205
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.67941
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.76753
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.62675
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.52911
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08791
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,50.3334
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5303
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.70705
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.83636
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.92241
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.776
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.94819

--- a/datasets/GM0597_ridderkerk/emissions.csv
+++ b/datasets/GM0597_ridderkerk/emissions.csv
@@ -1,46 +1,46 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.07271
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.36102
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02487
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00859
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.00093
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.46885
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11781
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08177
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.52446
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.07935
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00092
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00077
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.04738
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.69898
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,62.8596
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.47133
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74146
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,6.47103
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,6.4281
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,31.89302
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.35469
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0348
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.17162
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.38026
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.56013
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.44789
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00116
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.74773
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.17419
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.02544
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.8657
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13448
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,101.62729
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.98496
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.77105
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.66074
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.52872
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.19205
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.71221

--- a/datasets/GM0599_rotterdam/emissions.csv
+++ b/datasets/GM0599_rotterdam/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.32533
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.5631
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.24108
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05725
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.98801
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,345.78217
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.213
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.57605
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,8210.62051
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,30.98965
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,27.80589
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,3.88083
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.02567
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.1082
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01228
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.58168
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,11.76422
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,11.27567
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,717.26997
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,17.95521
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.97044
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,3.98217
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,65.57129
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,5.9255
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,26.63622
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,5.44084
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,12.37703
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3153.7041
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.12654
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.49563
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,30.07245
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,18.96494
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,12.84284
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,44.01753
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,9004.85044
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,32.22182
+Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,88.04124
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.20694
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00357
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,36.77812
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,16.1208
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,13.72541
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,11.58731
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,12.34141
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1064.16794
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,9.76374
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.71678
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,12.97312
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.01297
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,17.8091
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,21.5957

--- a/datasets/GM0603_rijswijk/emissions.csv
+++ b/datasets/GM0603_rijswijk/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.09236
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49776
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03307
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00125
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.13727
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,48.5833
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29468
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13669
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.06767
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01024
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00099
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00095
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.93968
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.87098
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,65.49791
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.47254
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.83263
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,21.90196
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.36102
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25174
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01505
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.08321
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.71134
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.22926
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.69334
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00392
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.95971
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.46312
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.10455
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.93249
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16757
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,50.0876
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.63392
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.92812
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.17695
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.12192

--- a/datasets/GM0606_schiedam/emissions.csv
+++ b/datasets/GM0606_schiedam/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.19259
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00056
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03291
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00802
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.21676
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,41.38719
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25103
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17942
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.12356
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03948
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0334
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00141
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00128
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.34509
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.16646
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,94.09814
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.13448
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.10393
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,6.9688
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,18.68947
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24059
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05799
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,95.4496
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.29552
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.09126
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.40402
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00125
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.23663
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.95948
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.58109
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.33479
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.22442
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,105.05541
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.13049
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.46475
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,10.54
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05447
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.13544
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.10567

--- a/datasets/GM0610_sliedrecht/emissions.csv
+++ b/datasets/GM0610_sliedrecht/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.01957
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00166
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00911
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03928
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.59031
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.05817
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0792
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05125
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00041
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.45009
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.37287
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.549
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79749
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40253
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.02638
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04383
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01935
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.51798
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.7363
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.16434
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.82172
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.41766
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.62637
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.52906
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.44665
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07174
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,40.75581
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42075
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.66101
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.2093
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.4709
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.986
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.22018

--- a/datasets/GM0613_albrandswaard/emissions.csv
+++ b/datasets/GM0613_albrandswaard/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.42432
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94309
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01262
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02462
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.60214
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.45595
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02703
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04966
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.27393
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.37954
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,22.46567
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51526
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49313
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.22753
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00374
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00688
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.31899
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.75254
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03505
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,5.55332
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.8628
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.63757
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.32199
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.27183
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07302
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,26.97135
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.31272
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29797
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.07534
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.09092

--- a/datasets/GM0622_vlaardingen/emissions.csv
+++ b/datasets/GM0622_vlaardingen/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.02411
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1e-05
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03509
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01203
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.00994
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,32.18787
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19178
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08489
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.1861
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02816
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00156
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00118
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.4843
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.07944
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,96.93281
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.3269
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02895
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,10.45321
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,2.21784
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02608
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2.49807
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.12244
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,76.40327
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27972
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04061
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.84662
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.12622
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.9242
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.95054
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00187
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.67509
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.8133
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.74472
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.47293
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.20768
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,105.25925
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06269
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7704
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.9537
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.12062
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.47795
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.8967

--- a/datasets/GM0626_voorschoten/emissions.csv
+++ b/datasets/GM0626_voorschoten/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.27098
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32821
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03581
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02574
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.61139
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.82523
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03533
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02441
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.44005
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35638
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,31.78484
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.75412
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37945
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.15403
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02084
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00208
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.63333
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70063
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05934
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.54778
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.38603
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59866
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.51726
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43668
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06856
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,21.39906
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28727
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17685
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01067
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.09369
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.02683

--- a/datasets/GM0627_waddinxveen/emissions.csv
+++ b/datasets/GM0627_waddinxveen/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.60214
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.91703
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09203
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05113
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.13782
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.63574
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07656
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0556
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.05183
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00054
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.50461
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.49575
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,34.88454
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84719
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54024
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,20.90641
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.48492
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14883
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03694
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.96824
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.97428
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.47265
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.99828
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00544
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.58936
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.83278
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.59314
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.50074
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09538
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,87.11881
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79948
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0671
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.95271
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.75531
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.2159
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.723

--- a/datasets/GM0629_wassenaar/emissions.csv
+++ b/datasets/GM0629_wassenaar/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.1009
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21533
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09884
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05186
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.18561
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.16345
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05558
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03022
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.08459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.47952
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.42154
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,45.14679
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.94456
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54338
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.26696
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01869
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00243
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.54652
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.82818
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0586
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.65023
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.51034
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.70812
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56365
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.47585
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0811
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,33.52559
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39891
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48661
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.1233
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01364

--- a/datasets/GM0632_woerden/emissions.csv
+++ b/datasets/GM0632_woerden/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.07508
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.93457
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.48726
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.44814
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,88.00379
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,28.09145
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16558
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10051
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.08298
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04027
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00087
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00086
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.82978
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.7835
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,58.94258
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.43755
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94068
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.14754
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,63.94093
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.11512
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12903
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02615
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.00793
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,11.3655
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.80713
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.75988
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.61355
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.31616
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.97536
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.82342
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15074
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,150.09198
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.32563
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.19688
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.8633
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.55825
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.71162
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.68251

--- a/datasets/GM0637_zoetermeer/emissions.csv
+++ b/datasets/GM0637_zoetermeer/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.23056
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.16658
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1106
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02622
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.37832
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,49.63615
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30107
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19961
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.39757
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.06015
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00202
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00199
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.91946
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.82066
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,120.15913
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.99113
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.75119
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.47549
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.54714
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,32.22682
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12496
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06608
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.03368
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.58074
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.11585
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,7.35307
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00098
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,6.04573
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.05845
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.25623
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.90477
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.35028
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,131.00003
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.55739
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.5934
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05447
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.16267
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.51077

--- a/datasets/GM0638_zoeterwoude/emissions.csv
+++ b/datasets/GM0638_zoeterwoude/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.4391
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01671
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1386
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.09511
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,21.6157
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.62835
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05234
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03412
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.08603
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00018
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00015
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.16672
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.13273
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,11.48086
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29048
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17021
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,85.80666
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.95929
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09422
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.20054
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.26088
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04497
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.33801
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.52512
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.22297
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.19597
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.16544
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02554
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,18.26407
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.20754
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28271
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.50967
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01507

--- a/datasets/GM0642_zwijndrecht/emissions.csv
+++ b/datasets/GM0642_zwijndrecht/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.36924
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.32778
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03772
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01992
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.35873
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,22.58388
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13698
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07557
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00093
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.88896
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.64963
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,60.03473
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.46982
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.68932
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.03739
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,99.27583
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.7053
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17113
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.08495
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.2847
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.52548
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.20423
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.79995
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.09129
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.04493
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.88215
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12498
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,73.23047
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79128
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.71103
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.65413
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.07099
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.73622

--- a/datasets/GM0654_borsele/emissions.csv
+++ b/datasets/GM0654_borsele/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,11.39735
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08232
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.14145
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.29001
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,20.68333
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.35929
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17441
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04694
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2470.27207
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,10.11743
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.39683
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.32968
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.77574
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.82068
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57854
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.82107
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02112
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13902
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.46762
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.65614
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09047
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,14.42999
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,9 +66,9 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,826.4524
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,3.50748
+Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.01533
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.24989
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.55382
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.46645
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39379
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06343
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,41.50907
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.462
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82784
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,61.77063
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.7892
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,672.60251
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,54.24406

--- a/datasets/GM0664_goes/emissions.csv
+++ b/datasets/GM0664_goes/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.75342
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07211
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07391
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21279
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,11.35489
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.44664
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14745
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09608
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.76468
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.20867
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00802
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00063
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.62538
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.57157
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,53.36566
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19358
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74773
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,12.05396
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30121
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0279
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.80078
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.12352
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.45924
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.20365
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.96976
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.96016
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.73511
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.62059
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10997
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,77.62677
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.77303
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.12718
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20316
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.78078
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.42712
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.13033

--- a/datasets/GM0668_west_maas_en_waal/emissions.csv
+++ b/datasets/GM0668_west_maas_en_waal/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,34.01949
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79845
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.56058
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.30294
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,54.80103
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.83684
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0354
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02675
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.32758
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.28684
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.0664
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70133
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49856
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.62097
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12462
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01032
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.42807
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.57751
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08932
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.72278
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.03177
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.48185
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.38505
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.32507
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05519
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,35.51476
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39666
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48821
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01978
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.37397
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.49814
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.30814

--- a/datasets/GM0677_hulst/emissions.csv
+++ b/datasets/GM0677_hulst/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.84405
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09419
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15937
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.43614
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,50.34653
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.2684
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06227
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03873
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00054
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.51066
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.39372
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,49.70584
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.10589
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7403
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.27028
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08951
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01806
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.58347
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.78581
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07308
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.71576
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.60843
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.6614
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.60026
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.50675
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07575
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,57.096
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60996
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49305
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.01012
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.43949
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.30576
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.69179

--- a/datasets/GM0678_kapelle/emissions.csv
+++ b/datasets/GM0678_kapelle/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.38202
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.40913
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.14168
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0747
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.89254
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.52915
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02072
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02058
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.00685
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02876
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.20052
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.18865
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,17.09997
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39573
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32192
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.70963
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01881
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0047
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.23138
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.37828
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02594
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.43644
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.63158
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.3169
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.2357
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.19898
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03629
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,33.8793
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33394
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53498
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.09098
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.22601
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.53567
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.32672

--- a/datasets/GM0687_middelburg/emissions.csv
+++ b/datasets/GM0687_middelburg/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.65692
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23695
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01277
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10554
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.1485
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,27.83335
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16882
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06052
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00091
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00079
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.86165
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.7215
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,66.16849
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.52118
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.8733
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,42.3106
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,8.70043
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.40138
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.03193
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,42.73339
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05684
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01779
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.00331
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.418
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.69197
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.27906
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00758
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.71395
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.21202
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.01283
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.85506
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13881
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,61.93141
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.72826
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62399
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02244
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07263
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.16324
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06344

--- a/datasets/GM0703_reimerswaal/emissions.csv
+++ b/datasets/GM0703_reimerswaal/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,22.48394
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.69175
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15284
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21244
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.01925
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.73048
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04799
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05093
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,34.09206
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.24955
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.38005
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.33538
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,32.42319
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.7496
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.52672
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.37491
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12954
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02854
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.4541
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.69699
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05423
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.1952
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.19703
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.5634
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.44672
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.37714
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06453
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,78.68361
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.71681
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.40671
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.23863
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.81726
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,10.05855
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.92246

--- a/datasets/GM0715_terneuzen/emissions.csv
+++ b/datasets/GM0715_terneuzen/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.06232
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32061
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.18946
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.55757
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,42.69462
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,35.81546
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.21682
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11501
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.00171
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00719
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,108.83033
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,9.49572
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,4.93062
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00115
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00087
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.09334
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.79067
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,95.85596
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.1432
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.23656
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.88714
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,36.03093
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,7.52205
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2534.13953
+Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,88.14345
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5792.90865
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81073
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57057
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.43426
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.58061
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.7
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.00473
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.44369
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.32821
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.28517
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.08497
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15212
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,115.89719
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.2816
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.53466
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.10731
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.39239
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.93603
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.49218

--- a/datasets/GM0716_tholen/emissions.csv
+++ b/datasets/GM0716_tholen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,6.16439
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.36266
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26786
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.31611
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.45314
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.04582
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03667
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03481
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00045
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.42874
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.38145
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.24634
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81983
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5791
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.06643
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02638
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01634
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.69068
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.91857
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06561
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68343
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.35039
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.64079
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.50396
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.42546
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07339
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,49.6701
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51627
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63029
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.95325
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.64982
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.02186
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.77547

--- a/datasets/GM0717_veere/emissions.csv
+++ b/datasets/GM0717_veere/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,15.43547
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64504
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26593
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.33479
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,39.41819
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.16413
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0434
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03298
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.58716
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02358
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.4125
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.31798
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,40.62985
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.88552
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58171
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.99554
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.43326
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01501
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00762
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.47045
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.62509
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11781
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.53576
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00018
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.29926
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.53416
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.48488
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.40934
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06118
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,43.32518
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47285
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44872
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.22277
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04052

--- a/datasets/GM0718_vlissingen/emissions.csv
+++ b/datasets/GM0718_vlissingen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.72257
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00332
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.05622
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04287
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.38298
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,23.85725
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14233
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09339
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.01863
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00975
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00091
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.86214
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.65299
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,67.60913
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.52126
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.72279
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,224.02824
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.61767
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.01008
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,257.05126
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24983
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0349
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.74126
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.29193
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.13579
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.90798
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.71547
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.09694
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.0134
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.85554
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12563
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,56.80393
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68883
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.73961
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.3865
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.12165
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.75753
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.2955

--- a/datasets/GM0736_de_ronde_venen/emissions.csv
+++ b/datasets/GM0736_de_ronde_venen/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.26312
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.37923
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26291
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.45325
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,92.00641
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.74991
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09498
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07762
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00079
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.75085
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.66874
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,57.95583
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.3687
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.89721
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.00023
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00978
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,22.19765
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.53306
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01634
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.14959
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.31938
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12574
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.22028
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.36494
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.12339
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.88258
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.7451
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12866
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,118.91004
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.12493
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.53174
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.6377
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.47483
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.04075
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.45462

--- a/datasets/GM0737_tytsjerksteradiel/emissions.csv
+++ b/datasets/GM0737_tytsjerksteradiel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,14.33683
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15114
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.14088
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.66682
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,121.29851
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.65245
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05798
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03917
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1607.75373
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.71409
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00183
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.07529
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.58938
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.59191
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,51.36018
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.2078
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82768
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -49,15 +49,15 @@ Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00017
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,38.36733
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10539
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01864
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.68934
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.9197
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.27124
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.75295
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.85635
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.78405
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.69278
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.58486
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0898
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,57.75449
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.63666
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7337
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.55209
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.78456
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.51465
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.09126

--- a/datasets/GM0743_asten/emissions.csv
+++ b/datasets/GM0743_asten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,84.81226
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.53438
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.43491
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.17717
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,83.93749
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.10071
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03628
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03061
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00027
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.2946
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.2487
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,16.36932
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.50647
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3752
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,25.79622
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18588
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02378
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.32405
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.48866
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07795
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.09335
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00972
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.92789
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.41779
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.34628
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.29234
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04785
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,45.11975
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.42697
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.98628
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.74021
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.59198
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.94042
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.57913

--- a/datasets/GM0744_baarle_nassau/emissions.csv
+++ b/datasets/GM0744_baarle_nassau/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,40.16258
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.99725
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67707
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19061
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,87.89949
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.00852
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01218
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01573
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00012
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00011
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.11474
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.09969
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,9.67265
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23621
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1771
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.25752
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01124
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0057
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.13078
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.19592
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.01485
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.19418
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.36138
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.16746
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.13487
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.11386
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.01918
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,14.9212
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1545
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11212
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67132
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34062
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.48034
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.32063

--- a/datasets/GM0748_bergen_op_zoom/emissions.csv
+++ b/datasets/GM0748_bergen_op_zoom/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.21307
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.44145
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.34448
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1117
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,11.63929
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,40.69775
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34791
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16943
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,15.60267
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.12295
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00122
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00109
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.18394
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.99865
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,85.17192
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.0337
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.15739
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,62.22146
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.87656
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.35464
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.50415
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,423.93849
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78523
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06718
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.57661
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.96553
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.73037
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.90216
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01115
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.65388
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.67759
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.36361
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.15119
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.19213
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,77.84382
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.94154
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.46156
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,66.02353
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.75682
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,712.43402
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,36.20694

--- a/datasets/GM0753_best/emissions.csv
+++ b/datasets/GM0753_best/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,55.20296
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.087
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.27085
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.04286
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,17.45251
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.42087
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07534
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0626
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.06093
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01615
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.04275
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.43474
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.44881
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,34.5352
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.80946
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.56016
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.96881
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15186
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02783
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.49575
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.88295
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11695
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.1684
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.36929
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.75394
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.51101
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43141
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08635
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,58.81152
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.66654
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.92707
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.15152
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06717

--- a/datasets/GM0755_boekel/emissions.csv
+++ b/datasets/GM0755_boekel/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,44.13559
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.91786
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.47482
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08223
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,46.83326
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.39336
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02058
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0135
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00018
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00018
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.16883
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.16106
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,13.91027
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33931
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.27953
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,7.46658
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.73159
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06664
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00478
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.19243
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.31647
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08557
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.27809
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00134
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.53175
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.27056
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.19845
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.16753
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03099
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,12.24313
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14291
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1236
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.15193
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0319

--- a/datasets/GM0757_boxtel/emissions.csv
+++ b/datasets/GM0757_boxtel/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,25.88079
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.517
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.66938
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13434
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,35.43008
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,16.62665
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09981
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05883
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.03726
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0195
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00063
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.59607
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.48777
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,43.97042
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.07012
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63706
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,29.8663
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.9895
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.11452
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.95204
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17393
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04627
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.67994
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.9597
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.82927
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.09477
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00535
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.87743
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.81939
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.70065
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.5915
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09384
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,88.23859
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.98962
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.23039
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.71579
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.47702
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.79214
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.50596

--- a/datasets/GM0758_breda/emissions.csv
+++ b/datasets/GM0758_breda/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.46561
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.88248
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.89432
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19494
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.75766
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,99.3246
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61268
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42486
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.74256
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.26364
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0529
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00307
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00297
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.92338
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.71161
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,204.46584
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.0237
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.97682
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,8.95989
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.01987
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,14.06933
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,166.38877
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79178
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19874
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,3.65593
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,5.32957
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.27926
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,10.00923
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0016
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,9.20775
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,4.55513
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,3.43628
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.90099
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.5217
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,318.45472
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.19191
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.70047
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,14.48304
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,11.94778
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,85.61822
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,30.52266

--- a/datasets/GM0762_deurne/emissions.csv
+++ b/datasets/GM0762_deurne/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,128.73371
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.4249
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.89065
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22596
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,118.42379
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.50442
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06978
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05299
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,5.58555
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05106
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00061
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00052
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.57946
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.47606
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,46.84439
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.13279
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.75725
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.99554
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.594
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11103
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05034
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.83451
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.93614
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.78861
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.86939
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00018
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.82513
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.79971
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.68113
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.57502
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09159
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,63.91875
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.67577
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.92141
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.41762
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.78453
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.20851

--- a/datasets/GM0765_pekela/emissions.csv
+++ b/datasets/GM0765_pekela/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.64599
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01153
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.17112
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16468
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.42656
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.31675
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02618
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01262
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.50257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01078
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00056
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00027
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.02288
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.2532
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.21673
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.22413
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5449
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.33372
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,53.61456
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58533
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1111
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.49007
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,5.86731
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05519
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.28007
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.7975
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.3003
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.29762
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.25126
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03439
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,25.86484
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28739
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2368
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.82577
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.40782
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.59897
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.79973

--- a/datasets/GM0766_dongen/emissions.csv
+++ b/datasets/GM0766_dongen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,6.16614
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.85163
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.28142
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06463
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.27963
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.85939
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0598
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03534
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.10151
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01536
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00048
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.4571
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.3919
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.79528
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85204
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.51239
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.03908
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,12.4551
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13288
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02679
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,83.09569
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,81.12321
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.16721
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68288
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00143
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.43972
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.65833
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.5373
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4536
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0754
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,24.28902
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.31839
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25881
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05447
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.05481
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04396

--- a/datasets/GM0770_eersel/emissions.csv
+++ b/datasets/GM0770_eersel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,32.13029
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15453
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.75361
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.14658
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,61.65033
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.84801
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03536
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03492
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.1861
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02816
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.33851
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.28868
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,28.1419
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.67891
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.46615
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.02439
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04028
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02816
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.38583
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.56725
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.19793
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.55839
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.06619
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.48494
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.3979
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.33591
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05554
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,44.93313
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.44272
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78026
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.09317
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.35224

--- a/datasets/GM0772_eindhoven/emissions.csv
+++ b/datasets/GM0772_eindhoven/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,6.52606
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26256
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.24388
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03035
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.30472
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,165.85368
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00608
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.61032
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,84.94946
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.33268
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00962
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00395
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00387
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,3.75198
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,3.53624
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,300.7056
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.69432
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.66607
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,14.43538
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.88214
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,51.41102
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.29607
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.30889
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.6264
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,6.94899
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.22752
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,9.03783
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00259
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,11.81759
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,5.94037
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.41026
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.72325
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.68035
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,259.81244
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.00408
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.28666
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,27.45803
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,18.44287
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,16.52233
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.52716

--- a/datasets/GM0777_etten_leur/emissions.csv
+++ b/datasets/GM0777_etten_leur/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,11.81855
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.4425
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.42764
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.11795
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.97831
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.066
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11512
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09346
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,27 +23,27 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00065
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.62118
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.64661
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,48.91522
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.14317
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74922
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.47995
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,27.18318
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.69723
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08682
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,42.189
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,41.1029
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.22175
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.43413
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0008
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.95654
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.08621
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.73017
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.61643
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1244
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,70.71255
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78647
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94398
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.79434
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.01487
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.41775

--- a/datasets/GM0779_geertruidenberg/emissions.csv
+++ b/datasets/GM0779_geertruidenberg/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.6178
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.10547
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.06802
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06009
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,16.08295
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.73455
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07724
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0468
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6162.38238
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,23.95137
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00748
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40259
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.32031
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,28.19873
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70744
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41416
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,23.39527
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00403
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,38.31282
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.53244
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06669
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,12.87778
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.63128
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11979
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.82127
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01908
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.26802
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.53807
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47322
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.3995
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06163
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,52.1962
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48199
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.84321
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.14526
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.12157
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06568

--- a/datasets/GM0784_gilze_en_rijen/emissions.csv
+++ b/datasets/GM0784_gilze_en_rijen/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,21.88019
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.77236
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.52315
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13561
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,34.13564
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.11431
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06741
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04553
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.44641
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.38883
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.70504
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.82231
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54227
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.49332
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.84266
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0819
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01803
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,10.08345
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.76465
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07305
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.91526
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00027
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.40606
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.65317
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.52473
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.44299
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07481
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,62.08301
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.59905
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.87254
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.90333
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.97229
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.64748
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.65024

--- a/datasets/GM0785_goirle/emissions.csv
+++ b/datasets/GM0785_goirle/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,18.75996
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09414
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.36142
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0817
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,21.10477
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.6
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04003
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02916
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41905
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34995
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.35066
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.74514
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45658
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,34.84402
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,54.41671
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.7541
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02161
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.50176
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.68765
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05751
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.57525
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00624
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.31988
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58787
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49257
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.41584
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06733
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,23.22577
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30218
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23764
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10653
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.31296
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.14632
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.24844

--- a/datasets/GM0794_helmond/emissions.csv
+++ b/datasets/GM0794_helmond/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,25.8127
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.20867
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.30373
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.00436
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,39.48738
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23946
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14791
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,85.95084
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.21022
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00142
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00149
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.3515
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.36095
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,92.26334
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.31927
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.56487
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,58.73706
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,80.24608
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51931
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14633
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.60698
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.6753
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.86797
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.07369
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01052
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.25682
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.2862
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.58862
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.34115
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.26184
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,76.67508
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.99205
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.04443
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.68999
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.39974
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.6665

--- a/datasets/GM0796_s_hertogenbosch/emissions.csv
+++ b/datasets/GM0796_s_hertogenbosch/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,27.01223
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.267
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.83279
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.20638
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,63.10352
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,102.78952
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61797
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42945
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,10.98459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.43481
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.97843
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00255
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00252
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.42437
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.29798
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,187.59566
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.30434
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.64017
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.52735
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,2.79789
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00025
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,3.15147
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00076
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,88.43651
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.6077
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07047
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.92072
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.51912
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.13196
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,9.85271
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,7.63602
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,3.86029
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.84973
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.4058
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.44212
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,231.54862
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.40274
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.81437
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,9.37593
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.57743
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,10.89407
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.67131

--- a/datasets/GM0797_heusden/emissions.csv
+++ b/datasets/GM0797_heusden/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,14.97486
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,9.16833
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.53248
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19311
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,30.79425
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.44328
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08761
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06572
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.16918
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0256
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00081
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.77024
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.66586
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,60.43778
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.44619
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.89229
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,27.50473
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17495
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05306
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,11.7563
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,13.09348
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.1161
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.24491
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00125
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.42601
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.11856
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.90538
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.76434
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12811
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,74.75796
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.76379
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.13741
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.23938
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.1627

--- a/datasets/GM0798_hilvarenbeek/emissions.csv
+++ b/datasets/GM0798_hilvarenbeek/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,36.97884
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16543
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.90021
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19329
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,80.3175
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.3177
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0498
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02763
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00025
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.27051
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.23229
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,22.52275
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54016
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40107
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.85927
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05419
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00836
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.02405
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.45657
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04754
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.4264
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.85201
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.39022
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.31797
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.26843
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04469
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,36.23099
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40348
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44072
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,13.83067
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.6236
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,120.20056
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.37757

--- a/datasets/GM0809_loon_op_zand/emissions.csv
+++ b/datasets/GM0809_loon_op_zand/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,19.18829
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11995
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.37859
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08514
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,16.01928
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.91352
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04193
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03502
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -22,25 +22,25 @@ Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00011
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00501
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.62759
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35691
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.77959
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81616
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50157
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.97326
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,7.01248
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,10.30524
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11953
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01191
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.50231
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.68609
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05439
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.60309
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00107
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.37541
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58654
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.5133
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43334
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06718
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,26.77306
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33032
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49534
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.01176
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.88492
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.84278
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.45751

--- a/datasets/GM0820_nuenen_gerwen_en_nederwetten/emissions.csv
+++ b/datasets/GM0820_nuenen_gerwen_en_nederwetten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.39119
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15193
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.24443
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07362
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.40321
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,18.50022
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.36956
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10986
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6.16254
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.06617
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00107
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40985
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35117
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.46059
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.77988
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49323
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.93057
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30467
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01397
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.48107
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.69021
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13147
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.92398
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.29091
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58991
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.48176
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.40672
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06756
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,26.31955
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30816
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37149
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,159.87693
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.82075
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1739.82236
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,75.28097

--- a/datasets/GM0823_oirschot/emissions.csv
+++ b/datasets/GM0823_oirschot/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,51.43929
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.6913
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.97799
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16994
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,57.35481
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.43503
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03297
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03468
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.31704
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.27437
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.75856
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61994
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44214
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.38361
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,166.24643
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.20755
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08915
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01657
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.36158
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.53934
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07712
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.71215
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.99859
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.4609
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.37267
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.31461
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05279
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,64.43278
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55076
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.24986
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.07862
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01185

--- a/datasets/GM0824_oisterwijk/emissions.csv
+++ b/datasets/GM0824_oisterwijk/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,31.57028
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78829
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.72397
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16778
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,50.61667
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.81389
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07163
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04958
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.10997
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01664
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00052
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.58979
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.47806
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,45.81519
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.10374
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.71929
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,22.39973
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.11724
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.26124
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0631
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01249
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.20852
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.93994
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13057
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.86727
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00464
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.85765
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.80308
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.69327
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.58527
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09198
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,60.71529
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60973
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78997
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.05594
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.1667
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.25592
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.11463

--- a/datasets/GM0826_oosterhout/emissions.csv
+++ b/datasets/GM0826_oosterhout/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,14.90668
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.41195
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.4528
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12858
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.90955
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,28.65096
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17223
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11289
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.38066
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05759
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.001
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00092
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.94661
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.83958
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,70.31007
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.66047
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.00245
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,5e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,101.81596
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78378
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17613
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,10.42888
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.65106
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.25222
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.67926
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.04431
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.98155
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.41038
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.1127
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.93937
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16153
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,110.05817
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.11464
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.58967
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.05877
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.41781
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.54205
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.69391

--- a/datasets/GM0828_oss/emissions.csv
+++ b/datasets/GM0828_oss/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,65.73165
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.75362
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.58199
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.52445
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,153.4663
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,52.97776
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.49666
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15858
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,36.34079
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.30104
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00162
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0015
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.54191
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.36861
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,123.99742
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.8935
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.83857
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,20.84625
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,16.12825
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.04129
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.40957
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,73.2887
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.23593
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10435
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.87002
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.69597
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.75766
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.36786
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00134
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.85656
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.29907
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,96.97361
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,8.31349
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,2.72112
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,108.94987
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.2882
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.47502
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,118.6397
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.12416
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1193.7962
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.72591

--- a/datasets/GM0840_rucphen/emissions.csv
+++ b/datasets/GM0840_rucphen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,10.81773
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.55127
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.57035
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13661
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,37.3512
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.25088
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0379
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02974
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.02206
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02413
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41871
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.33722
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,38.44601
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.88338
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58447
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.08317
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10957
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02454
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.4773
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.66273
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09291
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.56731
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.3188
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.56648
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49217
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4155
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06488
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,38.71745
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39272
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.61325
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.40558
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.50475
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.13208

--- a/datasets/GM0845_sint_michielsgestel/emissions.csv
+++ b/datasets/GM0845_sint_michielsgestel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,25.98142
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29446
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.58825
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.151
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,43.18071
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.88654
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04784
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03232
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00048
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.52273
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.43577
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.12879
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.01996
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.72167
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.43967
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33278
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01029
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.6077
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.85666
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07784
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68534
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.64645
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.73204
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.61445
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.51873
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08384
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,42.69387
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51205
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4383
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03632
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.2367
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0458

--- a/datasets/GM0847_someren/emissions.csv
+++ b/datasets/GM0847_someren/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,142.12478
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.07684
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.61443
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1487
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,72.77481
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.5917
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03392
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03318
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.33387
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.28851
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,26.8631
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.65299
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43619
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.49777
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.33906
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04409
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02737
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.56804
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.56719
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05538
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.53431
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,9e-05
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.05158
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.48465
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.39245
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.33131
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05551
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,40.51959
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.41542
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.76769
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1271
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.705
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.1396

--- a/datasets/GM0848_son_en_breugel/emissions.csv
+++ b/datasets/GM0848_son_en_breugel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,34.15916
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28623
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22571
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03747
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.51544
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.57915
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05204
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05011
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.08802
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02718
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.28008
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.25378
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,21.30108
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.50853
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39034
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -49,15 +49,15 @@ Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,2e-05
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,38.25032
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12153
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02237
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,19.7865
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.49869
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04872
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.81926
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00651
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.88216
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.42632
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.32922
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.27793
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04883
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,22.72865
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27709
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55682
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.94419
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.165
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03755

--- a/datasets/GM0851_steenbergen/emissions.csv
+++ b/datasets/GM0851_steenbergen/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.80241
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,18.12296
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22342
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34538
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,36.08351
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.08705
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04299
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03222
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0016
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.42061
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35165
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,36.65885
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.8341
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54305
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,3.98217
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,121.55585
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61846
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0116
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.56431
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70265
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05462
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.69128
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00071
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.3248
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59073
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49441
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.41739
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06766
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,58.52124
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61464
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.98637
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.44069
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.3151
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.60031
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.32149

--- a/datasets/GM0852_waterland/emissions.csv
+++ b/datasets/GM0852_waterland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.11984
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02076
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10779
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.27592
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,48.07168
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.23765
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03177
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01716
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.03555
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01231
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00027
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.32497
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.24532
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.35692
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60626
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34959
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.94015
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01196
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00671
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.39955
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.48765
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04791
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.38442
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.02356
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.41211
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.38199
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.32248
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0472
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,46.24613
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.50802
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47571
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.46348
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.4454
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.8615
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.61626

--- a/datasets/GM0855_tilburg/emissions.csv
+++ b/datasets/GM0855_tilburg/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,52.75088
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.33172
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.88706
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15248
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.18865
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,97.07129
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58381
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48722
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,22.82082
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.42101
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.02672
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0036
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0036
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,3.42127
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,3.29201
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,237.23944
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.81954
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.45597
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,18.41755
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.05414
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.02523
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,92.21566
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.88815
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23484
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,13.62242
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,6.47125
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,3.95275
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,17.36265
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0033
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,10.77595
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,5.53011
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.02153
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,3.39507
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.63336
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,261.41902
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.9624
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.84584
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,10.65572
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.66952
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,7.47803
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,63.45078

--- a/datasets/GM0858_valkenswaard/emissions.csv
+++ b/datasets/GM0858_valkenswaard/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,12.54854
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02494
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.33811
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08193
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,22.60909
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.60152
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08857
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05433
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.58768
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45445
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,46.70211
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.08828
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57672
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.02756
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13703
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01913
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.26434
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.89296
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.23884
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.94847
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00178
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.85101
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.76341
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.69079
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.58318
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08743
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,46.30073
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55157
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48486
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.07337
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0413

--- a/datasets/GM0861_veldhoven/emissions.csv
+++ b/datasets/GM0861_veldhoven/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.25336
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40209
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22907
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03373
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.76603
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.88997
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12658
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15223
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.69884
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04741
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0008
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.7592
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.66494
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,58.94182
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.38341
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79628
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.59568
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0406
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06224
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.95269
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.30648
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.34524
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.0812
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.39125
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.11701
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.8924
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.75339
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12793
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,42.81362
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.52662
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82325
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.4721
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.20704
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.12935

--- a/datasets/GM0865_vught/emissions.csv
+++ b/datasets/GM0865_vught/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,14.10182
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09738
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.49025
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12409
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,16.93015
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.84378
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0778
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04644
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.17764
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02688
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00058
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.5558
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46454
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,44.59353
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.04073
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62371
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.30812
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01304
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00711
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.63419
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.91391
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.22159
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.7929
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.75059
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.78035
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.65331
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.55154
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08937
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,73.80748
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81999
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.84764
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.28839
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.05695

--- a/datasets/GM0866_waalre/emissions.csv
+++ b/datasets/GM0866_waalre/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.93305
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00337
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12697
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0256
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.60942
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.77164
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02894
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02319
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00031
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.29547
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.25994
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.32144
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56614
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39748
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.06674
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02545
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00332
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.33675
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.51073
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0999
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.44557
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.93063
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.43667
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.34731
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.2932
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05001
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,44.5941
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.41862
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45735
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.04289
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01044

--- a/datasets/GM0867_waalwijk/emissions.csv
+++ b/datasets/GM0867_waalwijk/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.53392
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.52147
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.21021
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.14416
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.92241
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.73676
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15529
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12932
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.06767
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01024
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00087
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01209
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.8311
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.73797
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,67.58882
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.56268
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.9295
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.01426
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.08051
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,24.97393
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1514
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05846
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.0164
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.41584
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.80082
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.26683
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.61772
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.2079
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.97692
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.82474
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13834
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,76.07139
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79296
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.37229
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.34446
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.54162
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.19441
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.63419

--- a/datasets/GM0873_woensdrecht/emissions.csv
+++ b/datasets/GM0873_woensdrecht/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.50262
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25211
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.2829
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.11257
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,19.83452
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.47448
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05135
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03252
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.08459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00347
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40114
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.31958
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.88134
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.82005
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53742
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.55608
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0984
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10287
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.47461
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.62829
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.17477
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.33796
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.26346
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.53685
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47152
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39807
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06149
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,36.40764
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4027
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.89896
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.19679
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.28359
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.40298
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.29682

--- a/datasets/GM0879_zundert/emissions.csv
+++ b/datasets/GM0879_zundert/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,58.74169
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.74141
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.20563
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.28952
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,59.29539
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.32736
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03838
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0339
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.36786
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.32363
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,32.66319
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.75989
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58466
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.81136
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02229
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00697
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.42046
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.63604
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04644
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.57002
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.15864
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.54366
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.4324
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.36504
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06226
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,35.62066
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39614
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38233
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.28633
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04175

--- a/datasets/GM0880_wormerland/emissions.csv
+++ b/datasets/GM0880_wormerland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.08528
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04755
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.19604
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.20479
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.11114
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.43991
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02693
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02129
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.27133
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.2613
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,22.90438
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51792
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31454
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.53779
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01365
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05766
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.30973
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.51355
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03329
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.44392
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.85461
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.43895
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.31894
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.26925
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05027
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,29.36077
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28058
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.57885
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.28126
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.66262
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.29338

--- a/datasets/GM0882_landgraaf/emissions.csv
+++ b/datasets/GM0882_landgraaf/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.82654
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00069
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00207
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01628
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.22133
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.59657
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06427
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08969
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00082
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0006
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.1973
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.55198
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,65.48577
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.47092
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69787
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,15.1937
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,6.0788
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.07063
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1966
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02351
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.11517
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.08467
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4697.30029
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.17091
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.46832
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.92725
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.92116
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.77767
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1062
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,40.34686
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54353
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32389
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.97089
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.74391
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.46062
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,31.76466

--- a/datasets/GM0888_beek/emissions.csv
+++ b/datasets/GM0888_beek/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.39695
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00611
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00186
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02955
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.875
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.24337
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0682
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03778
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01015
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00025
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.32526
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.22934
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,26.95194
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62566
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34681
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,42.18847
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51758
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00717
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,20.76839
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,8.42771
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05968
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.61697
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01444
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.02448
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.38527
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.38233
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.32277
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04412
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,42.4675
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40733
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63734
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.04961
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.02213

--- a/datasets/GM0889_beesel/emissions.csv
+++ b/datasets/GM0889_beesel/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.33718
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78502
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.23048
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0616
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.0776
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.02994
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02444
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01359
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.24904
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.19604
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,20.75618
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47882
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32234
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,35.34179
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.90964
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10348
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03615
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,3.23613
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.38641
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05647
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.34599
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00633
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.7844
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.32932
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.29273
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.24713
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03772
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,23.06656
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.27292
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36736
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.65367
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.09112
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03603

--- a/datasets/GM0893_bergen/emissions.csv
+++ b/datasets/GM0893_bergen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,22.98997
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.25806
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.77557
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.20293
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.18169
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.52707
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02139
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01548
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.25115
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.18625
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,20.97635
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.49903
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34662
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.3933
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05992
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00784
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.69365
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,5.39083
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04101
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.33177
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.79104
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.31287
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.29521
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.24923
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03583
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,47.57357
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51831
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29234
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.08737
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.36968
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0338

--- a/datasets/GM0899_brunssum/emissions.csv
+++ b/datasets/GM0899_brunssum/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.31472
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00427
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00206
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.00545
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.40221
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.96243
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07256
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02895
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.06767
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01024
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00061
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.5809
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.39528
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,47.86588
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06376
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48359
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.85396
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04114
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02481
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,12.19256
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,10.0106
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,7.94659
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.87393
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.82967
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.66402
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.68282
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.57646
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07605
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,29.93101
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40537
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.29654
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.18158
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.05486
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.04175

--- a/datasets/GM0907_gennep/emissions.csv
+++ b/datasets/GM0907_gennep/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,21.63711
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11294
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.37438
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12634
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.53737
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.68603
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07088
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05899
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00034
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.31886
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.25525
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,24.95432
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60558
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.40743
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,63.21701
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -49,15 +49,15 @@ Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00181
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,152.30153
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2326
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.42877
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,12.35114
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.50229
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05199
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.5746
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01765
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.00431
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.42879
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.3748
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.31642
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04911
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,33.92044
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37793
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37859
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.90388
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.60104
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.84924
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.87937

--- a/datasets/GM0917_heerlen/emissions.csv
+++ b/datasets/GM0917_heerlen/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.27651
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01449
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00372
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02016
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.69845
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,62.23244
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37687
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20111
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0423
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0064
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00193
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00138
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.83496
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.25833
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,138.275
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.20258
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.42799
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,3.53808
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00168
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,16 +51,16 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,262.62733
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.10758
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16414
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,18.68536
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.47274
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.86257
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.07526
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,7e-05
 Industry,Other metals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.02015
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.77958
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.11382
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.15691
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.82091
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.2421
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,143.38163
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.68998
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.61837
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.0829
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.15122
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.83275
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.39724

--- a/datasets/GM0928_kerkrade/emissions.csv
+++ b/datasets/GM0928_kerkrade/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.75027
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02137
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00278
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.01116
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.45794
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,22.90232
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13891
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0555
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,39.06678
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.28038
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00109
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00072
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.03916
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.65711
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,79.22692
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.83175
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78967
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.49332
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,20.67135
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39594
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04892
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,6.86451
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.05139
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.25795
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.1942
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00027
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.27304
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.10385
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.22148
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.0312
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12642
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,53.39297
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.71893
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45524
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.87842
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.46238
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.01375
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.24713

--- a/datasets/GM0935_maastricht/emissions.csv
+++ b/datasets/GM0935_maastricht/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.17556
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00105
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03897
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03837
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.94302
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,85.36335
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5109
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26311
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,56.24912
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.07542
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01737
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0024
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00195
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.50922
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.78231
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,176.5795
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.01319
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.88527
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,15.92869
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,8.18122
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02642
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00364
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,752.23089
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.07872
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19482
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,735.83807
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,121.65091
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4.60665
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,7.62214
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.07543
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,7.20176
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.99403
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.68766
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,2.26898
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.3429
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,134.81815
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.69647
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.37624
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.78986
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.35271
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,6.65907
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,26.86932

--- a/datasets/GM0938_meerssen/emissions.csv
+++ b/datasets/GM0938_meerssen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.4404
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01764
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01606
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.041
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.48043
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.23068
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03779
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02484
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.40084
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.26488
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.78057
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78598
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.45349
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,21.89688
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07822
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00362
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.48964
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.52158
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04462
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.55176
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.26252
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.44496
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.47117
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39777
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05096
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,33.4508
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.36623
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.38554
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.06981
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.00311

--- a/datasets/GM0944_mook_en_middelaar/emissions.csv
+++ b/datasets/GM0944_mook_en_middelaar/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.86463
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00391
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10184
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02998
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.30601
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.18305
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01324
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00892
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00015
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00012
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.14086
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.11308
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,12.30789
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.28438
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19874
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.18167
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01966
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00868
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.16181
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.22254
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02093
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.1817
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.44368
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.18996
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.16558
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.13978
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02176
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,14.4638
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17027
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09539
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.06515
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.00478

--- a/datasets/GM0946_nederweert/emissions.csv
+++ b/datasets/GM0946_nederweert/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,245.9347
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.99366
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.55057
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.18156
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,88.6128
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.41105
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02676
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02867
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.50771
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03235
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00028
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.29968
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.25153
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.02941
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.59788
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41505
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,77.65239
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.6002
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07358
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0174
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.43721
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.49478
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04768
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.48542
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01391
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.94392
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.42253
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.35226
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.29739
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04839
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,34.05977
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37964
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39129
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.81709
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.32164
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0283

--- a/datasets/GM0957_roermond/emissions.csv
+++ b/datasets/GM0957_roermond/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,19.16586
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01153
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.36314
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.09672
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.92156
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,38.43659
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23074
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11877
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.01531
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03004
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00105
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00095
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,2.30964
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.87109
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,81.8721
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.84295
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.13662
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,146.84266
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,48.21078
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02115
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0016
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,246.71301
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.04596
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.9014
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,21.7884
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,90.73024
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.70665
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.93804
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0263
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.14068
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.46331
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.17209
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.9895
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16759
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,83.8274
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.99824
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.34524
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.94983
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.92408
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.69277
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.58061

--- a/datasets/GM0965_simpelveld/emissions.csv
+++ b/datasets/GM0965_simpelveld/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.03343
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00917
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.005
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03791
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.12618
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.99371
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01209
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00762
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00025
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00016
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.235
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.15007
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,18.59778
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4396
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2489
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.925
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0114
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00145
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.26787
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.29489
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04365
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.2202
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.74018
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.25209
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.27623
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.2332
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02887
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,13.56131
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16874
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10895
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.48239
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15641
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.50163
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.18306

--- a/datasets/GM0971_stein/emissions.csv
+++ b/datasets/GM0971_stein/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.68751
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00281
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01042
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.02555
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.64017
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.66815
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03382
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03328
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.52053
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35457
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.89273
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00038
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55433
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.99439
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0106
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01683
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.60779
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.69878
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06214
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.80071
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.63952
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59563
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.61186
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.51655
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06822
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,27.29057
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34962
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32828
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.0102
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.41967
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.95416
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.50888

--- a/datasets/GM0981_vaals/emissions.csv
+++ b/datasets/GM0981_vaals/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.05706
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00493
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03993
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05114
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,8.2943
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.26363
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01373
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00881
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00022
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00016
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.20993
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.14705
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,16.81503
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39101
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20397
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.2921
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01871
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00232
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.23927
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.28894
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02913
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.2251
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.66123
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.24703
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.24677
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.20833
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02829
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,13.60607
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17275
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10172
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.06801
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.01666

--- a/datasets/GM0983_venlo/emissions.csv
+++ b/datasets/GM0983_venlo/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,41.45797
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,30.40479
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.64427
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.14265
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.78422
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,68.57343
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.41593
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2235
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4.66843
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05667
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01336
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.002
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00164
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.90229
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.49852
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,148.71941
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.42244
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.86192
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,317.57835
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00309
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.15633
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,111.26103
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00417
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11676
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,70.90135
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,32.01049
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.05361
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,6.39555
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.07356
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.99164
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.5173
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.23605
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.88773
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.28831
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,158.18237
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.83841
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.9474
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.2406
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,9.8671
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,6.7135
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.0564

--- a/datasets/GM0984_venray/emissions.csv
+++ b/datasets/GM0984_venray/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,295.51444
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.58821
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.54197
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.26562
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,172.34683
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.89552
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14549
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0895
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.0136
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02285
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00077
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.73463
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.64587
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,57.33231
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.37214
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.9331
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,31.2727
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08901
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04863
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.84096
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.27181
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.05564
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.26391
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.31387
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.08498
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.86353
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.72901
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12426
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,91.4746
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.01614
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.26403
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.009
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.68535
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.18148
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.78389

--- a/datasets/GM0986_voerendaal/emissions.csv
+++ b/datasets/GM0986_voerendaal/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.51318
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00981
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00562
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.06903
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.59588
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.85809
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01127
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00998
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00027
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.25317
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.18294
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,22.49682
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.5151
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3107
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.9883
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02027
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00162
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.28864
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.35956
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03184
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.27274
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.79739
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.30732
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.29758
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.25123
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0352
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,22.5595
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23259
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2658
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.05556
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.00663

--- a/datasets/GM0988_weert/emissions.csv
+++ b/datasets/GM0988_weert/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,118.36903
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62983
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.69183
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15749
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,36.88761
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,34.16322
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30256
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1333
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.02709
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01103
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.05317
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,12.41192
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0415
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,19.81135
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00081
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,20.49727
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.73578
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,72.84537
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.68022
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.01606
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,16.42647
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02426
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0658
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,74.6472
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.437
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08137
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,8.77863
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.44684
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.3026
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.17333
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01204
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.7899
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.236
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.04118
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.87899
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14156
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,94.24216
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.9704
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.38182
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,63.72638
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.80117
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,655.50728
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,24.57213

--- a/datasets/GM0994_valkenburg_aan_de_geul/emissions.csv
+++ b/datasets/GM0994_valkenburg_aan_de_geul/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.21037
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00582
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00168
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05527
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,11.02859
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.22086
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03773
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02937
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.35213
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.23845
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.50972
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.70027
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36677
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,10.19713
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08601
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00483
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.40148
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.46862
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04964
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.41747
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.10909
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.40056
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.41391
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.34943
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.04588
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,36.62724
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.38627
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34649
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.64543
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.15704
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,22.71998

--- a/datasets/GM0995_lelystad/emissions.csv
+++ b/datasets/GM0995_lelystad/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.91216
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0666
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00925
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.28707
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,44.20824
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.04612
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15141
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12733
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1112.36423
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.3988
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.74174
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00119
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00132
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.1271
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.20163
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,74.67556
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.83621
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.40223
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,2.98663
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,5e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,13.0197
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19725
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09038
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.17733
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.38454
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.28888
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.1958
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00152
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.55001
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.01856
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.32485
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.11847
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.23119
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,199.56016
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.8974
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.12731
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.6776
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,9.93621
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.79041
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,75.53627

--- a/datasets/GM1507_horst_aan_de_maas/emissions.csv
+++ b/datasets/GM1507_horst_aan_de_maas/emissions.csv
@@ -1,46 +1,46 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,145.00288
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,30.2202
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.89248
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.33914
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,85.4272
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.44842
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19423
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08616
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.53137
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.029
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00076
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00069
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.75037
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.62757
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,61.01602
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.4433
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0346
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,1.16875
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,17.49726
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18243
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05908
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.96806
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.23808
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13705
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.25951
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00018
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.26321
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.05423
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.84462
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.71305
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12074
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,75.51277
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84951
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.28124
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,43.6028
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.26454
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,475.55732
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.59104

--- a/datasets/GM1509_oude_ijsselstreek/emissions.csv
+++ b/datasets/GM1509_oude_ijsselstreek/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,38.79265
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20334
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.57808
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.55122
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,99.45326
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,17.47579
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10481
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07321
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00082
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.77842
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.56522
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,64.40537
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.54571
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.93304
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,20.83494
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.159
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1028
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.36464
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.11081
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.24112
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.452
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00178
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.4518
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.94949
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.915
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.77246
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10874
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,84.09857
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.90108
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.72658
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.20632
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,5.01327
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.11474
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.23613

--- a/datasets/GM1525_teylingen/emissions.csv
+++ b/datasets/GM1525_teylingen/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.20655
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.65855
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12506
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08271
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,8.93557
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.54047
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08809
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05837
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0423
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0064
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0006
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00063
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.56591
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.57127
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.77066
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00482
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64521
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.23106
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10977
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02901
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.64827
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.12328
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07241
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.01159
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.78244
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.95965
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.6652
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.56158
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10991
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,51.22591
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54303
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.63109
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67629
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.8743
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.1598

--- a/datasets/GM1581_utrechtse_heuvelrug/emissions.csv
+++ b/datasets/GM1581_utrechtse_heuvelrug/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.19138
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20316
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67068
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22683
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,48.42146
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,20.80029
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12497
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06719
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00098
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00081
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.93066
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.74107
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,76.69997
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.7777
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.10647
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,8.95989
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.93113
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05115
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00728
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.07944
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.45761
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.15873
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.2251
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0016
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.9313
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.24489
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.09395
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.92354
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14258
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,161.87703
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.51916
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.73785
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.26378
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.30237
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.37634
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.53988

--- a/datasets/GM1586_oost_gelre/emissions.csv
+++ b/datasets/GM1586_oost_gelre/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,66.7339
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26601
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.46398
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.42094
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,123.31324
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.05972
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09134
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06458
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00058
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.55132
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.43047
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,43.22717
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.05635
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.67922
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,43.30614
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,34.04413
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13101
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07046
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.63759
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.8459
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.15245
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.92921
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00776
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.73648
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.72313
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.64804
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.54709
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08282
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,52.2296
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58921
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55942
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.72672
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.45074
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.05072
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.89473

--- a/datasets/GM1598_koggenland/emissions.csv
+++ b/datasets/GM1598_koggenland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.7517
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.1812
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.61926
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.34067
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,60.98162
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.23488
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03782
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03133
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.5364
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0159
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.36287
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34339
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,30.62982
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.73298
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54426
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.43202
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01351
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02441
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.41388
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.67527
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04623
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.59028
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.14293
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.57684
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.42654
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.36009
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06607
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,54.02559
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.51499
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.86918
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.17041
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.59652
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.21498
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.04165

--- a/datasets/GM1621_lansingerland/emissions.csv
+++ b/datasets/GM1621_lansingerland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,16.97982
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,92.50232
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.23116
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07011
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.27107
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,16.13371
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09786
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12967
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00063
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00104
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.60374
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.95374
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,46.89462
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.10331
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09089
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.09473
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.19659
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11534
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04308
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.69645
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.87458
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.1101
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.38007
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.90158
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.60216
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.70966
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.59911
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.18349
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,70.75241
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.75654
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.06459
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.20913
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.30646
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.18954

--- a/datasets/GM1640_leudal/emissions.csv
+++ b/datasets/GM1640_leudal/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,174.49437
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.45988
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.35748
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.31586
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,82.54367
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.57968
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06417
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05295
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3025.4146
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,11.93816
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0007
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.66619
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.51886
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,58.17635
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.35554
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.9179
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.96993
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.20826
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13419
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,14.78479
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.02184
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11357
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.27687
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.09828
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.87161
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.78307
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.66108
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09982
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,123.19099
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19452
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.23638
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10895
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.51119
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.43851

--- a/datasets/GM1641_maasgouw/emissions.csv
+++ b/datasets/GM1641_maasgouw/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,6.18585
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13268
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26801
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07279
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.85003
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.2759
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06352
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03773
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,664.32257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.74156
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.46982
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34668
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,40.63293
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.94941
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.60317
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.9937
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22939
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01762
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,24.40786
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,10.18113
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11217
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.64453
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.47978
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.58238
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.55225
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.46622
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0667
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,60.31769
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.61909
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.71064
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67558
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.60162
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.78368
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.64115

--- a/datasets/GM1652_gemert_bakel/emissions.csv
+++ b/datasets/GM1652_gemert_bakel/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,143.50994
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.80733
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.16301
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.24604
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,121.44211
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.128
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05537
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04407
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00052
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0005
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.49801
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.45257
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,39.44263
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.95969
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69676
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.68593
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19638
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01713
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.76545
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.88931
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.085
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.77753
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.56859
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.76025
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.58539
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4942
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08707
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,50.60624
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58052
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49971
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03351
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1271
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.23011
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06436

--- a/datasets/GM1655_halderberge/emissions.csv
+++ b/datasets/GM1655_halderberge/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,16.33836
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.44914
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.44051
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16079
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,34.1934
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.50294
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05717
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04242
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,59.88104
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.46999
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0006
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.57072
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.44474
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,45.81458
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.09504
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7191
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,86.11451
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,18.96592
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25452
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05536
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.6776
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.87454
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.34155
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.76216
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01543
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.79758
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.7471
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.67085
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.56635
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08557
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,49.49169
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.53508
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.64765
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.77609
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.56288
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.95342
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.08834

--- a/datasets/GM1658_heeze_leende/emissions.csv
+++ b/datasets/GM1658_heeze_leende/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,45.98799
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31342
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.69617
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16484
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,46.01305
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.96397
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02391
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02018
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.19456
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02944
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00026
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.2824
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.24014
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,23.62079
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56585
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4122
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.60278
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11997
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01797
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.35568
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.47217
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.22985
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.40308
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.88948
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.40339
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.33195
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.28024
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0462
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,64.85506
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.557
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.71972
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.24162
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.3568

--- a/datasets/GM1659_laarbeek/emissions.csv
+++ b/datasets/GM1659_laarbeek/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,33.55828
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.01867
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.64186
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13621
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,45.55177
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.12836
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03717
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03196
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,22 +23,22 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.3991
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.34188
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,32.10098
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.76637
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5815
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,10.95098
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,59.03382
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09095
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11334
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.45568
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.67224
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08314
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.63371
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00196
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.25703
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.57431
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.46912
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.39604
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06578
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,30.96823
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37264
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4855
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,5.83995
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.73713
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.6557
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.07247

--- a/datasets/GM1667_reusel_de_mierden/emissions.csv
+++ b/datasets/GM1667_reusel_de_mierden/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,47.62011
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48967
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.65877
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12405
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,88.76399
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.82542
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01714
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.019
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00024
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00021
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.23167
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.19505
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,19.13104
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47039
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.34285
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.53267
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01368
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00977
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.36641
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.38326
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03051
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.33333
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.7297
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.32765
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.27232
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.2299
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03753
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,20.16579
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22982
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19992
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.17797
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0183

--- a/datasets/GM1669_roerdalen/emissions.csv
+++ b/datasets/GM1669_roerdalen/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,15.79305
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.35767
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.51239
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15533
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,22.04443
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.93201
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04811
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02756
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,27 +23,27 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41094
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.29931
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,37.30966
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84881
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55008
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.03112
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.02906
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,10.26635
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01857
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01024
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.49284
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.58816
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08331
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.48932
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.29434
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.50279
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.48304
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4078
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05758
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,33.9787
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40815
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48355
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.92678
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.09453
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,16.08411

--- a/datasets/GM1674_roosendaal/emissions.csv
+++ b/datasets/GM1674_roosendaal/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.82725
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.12139
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.94069
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.2478
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,43.75775
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,44.66685
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2709
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12543
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,41.62182
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.30603
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,2.61799
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00142
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00123
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.3481
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.12314
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,108.69017
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.5214
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.39024
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,18.23417
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00864
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,73.34659
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.48409
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16274
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.54654
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.20776
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.43325
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.13644
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.24609
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.88672
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.58462
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.33777
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.21609
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,123.69728
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.27619
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.59011
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16342
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.77632
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.32434

--- a/datasets/GM1676_schouwen_duiveland/emissions.csv
+++ b/datasets/GM1676_schouwen_duiveland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,10.63781
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.0623
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26377
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.48063
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,38.33179
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.09884
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06732
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0563
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00054
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.58611
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.49437
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,60.22148
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.29182
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.87165
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.80821
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02407
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04812
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.67923
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.98192
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.38595
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.91421
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.84605
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.83047
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.68894
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.58162
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09511
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,100.88872
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.05623
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.11002
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.89868
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.84446
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.84651
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.82335

--- a/datasets/GM1680_aa_en_hunze/emissions.csv
+++ b/datasets/GM1680_aa_en_hunze/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,21.09769
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08405
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.55201
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.67784
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,71.90742
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.14124
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0372
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02484
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.07613
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01152
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00115
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00046
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.04715
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.43925
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.44663
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,43.80073
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.98732
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.70984
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.49777
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,33.90886
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08562
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5055
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.50065
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.72398
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12238
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.57252
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,9e-05
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.38351
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.61883
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.51632
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43589
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07087
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,85.49873
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.8051
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09992
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.44741
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.4477
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.5645
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.07021

--- a/datasets/GM1681_borger_odoorn/emissions.csv
+++ b/datasets/GM1681_borger_odoorn/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,29.88436
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.142
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.88635
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.7656
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,72.53975
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.35328
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03852
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02625
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05075
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00768
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00042
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.46587
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.38344
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,48.29367
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.06516
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.75572
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.34188
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01769
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01412
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.54823
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.75349
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.09981
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.62516
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.46734
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.64413
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.5476
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.4623
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07377
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,72.8738
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.73109
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74399
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.57897
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.50504
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.57986
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.54437

--- a/datasets/GM1690_de_wolden/emissions.csv
+++ b/datasets/GM1690_de_wolden/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,67.6982
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22403
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.69211
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.86064
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,149.4941
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.79662
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02909
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03092
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.02538
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00384
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00198
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.08099
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.41955
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.48821
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,38.91817
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.90813
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.65437
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,23.28452
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18171
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00617
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.49348
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.69449
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06994
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.58054
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.32145
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59348
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.49316
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.41633
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06797
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,66.46964
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.57551
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.16034
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.34844
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.17783
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.93471
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.08869

--- a/datasets/GM1695_noord_beveland/emissions.csv
+++ b/datasets/GM1695_noord_beveland/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.36847
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06668
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.00552
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21871
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,22.35157
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1.79095
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01086
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01053
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00014
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00012
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.13169
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.11101
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,15.31885
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.3034
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.22187
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2.01417
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.00571
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00334
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.15091
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.21871
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.01409
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.18869
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.4148
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.18647
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.1548
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.13069
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02136
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,28.89952
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2885
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3479
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.33119
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22574
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.45605
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.3526

--- a/datasets/GM1696_wijdemeren/emissions.csv
+++ b/datasets/GM1696_wijdemeren/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.46419
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.16511
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22241
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10784
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,15.19352
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.1584
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04709
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03874
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.44981
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.35686
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,36.35708
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85219
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.54421
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.82408
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02098
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00637
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.51281
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.70157
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12309
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.61242
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.41677
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.59948
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.52873
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.44637
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06866
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,46.93713
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.54855
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32508
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.52708
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.68968
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.84399
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.92771

--- a/datasets/GM1699_noordenveld/emissions.csv
+++ b/datasets/GM1699_noordenveld/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,11.93002
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2022
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.90918
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.59292
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,78.53364
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,32.63101
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.6253
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03693
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,6e-05
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00063
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00278
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.59547
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46913
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,50.93872
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19351
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79134
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.32113
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01762
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00726
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.68444
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.91437
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.17556
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.77323
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.87555
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.7817
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.69994
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.59091
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08953
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,58.39723
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.65869
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55582
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,265.74694
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.29027
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2889.08641
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.10766

--- a/datasets/GM1700_twenterand/emissions.csv
+++ b/datasets/GM1700_twenterand/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,43.11128
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.35074
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.41506
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.35521
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,77.34044
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.44242
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06324
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04828
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00065
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.61762
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.48877
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,49.99587
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.22741
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.81389
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,85.61673
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,18.91567
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08798
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03556
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.70405
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.96052
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13184
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.89843
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01534
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.9453
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.82106
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.72598
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.61289
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09404
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,46.40032
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.52507
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.59038
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.03599
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.57617
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.69883
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.25371

--- a/datasets/GM1701_westerveld/emissions.csv
+++ b/datasets/GM1701_westerveld/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.54999
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0857
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.29106
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.68788
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,107.76067
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.41104
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02676
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02235
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -22,20 +22,20 @@ Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0062
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.25333
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.33109
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.70741
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,32.95602
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.75037
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.53498
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.09632
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01683
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00328
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.46941
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.5579
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04147
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.45235
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.04282
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.47688
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.38918
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.32855
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05462
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,50.97723
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.53982
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.65083
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.84876
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.87991
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.15347
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.73371

--- a/datasets/GM1705_lingewaard/emissions.csv
+++ b/datasets/GM1705_lingewaard/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.29761
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.70502
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0473
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.12835
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,17.70775
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,11.45868
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0695
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05897
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,7.5213
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0552
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.73786
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00079
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00075
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.74907
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.68975
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,59.1643
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.41896
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.00488
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,49.2794
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.23764
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.32818
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06013
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,51.40196
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,35.39451
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10051
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.138
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00883
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.35933
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.15868
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.88049
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.74333
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1327
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,62.11034
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.72152
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.61618
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.11936
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.05282
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.51161
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.87136

--- a/datasets/GM1706_cranendonck/emissions.csv
+++ b/datasets/GM1706_cranendonck/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,44.9872
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.41291
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.53969
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.1269
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,28.23116
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.93713
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04814
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03183
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.13534
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02048
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.38513
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.30071
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.14262
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.76862
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.5301
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,156.15217
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00291
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00443
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,30.42392
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15279
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0806
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.44612
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.59111
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08113
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.56035
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.21306
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.50515
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.45271
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.38219
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05786
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,39.44981
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40235
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.62112
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.22402
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.85976
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.82162
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.62968

--- a/datasets/GM1708_steenwijkerland/emissions.csv
+++ b/datasets/GM1708_steenwijkerland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.4592
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28413
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.02303
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.93987
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,188.93536
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.31961
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07396
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05953
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.17764
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02688
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00188
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00078
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.07748
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.74511
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.77346
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,67.4673
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.54378
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.05547
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.36301
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02677
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02059
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.89338
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.26789
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.28869
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.18408
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.34687
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.08344
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.87584
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.7394
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12409
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,81.95641
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.86961
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02602
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.78081
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.27775
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.91697
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.61669

--- a/datasets/GM1709_moerdijk/emissions.csv
+++ b/datasets/GM1709_moerdijk/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.81807
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.83982
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09042
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.32906
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,35.98603
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.71894
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08928
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12771
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,164.24823
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.07732
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,41.5406
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0006
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.69353
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.54556
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,57.8341
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.34146
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.81073
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,11.0204
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,3.87817
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2215.91965
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.10208
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20921
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.78374
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,64.08744
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.21125
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.32983
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00606
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.1844
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.91646
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.81521
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.68822
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10496
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,159.29626
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.3491
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.17832
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.17453
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.59752
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.35353
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,29.87631

--- a/datasets/GM1711_echt_susteren/emissions.csv
+++ b/datasets/GM1711_echt_susteren/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,20.73612
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06431
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.72462
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.22629
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,39.20095
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.49131
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06168
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04867
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,8.52301
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.06239
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00064
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.60754
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46418
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,53.72972
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.23211
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.77103
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.03734
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07875
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05326
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,3.29305
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,8.68397
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.1039
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.92898
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.91357
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.77975
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.71413
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.60289
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0893
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,92.15854
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.87513
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.37716
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.85388
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.35022
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.30595
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,4.34385

--- a/datasets/GM1714_sluis/emissions.csv
+++ b/datasets/GM1714_sluis/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.46956
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04137
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.17219
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.67564
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,49.76713
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.47206
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05745
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04071
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.50257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01078
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.4819
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.32617
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,55.08152
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.1211
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6484
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.28087
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04734
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01608
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.54924
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.64191
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.80422
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.96994
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.51782
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.54792
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56644
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.47821
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06275
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,77.27417
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.76966
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6901
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.10328
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.02632
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.23352
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.18393

--- a/datasets/GM1719_drimmelen/emissions.csv
+++ b/datasets/GM1719_drimmelen/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,23.75521
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.06732
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.3255
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.24861
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,45.1601
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.022
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04259
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03473
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00052
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.49214
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.3938
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.37008
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83961
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.60282
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,10.42374
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47841
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00727
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.61054
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.78185
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08551
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.661
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.5501
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.66153
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.57849
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.48838
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07577
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,42.81435
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47355
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.78589
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.19427
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13238
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.2774
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.16654

--- a/datasets/GM1721_bernheze/emissions.csv
+++ b/datasets/GM1721_bernheze/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,121.27014
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69137
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.09687
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21341
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,112.67293
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.54731
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03971
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04571
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00055
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.52125
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.46465
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,42.03567
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.02471
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.75745
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.92065
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0327
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01926
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.61192
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.91317
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06773
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.80127
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.64177
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.78054
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.6127
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.51726
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.08939
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,72.78394
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.76764
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.21505
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,6.40883
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.10226
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.24931
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,5.6717

--- a/datasets/GM1723_alphen_chaam/emissions.csv
+++ b/datasets/GM1723_alphen_chaam/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,35.52121
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.04639
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.93623
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.23055
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,67.48111
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,2.54801
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01545
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01394
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00018
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00016
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.17145
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.14988
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,14.99782
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.35701
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.27455
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.51767
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06741
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00507
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.21268
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.29455
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.02505
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.25127
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.54001
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.25177
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.20153
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.17014
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.02884
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,21.29174
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.2324
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21913
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.28259
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19841
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.26334
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.18811

--- a/datasets/GM1724_bergeijk/emissions.csv
+++ b/datasets/GM1724_bergeijk/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,61.62693
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13032
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.87137
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.17112
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,56.28695
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.52551
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03958
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03445
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00035
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.33374
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.2756
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.01197
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68961
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.47472
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.24609
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04067
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01562
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.38153
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.54153
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08283
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.58053
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.05117
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.46297
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.39229
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.33118
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05302
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,25.86107
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.30647
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.31418
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.22998
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.04246

--- a/datasets/GM1728_bladel/emissions.csv
+++ b/datasets/GM1728_bladel/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,42.75042
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.23148
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.73451
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13655
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,52.34668
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.20589
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0619
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04603
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,15.84799
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.16006
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00855
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00038
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.35676
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.30368
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,28.58365
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.69113
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.48165
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.21496
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11911
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06037
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.40777
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.59668
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.18925
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.75121
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.12369
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.51014
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.41935
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.35403
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05843
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,43.68503
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43798
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.59072
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.51265
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.17547
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.60344
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.28462

--- a/datasets/GM1729_gulpen_wittem/emissions.csv
+++ b/datasets/GM1729_gulpen_wittem/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1.81734
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04618
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.04216
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21406
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,28.78567
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,3.93218
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02302
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01941
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00032
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00022
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.30155
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.20505
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,26.04738
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.60735
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.35555
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.90315
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03814
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01104
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.35983
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.40293
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.03471
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.32882
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.94979
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.34446
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.35446
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.29924
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.03945
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,30.56812
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.34801
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.25065
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.56523
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.36319
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.04601
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.79638

--- a/datasets/GM1730_tynaarlo/emissions.csv
+++ b/datasets/GM1730_tynaarlo/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.08704
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07698
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.62154
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.46588
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,60.7611
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.63747
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05846
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03682
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05921
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00896
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00066
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00061
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.02761
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.5849
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.54296
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,52.70557
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.21752
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.8597
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.49777
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1.96299
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0079
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00502
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.68661
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.97822
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06781
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.80183
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,9e-05
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.84225
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.83597
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.68752
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.58042
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09574
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,77.91901
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.77261
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.81474
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.21272
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.01909
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.9111
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.72336

--- a/datasets/GM1731_midden_drenthe/emissions.csv
+++ b/datasets/GM1731_midden_drenthe/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,69.50451
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.35813
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.86079
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.03696
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,156.35788
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.93785
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05964
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.36554
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,165.80878
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.19364
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,23.35993
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00061
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.58082
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.4833
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,50.71665
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19457
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.8735
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,40.44333
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.07275
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05013
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.66263
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.95027
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07628
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.81948
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.8294
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.81187
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.68272
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.57637
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09298
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,118.52638
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.00876
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.70763
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.91134
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,23.62748
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.14505
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,200.95658

--- a/datasets/GM1734_overbetuwe/emissions.csv
+++ b/datasets/GM1734_overbetuwe/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,29.31574
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.24467
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.57721
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.38397
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,52.65495
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,10.91424
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06614
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07237
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.09305
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01408
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0008
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.69414
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.72669
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,55.3548
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.32612
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.05093
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.11462
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15284
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03306
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.96425
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,9.35533
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.1817
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.64212
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.18632
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.22074
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.81592
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.68882
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13981
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,145.22581
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.22216
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.34959
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.12374
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.189
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.76024
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.31791

--- a/datasets/GM1735_hof_van_twente/emissions.csv
+++ b/datasets/GM1735_hof_van_twente/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,87.31669
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.39175
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.05981
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.74408
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,184.07411
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.76608
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08302
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05774
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0008
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00071
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00056
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.67501
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.50708
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,56.11574
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.33942
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.85674
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02246
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,24.89324
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19125
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04081
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.80018
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.99904
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.1029
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.75974
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.12609
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.85182
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.79345
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.66985
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09756
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,80.37651
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.87708
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.80326
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.97656
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.65551
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.60699
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.50748

--- a/datasets/GM1740_neder_betuwe/emissions.csv
+++ b/datasets/GM1740_neder_betuwe/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,32.64719
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.80549
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.30973
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.16991
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,23.48884
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,6.86553
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04164
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04547
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00041
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.38928
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.36351
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,29.99308
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.74542
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.55014
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.7138
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.36476
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0386
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,51.62738
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,17.06687
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.06675
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.13006
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.2261
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.61065
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.45758
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.3863
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06994
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,79.64713
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.69282
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.38018
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.55035
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.01533
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.08261
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.39076

--- a/datasets/GM1742_rijssen_holten/emissions.csv
+++ b/datasets/GM1742_rijssen_holten/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.71392
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.17263
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.74732
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.26508
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,59.64517
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.09884
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09115
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08131
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.01188
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01566
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00068
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00061
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.64229
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.5572
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,49.4198
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.225
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74263
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.60965
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14195
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05238
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,6.49582
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.09539
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12103
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.15154
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.02302
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.93602
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.75498
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.63737
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1072
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,79.02075
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81437
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.23741
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.34965
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.9095
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.42815
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.00517

--- a/datasets/GM1771_geldrop_mierlo/emissions.csv
+++ b/datasets/GM1771_geldrop_mierlo/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,24.93628
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.44126
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.17074
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03919
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,7.3621
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.63827
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07666
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04498
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00065
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.69425
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.5946
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,54.62138
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.26687
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.74202
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,24.43674
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14596
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02196
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.33526
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.16849
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.10189
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.05029
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00553
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.18667
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.99885
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.81605
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.68893
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.1144
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,48.50693
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56591
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.95458
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19973
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.12273
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.08935

--- a/datasets/GM1773_olst_wijhe/emissions.csv
+++ b/datasets/GM1773_olst_wijhe/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,19.43283
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18398
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.77699
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.45453
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,91.12319
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.60423
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03399
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01946
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00033
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00029
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.31704
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.26846
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,25.74637
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62392
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4518
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.80841
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02149
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00673
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.39855
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.52984
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.04584
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.52941
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.99857
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.45098
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.37266
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.31461
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05165
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,37.43142
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40186
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37154
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.31485
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.82706
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.19187
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.67133

--- a/datasets/GM1774_dinkelland/emissions.csv
+++ b/datasets/GM1774_dinkelland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,33.69482
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.67878
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.83317
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.70096
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,164.00127
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.66785
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04651
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04383
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.00514
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02157
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0024
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00049
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00043
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.46983
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.39179
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,40.68187
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.97212
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.70201
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.44974
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09207
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.023
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.62989
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.76998
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08142
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.70487
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.47982
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.65814
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.55226
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.46623
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07538
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,53.91527
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.58486
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.56735
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.36126
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.4517
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.86408
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.90901

--- a/datasets/GM1783_westland/emissions.csv
+++ b/datasets/GM1783_westland/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,52.40207
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,234.92802
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.40758
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07096
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.65264
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,55.32041
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.33523
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24505
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,61.17704
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.59388
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01015
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00068
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00186
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.02944
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.76562
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.75518
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,128.60287
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.12551
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.01239
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,8.46212
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,27.54813
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55468
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09952
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.02517
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,3.35825
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.77672
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,9.02666
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00152
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.56115
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.87093
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.07539
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.7521
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.32881
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,156.74835
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.85703
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.57486
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07263
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.23276
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.19999

--- a/datasets/GM1842_midden_delfland/emissions.csv
+++ b/datasets/GM1842_midden_delfland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,4.47748
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,32.27877
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.32617
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.21091
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,37.59599
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.85186
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03507
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03853
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.64289
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.09727
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00133
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00023
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.05467
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.21521
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.40545
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,20.74681
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.43454
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3798
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6.84709
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02112
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00459
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.24549
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.61811
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.63015
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.55145
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.67786
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.52834
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.25297
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.21357
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06051
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,43.7555
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39104
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1482
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,20.79765
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.30015
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,23.21378

--- a/datasets/GM1859_berkelland/emissions.csv
+++ b/datasets/GM1859_berkelland/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,73.11028
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.35333
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.12609
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.01632
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,233.75945
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,18.94639
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1324
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06276
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.00171
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00719
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0009
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00069
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.85179
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.63248
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,69.01187
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.68428
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0479
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,7.46658
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,99.93946
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24608
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1792
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.70374
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.24289
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.15103
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.71833
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00223
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.68289
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.06248
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.00124
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.84527
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12169
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,89.17735
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.97909
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.86604
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,13.37566
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.57016
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,122.24513
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.26117

--- a/datasets/GM1876_bronckhorst/emissions.csv
+++ b/datasets/GM1876_bronckhorst/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,66.88354
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19296
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.37606
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.0591
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,207.67971
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.8634
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0767
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09883
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.50428
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01797
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00075
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.71119
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.5246
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,60.80578
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.46728
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.93561
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.49307
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.16039
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.20655
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.9031
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.03208
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13092
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.05365
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.24002
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.88126
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.83597
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.70574
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10093
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,88.37147
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.9466
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.85059
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.78012
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.4983
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,5.45216
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,23.76613

--- a/datasets/GM1883_sittard_geleen/emissions.csv
+++ b/datasets/GM1883_sittard_geleen/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.4124
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0251
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.09651
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07079
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,11.25089
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,65.94298
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.39998
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.21889
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.57024
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02102
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.06012
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00191
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00147
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.81989
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.34548
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,153.85548
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.45648
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.75426
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,139.87385
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,3.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,457.77663
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,372.79591
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.61416
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6858.32027
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.59506
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13499
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.21924
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.64553
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.08689
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.01703
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.02505
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.7321
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.26021
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,2.13919
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.80595
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.25886
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,159.83871
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.67569
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.60002
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.98051
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.22948
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.52324

--- a/datasets/GM1884_kaag_en_braassem/emissions.csv
+++ b/datasets/GM1884_kaag_en_braassem/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.48704
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.44797
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.45459
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.28424
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,52.76765
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.27641
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04413
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03888
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00044
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.48535
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.40645
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.74553
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.88746
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.58765
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,5.11338
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02206
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0169
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.7357
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.79931
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07919
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.68573
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.5287
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.68278
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.5705
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.48163
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0782
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,90.27414
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85128
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.36041
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.95958
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.12183
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.31371
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.86814

--- a/datasets/GM1891_dantumadiel/emissions.csv
+++ b/datasets/GM1891_dantumadiel/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,24.88106
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08317
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.70718
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.42624
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,69.13926
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,4.42966
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.02687
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01744
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,19 +23,19 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0004
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0003
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.37732
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.27613
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,33.31743
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.78782
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.51838
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.78204
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.01384
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01076
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.5477
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.5427
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.05232
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.42848
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.18844
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.46386
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.44352
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.37443
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.05313
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,28.26984
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.32476
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.30444
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.77746
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.56317
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.98447
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.69119

--- a/datasets/GM1892_zuidplas/emissions.csv
+++ b/datasets/GM1892_zuidplas/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,12.33531
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,21.91662
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.22728
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.13238
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,12.98219
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.2272
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07297
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0746
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,22.84619
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.42485
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00067
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00078
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.64036
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.71619
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,49.30492
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.15139
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.85857
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,6.9688
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,9.81602
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10444
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18964
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.731
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.40886
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.75642
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.45694
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00125
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.01694
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.2031
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.75271
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.63546
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.13779
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,96.56634
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.87835
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.57967
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.67892
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.65091
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.41602
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.11904

--- a/datasets/GM1894_peel_en_maas/emissions.csv
+++ b/datasets/GM1894_peel_en_maas/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,182.17546
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,32.92098
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.41427
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.29929
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,81.65271
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.68033
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08902
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06519
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.08459
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0128
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0008
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00072
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.75748
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.65366
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,61.65075
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.47869
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.07933
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,30.36407
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.32935
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13192
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04538
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,12.67814
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,27.69338
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.21265
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.28044
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00544
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.38584
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.09805
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.89038
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.75168
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12576
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,110.3688
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.1285
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.49559
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.28758
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.19491
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.73174
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.31239

--- a/datasets/GM1895_oldambt/emissions.csv
+++ b/datasets/GM1895_oldambt/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,13.95733
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08043
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.69563
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.71399
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,81.85351
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,19.00463
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11446
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.20302
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03072
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.09085
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00082
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,3.70674
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.78139
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,6.7658
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,74.91759
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.66232
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.96579
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,8.95989
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,28.6954
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,4.32542
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.02358
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,3e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,72.67996
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.79969
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08065
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.06815
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.10571
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.67976
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.41552
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0016
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.46115
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.94444
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.91849
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.77541
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10817
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,95.94557
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.96223
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.94402
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.16601
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.91897
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.83814
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.09132

--- a/datasets/GM1896_zwartewaterland/emissions.csv
+++ b/datasets/GM1896_zwartewaterland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2.21539
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.43422
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.14796
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.39709
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,90.38763
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.291
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05635
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04613
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0423
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0064
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00037
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.3743
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.33706
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,27.55676
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.68025
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.49189
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,20.66433
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08515
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06055
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.8311
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.66371
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07054
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.6601
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.17892
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.56622
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.43997
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.37143
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.06485
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,32.97546
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.37431
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.37198
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1842
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.8579
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.99879
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.82397

--- a/datasets/GM1900_sudwest_fryslan/emissions.csv
+++ b/datasets/GM1900_sudwest_fryslan/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,26.71569
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.30598
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.85543
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.03854
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,529.14435
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,32.56472
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19742
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14878
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.15569
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03741
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00347
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00169
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00143
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.60392
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.30572
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,141.55171
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.2231
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.06679
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,15.92869
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,62.3362
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.65722
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.11604
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.89918
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.5725
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.32115
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.92694
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00285
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.05186
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.19343
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.88533
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.59164
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.25121
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,210.65377
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.11395
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.50533
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.46911
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.14155
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.9064
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.44321

--- a/datasets/GM1901_bodegraven_reeuwijk/emissions.csv
+++ b/datasets/GM1901_bodegraven_reeuwijk/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.00322
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13677
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.27125
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.3517
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,75.04819
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.37897
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07508
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06356
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00062
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0006
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.59182
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.54561
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,45.564
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.08452
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6758
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,51.76889
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.85801
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0175
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.68255
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.07266
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.08863
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.35501
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.86405
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.91654
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.69566
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.58729
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10497
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,137.56043
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.17004
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.7519
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.05626
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.09051
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.39193
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.97903

--- a/datasets/GM1903_eijsden_margraten/emissions.csv
+++ b/datasets/GM1903_eijsden_margraten/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.91856
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04727
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.02459
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.15578
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,30.06125
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,5.73693
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0348
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03032
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00051
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00041
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.48285
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.37393
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,41.2458
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.97192
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.61463
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,6.18205
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0453
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,35.31711
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.06533
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01215
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.40913
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.73505
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10597
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.84766
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00223
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.52084
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.62814
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.56757
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.47915
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07194
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,42.38784
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47455
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4857
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.10712
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.4047
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.06899

--- a/datasets/GM1904_stichtse_vecht/emissions.csv
+++ b/datasets/GM1904_stichtse_vecht/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.00273
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.3888
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.39584
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.41579
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,79.43238
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,26.07889
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15751
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09688
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00124
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00102
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.18035
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.93493
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,80.88587
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.00696
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.21306
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,3.98217
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,6.1512
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.01165
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,18.26249
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.83755
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01404
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.35852
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.86489
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.14963
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.62018
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00071
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.71774
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.57055
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.38744
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.17131
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.17987
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,201.51237
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.83913
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.77554
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.53697
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.69574
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.68973
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.81665

--- a/datasets/GM1911_hollands_kroon/emissions.csv
+++ b/datasets/GM1911_hollands_kroon/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,9.6497
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,16.87313
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.9167
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.91773
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,119.29474
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.53416
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07603
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13596
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.09305
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01408
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00347
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00088
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00078
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.83315
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.7113
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,73.15567
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.70768
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.1817
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,7.46658
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.34504
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22946
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.15522
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,2.85578
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.39995
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.14407
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.60793
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00366
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.62417
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.19489
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.89579
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.84296
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,5.54512
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,133.89126
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.31094
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.71681
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.42715
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.25598
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.97168
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,52.46004

--- a/datasets/GM1916_leidschendam_voorburg/emissions.csv
+++ b/datasets/GM1916_leidschendam_voorburg/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.04721
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.71511
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.15394
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.08536
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,13.83663
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,42.04485
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25422
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10044
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.37036
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.20733
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00214
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0014
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00119
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.32745
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.09147
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,91.75207
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.13588
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0965
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,4.47995
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7.70936
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17459
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00787
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.51367
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.14488
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.40768
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.80064
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0008
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.18105
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.83351
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.56035
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.31728
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.20999
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,119.71404
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.24276
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.45284
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03424
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.25294
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.03065

--- a/datasets/GM1924_goeree_overflakkee/emissions.csv
+++ b/datasets/GM1924_goeree_overflakkee/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,5.59426
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.10144
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1059
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.50287
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,58.31545
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.09973
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09159
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07097
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.50257
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01078
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00089
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00081
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.84376
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.74177
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,70.98525
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.64747
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.13018
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8.8294
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.12742
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03267
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.96689
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.4743
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.36444
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.39063
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.65759
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.24607
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.9918
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.8373
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14271
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,116.57869
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.23605
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.50015
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.61619
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.87325
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.511
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.79008

--- a/datasets/GM1926_pijnacker_nootdorp/emissions.csv
+++ b/datasets/GM1926_pijnacker_nootdorp/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.8766
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,37.85975
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26947
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.07299
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,6.82432
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,8.92859
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.05414
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06311
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00267
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00047
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00093
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.44287
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.84613
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,35.30867
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.81407
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.93015
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.06065
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0191
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00811
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.50511
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.66294
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12189
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.75789
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.39491
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.42138
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.52057
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.43948
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16279
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,54.33088
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.619
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.4986
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.26117
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.1625

--- a/datasets/GM1930_nissewaard/emissions.csv
+++ b/datasets/GM1930_nissewaard/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.60499
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.1318
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.16357
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.18793
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,22.62507
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,26.371
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15944
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08986
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.77823
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.11774
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0018
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00161
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.07476
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.52745
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.38909
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,106.52965
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.55766
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.37426
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.99554
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,11.64128
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.03974
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01852
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.75483
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.49737
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.78017
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.61194
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00018
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.811
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.12715
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.79544
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.51575
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.24362
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,99.68435
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.24992
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.82837
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.82512
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.87173
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.82284
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.42119

--- a/datasets/GM1931_krimpenerwaard/emissions.csv
+++ b/datasets/GM1931_krimpenerwaard/emissions.csv
@@ -1,48 +1,48 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,20.15083
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.27454
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.26559
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.67586
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,136.27903
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,17.66953
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.10708
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07777
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.73096
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04534
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00104
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00095
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.98559
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.86563
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,80.51611
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.87018
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.20065
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,13.43984
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.00045
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,25.8643
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.49386
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05947
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.32881
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.71355
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.31738
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.54536
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00241
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.1043
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.45414
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.15851
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.97804
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16654
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,90.05518
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.03405
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.9266
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.96922
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.66269
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.07585
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.06502

--- a/datasets/GM1940_de_fryske_marren/emissions.csv
+++ b/datasets/GM1940_de_fryske_marren/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,27.21756
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.32346
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.40911
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.59586
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,339.57832
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.1787
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09204
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08597
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.05075
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00768
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00093
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00082
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.88859
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.74791
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,81.94931
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.85046
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.33745
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.99554
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,71.07677
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.4738
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05272
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.04712
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.47675
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.18442
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.56398
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00018
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.79879
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.25638
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.04449
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.88179
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14389
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,133.10146
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.21529
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.88356
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.19244
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.02218
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.81381
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.76707

--- a/datasets/GM1942_gooise_meren/emissions.csv
+++ b/datasets/GM1942_gooise_meren/emissions.csv
@@ -1,20 +1,20 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.72784
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.00512
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.07003
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.05818
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.29012
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.47615
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14846
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10017
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
@@ -23,27 +23,27 @@ Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00114
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00095
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.08297
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.86783
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,89.13441
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.99894
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.02482
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.01261
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.09283
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,21.46846
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.17745
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09834
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.24311
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.70867
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13289
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.50235
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.41103
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.45783
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.27298
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.07468
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16696
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,160.5201
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.45961
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.41456
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.24847
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.19043
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,29.17141

--- a/datasets/GM1945_berg_en_dal/emissions.csv
+++ b/datasets/GM1945_berg_en_dal/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,34.76323
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.3215
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.20154
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.17185
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,27.95976
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,9.96941
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0602
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03875
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.40603
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.06143
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00068
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00056
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.64504
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.51142
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,52.92864
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.25265
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79511
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,3.48482
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13357
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01494
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,22.14032
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,13.45924
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.44363
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.81326
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.03169
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.85911
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.75822
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.6401
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.09839
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,53.43268
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62652
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.46151
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.51753
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.02293
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.88416
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.84181

--- a/datasets/GM1948_meierijstad/emissions.csv
+++ b/datasets/GM1948_meierijstad/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,147.54745
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.94903
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.19656
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.45279
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,178.74117
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,38.92314
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.23541
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24006
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,24.94799
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.23756
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00143
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00133
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.36168
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.2167
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,107.37304
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.57688
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.69598
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,6.47103
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -49,15 +49,15 @@ Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00044
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,136.89932
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.92863
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.50189
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.78192
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.39164
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.8514
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.33104
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00116
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.28888
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.04389
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.60059
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.35125
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.23409
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,130.78027
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.52264
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.22808
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.87966
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.65345
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.90122
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,113.60464

--- a/datasets/GM1949_waadhoeke/emissions.csv
+++ b/datasets/GM1949_waadhoeke/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,15.66079
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,18.38615
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.39074
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.29251
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,190.49132
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.81576
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08325
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05573
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.00846
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00128
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00095
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.90084
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.66973
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,80.0965
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.85098
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.23267
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.05902
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,25.57637
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,29.03943
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.47093
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.02058
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.04911
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.31693
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13953
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.40632
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.83737
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.12506
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.05889
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.89394
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12885
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,95.6216
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.96986
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09201
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.31014
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.40827
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.67183
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.63591

--- a/datasets/GM1950_westerwolde/emissions.csv
+++ b/datasets/GM1950_westerwolde/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,35.89427
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.26885
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.70377
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.88844
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,90.53003
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,7.2016
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.04356
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0275
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.01188
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01566
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00036
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00053
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0151
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.50127
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.40042
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,50.40672
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.14585
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.73657
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,1.02362
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.15295
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,82.83961
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19141
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.98776
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.57134
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.73857
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.07432
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.70265
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,1.57886
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.63135
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.58922
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.49744
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.07231
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,56.72902
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56281
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.51777
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.37447
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.24932
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.67699
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.52691

--- a/datasets/GM1952_midden_groningen/emissions.csv
+++ b/datasets/GM1952_midden_groningen/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,22.42155
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.09864
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.46135
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.96248
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,104.18278
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,24.76322
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15017
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07722
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2.59733
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.03205
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01443
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,111.96913
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.249
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.09005
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,118.86377
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,3.67444
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,118.84282
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,7.03623
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,103.47435
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.38329
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.43869
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,12.94206
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,180.80507
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.63016
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28101
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,85.76481
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,20.49157
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.30514
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.55279
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00232
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.69709
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.49055
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.37974
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.16481
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.17071
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,130.42441
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.31821
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.7166
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.81409
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.94952
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.31896
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.00562

--- a/datasets/GM1954_beekdaelen/emissions.csv
+++ b/datasets/GM1954_beekdaelen/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,7.78566
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0114
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.01157
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10777
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,18.74033
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,30.41958
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55807
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09875
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.03384
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00512
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00079
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00057
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.74895
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.52009
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,64.73616
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.49214
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.88673
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,3.39344
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,1470.6415
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,27.83114
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.46602
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01407
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,5.95998
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.02207
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.10025
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.86928
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.35897
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.87368
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.88036
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.74322
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10006
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,76.74259
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.84093
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.7546
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,233.23921
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.725
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2531.60404
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,32.05372

--- a/datasets/GM1955_montferland/emissions.csv
+++ b/datasets/GM1955_montferland/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,35.81364
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14903
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.00611
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.33435
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,70.91434
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,12.83301
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.07765
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07338
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00069
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00058
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.65775
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.53287
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,54.26442
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.29085
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.80862
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,3.98217
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,12.01006
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.1
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06096
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.22788
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,4.11467
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.11408
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.22373
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00071
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.0717
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.89515
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.77315
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.65271
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.10252
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,60.59035
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.67601
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.68461
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.81687
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.03632
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.19596
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.68333

--- a/datasets/GM1959_altena/emissions.csv
+++ b/datasets/GM1959_altena/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,11.9846
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.72986
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.67223
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.61051
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,75.2997
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.96321
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09027
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08139
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1.73765
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.11853
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00101
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0009
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.96138
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.82551
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,76.88747
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.86431
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.27604
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,12.49345
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11932
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04113
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.12627
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.64457
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.80118
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.91469
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.02806
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.38673
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.13006
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.95402
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.15882
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,136.46493
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.29022
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.7124
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.18841
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.86361
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.32963
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,3.26538

--- a/datasets/GM1960_west_betuwe/emissions.csv
+++ b/datasets/GM1960_west_betuwe/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,31.8804
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.64781
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.41702
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.81002
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,133.91435
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,21.67457
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.18997
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12481
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00088
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00084
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.8385
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.76815
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,72.34174
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.70238
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.21736
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,5.97326
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.11803
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,51.15275
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,19.348
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.56182
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.14764
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,49.37392
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,14.89166
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.18404
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.72263
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00107
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.64102
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.29038
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.98561
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.83208
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.14779
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,231.55997
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.95233
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.79322
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,37.7068
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.1842
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,397.54757
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,14.49104

--- a/datasets/GM1961_vijfheerenlanden/emissions.csv
+++ b/datasets/GM1961_vijfheerenlanden/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,16.56642
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.085
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.19162
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.66763
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,106.91964
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,23.09403
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.13987
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.13799
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.34682
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.05247
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00053
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00105
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00094
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.00281
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.86044
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,74.27893
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.81687
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.13517
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,8.46212
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,16.84873
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.40608
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03271
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,81.03723
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,100.88747
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.57845
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.78992
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00152
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.15854
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.44542
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.17875
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.99513
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16554
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,190.66132
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.66194
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.99476
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.07966
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.167
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.76082
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.51308

--- a/datasets/GM1963_hoeksche_waard/emissions.csv
+++ b/datasets/GM1963_hoeksche_waard/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.69634
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.18866
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.1857
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.64052
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,44.58045
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.70779
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15563
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12303
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.08795
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.10628
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.08203
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00073
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00162
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0313
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.53866
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.33308
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,121.51099
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.90929
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.78566
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,390.45567
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.56568
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10674
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,4.13164
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.57119
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.66344
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.05433
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00259
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.8463
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.15532
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.80861
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.52688
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.24685
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,181.22521
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.8753
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.44548
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.49074
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.57216
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.98601
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.17422

--- a/datasets/GM1966_het_hogeland/emissions.csv
+++ b/datasets/GM1966_het_hogeland/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.63623
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.77994
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.81129
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.81489
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,196.79803
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,13.24533
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08034
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05063
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1575.01557
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.6865
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,19.84224
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.01443
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.001
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.59332
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.9546
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.84928
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,89.8247
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.06839
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.32945
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,27.84647
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.19921
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.01674
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.15745
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.35781
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.13732
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.09945
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.00671
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.15955
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,51.10509
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,6.58916
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,19.18694
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,115.347
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.16214
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.99158
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.51983
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.04437
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3.43803
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.175

--- a/datasets/GM1969_westerkwartier/emissions.csv
+++ b/datasets/GM1969_westerkwartier/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,56.754
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.71441
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.94375
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.85009
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,283.68004
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,23.64098
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.25668
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.09003
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.3299
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.04991
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00107
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00602
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01915
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.24645
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,6.65129
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.33315
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,97.1888
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.30784
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.64558
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,51.27049
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,25.07028
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08024
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04037
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.32391
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.81583
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.459
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.70139
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,621.00026
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,12.87119
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00918
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.45851
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.54935
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.2907
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.08964
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.17745
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,136.60336
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.33891
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.99799
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,72.97235
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.92425
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,770.88051
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.95737

--- a/datasets/GM1970_noardeast_fryslan/emissions.csv
+++ b/datasets/GM1970_noardeast_fryslan/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,17.2491
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2654
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,3.7425
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.67862
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,250.73162
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,15.06619
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.09138
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.05974
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01095
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.02814
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00095
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,1.14867
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.9018
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,2.57517
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,80.10055
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.86402
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.18872
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,14.68163
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0532
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.04124
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.03621
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.2852
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.05507
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.32293
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.84039
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.09801
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.06002
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.89489
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12575
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,82.07991
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.86538
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.81256
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.47609
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.00218
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.56912
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1.60113

--- a/datasets/GM1978_molenlanden/emissions.csv
+++ b/datasets/GM1978_molenlanden/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,8.14772
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.18732
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.62455
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.97341
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,227.6698
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,14.13222
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.08572
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08311
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.01692
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.00256
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00083
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00072
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.79133
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.65696
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,61.64142
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.50238
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.97155
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -43,7 +43,7 @@ Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,15.59522
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.24149
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.03785
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.97451
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.3084
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.12716
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.42658
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00027
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,2.49245
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.1036
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.93017
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.78527
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12639
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,103.79424
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.03646
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.24536
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.39247
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.67239
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.69421
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.55972

--- a/datasets/GM1979_eemsdelta/emissions.csv
+++ b/datasets/GM1979_eemsdelta/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,17.53216
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.28081
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.67517
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.14708
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,134.47582
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,23.38781
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.14173
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06301
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,886.16712
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.02376
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,7.2944
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00422
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00115
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.17278
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.089
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.93943
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,93.32222
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.15846
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.12345
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,3.16785
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,1.40692
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,4.0793
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2.40186
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1025.38212
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.62663
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12333
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,31.79626
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.28351
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,1.46924
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.7563
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.43001
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.09428
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.28006
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.08066
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.12533
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,102.54703
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.12544
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.86193
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.45925
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.17167
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,1.02209
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,9.09946

--- a/datasets/GM1980_dijk_en_waard/emissions.csv
+++ b/datasets/GM1980_dijk_en_waard/emissions.csv
@@ -1,44 +1,44 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,22.14945
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.23796
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.16762
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.10833
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,17.33885
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.51223
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15474
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.12486
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.16072
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02432
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00116
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00141
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.09858
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.29054
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,87.17133
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.05449
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.61631
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.99109
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,41.07625
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.38289
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.06773
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.26189
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.53683
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.21351
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,3.30263
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00036
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.4602
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.16793
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.29133
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.09017
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.24829
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,93.74775
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.12617
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.10344
 Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
 Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.56215
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.36905

--- a/datasets/GM1982_land_van_cuijk/emissions.csv
+++ b/datasets/GM1982_land_van_cuijk/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,295.70096
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.23121
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,4.09368
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.8189
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,318.20164
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,38.02124
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.22949
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.19171
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,32.72483
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.25924
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.00134
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00167
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00144
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.59068
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.31705
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,131.36043
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.12408
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.12587
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,98.5588
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.01847
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00017
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,75.77926
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.28151
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.07053
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.88923
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,18.27529
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,2.06366
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,4.67325
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01765
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,5.01016
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,2.21246
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.86977
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.5785
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.25339
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,177.51884
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.87419
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.89949
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,2.5105
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.00116
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,4.33757
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,26.94261

--- a/datasets/GM1991_maashorst/emissions.csv
+++ b/datasets/GM1991_maashorst/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,110.97912
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.44494
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.43601
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.25116
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,112.64673
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,25.28006
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.15334
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.2637
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.11843
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.01792
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00101
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00093
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.95649
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.85281
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,75.82319
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.80363
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.20369
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,1.99109
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00184
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,17.06614
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11073
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0394
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.12937
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,1.67603
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.21741
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,2.29291
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00036
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,3.01266
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.4326
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.12431
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.94917
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.16407
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,112.54084
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.26821
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.61988
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.2032
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,1.2804
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.42984
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,10.55141

--- a/datasets/GM1992_voorne_aan_zee/emissions.csv
+++ b/datasets/GM1992_voorne_aan_zee/emissions.csv
@@ -1,41 +1,41 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,3.53246
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,24.73168
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.03265
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.2114
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,19.8662
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,18.43382
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.11181
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.08439
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3.03051
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.02541
 Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00134
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00117
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,1.27533
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,1.06845
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,98.63962
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.32261
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.39565
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4.19688
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0894
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.10446
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,1.4824
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,2.09975
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.16154
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,1.73995
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,4.01689
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,1.79484
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,1.49908
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,1.26556
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.20556
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,115.31697
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.35922
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09675
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.46152
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.73657
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2.42532
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2.8947

--- a/datasets/PV20_groningen/emissions.csv
+++ b/datasets/PV20_groningen/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,174.33428
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.37685
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,16.40796
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,8.74387
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1028.50233
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,290.72267
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.87433
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.88068
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2788.46364
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,4.78519
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,27.4765
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,111.96913
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.249
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.20694
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,118.89197
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,8.45476
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,134.44234
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,23.88967
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,918.33106
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.11319
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.79642
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,105.02983
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,55.08724
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,6.75596
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,4.32945
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,4.61953
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,2106.85276
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.81642
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.8389
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,137.01329
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,41.10954
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,10.71082
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,21.38802
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,621.00026
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,12.87119
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01881
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,34.26248
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,14.38984
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,62.76958
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,16.4366
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,21.30994
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1061.35599
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,11.37688
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.76469
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,96.26775
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,35.95656
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,817.35578
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,143.74978

--- a/datasets/PV21_fryslan/emissions.csv
+++ b/datasets/PV21_fryslan/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,261.78011
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,22.10988
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,21.87271
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,14.54267
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2597.64405
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,268.1587
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.6214
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.09321
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1675.67455
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,2.56145
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,3.68634
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.03827
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.01232
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,1.57165
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,11.71931
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,12.09241
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,1027.45993
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,23.49323
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,15.19491
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,35.83956
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.05902
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.00111
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,25.57637
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00017
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,423.5949
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.26739
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.72442
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,16.80041
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,18.66387
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,9.96838
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,21.83087
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00945
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,36.91226
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,15.92341
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,14.61447
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,11.66642
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.8237
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1232.07321
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,12.95127
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,16.15289
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,29.4359
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,28.1605
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,30.74222
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,58.66305

--- a/datasets/PV22_drenthe/emissions.csv
+++ b/datasets/PV22_drenthe/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,335.40918
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,17.00108
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.6024
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,7.73816
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,1092.59278
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,229.35443
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.81277
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.0607
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,199.21347
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.77229
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,23.44275
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,173.61537
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,1.2337
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.02316
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,79.25073
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.95259
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,87.04106
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,8.81286
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,737.94353
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,17.087
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,11.59321
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,14.43538
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.25943
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,1.00635
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,466.26132
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,2.82584
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.92468
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,16.53348
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,14.21371
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,8.3466
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,16.67564
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00954
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,27.07177
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,12.14805
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,10.10305
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,8.52923
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.39131
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,995.02288
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.10022
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.52267
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,291.66103
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,42.35067
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2914.19249
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,218.40151

--- a/datasets/PV23_overijssel/emissions.csv
+++ b/datasets/PV23_overijssel/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,753.01824
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,19.7822
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,23.08712
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,11.21383
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2505.80462
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,533.58707
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.50937
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.10051
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1673.95268
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,3.07969
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,53.99278
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,111.7073
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.3735
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00772
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,178.31478
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.3337
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,196.45886
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,18.2676
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,1534.9053
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,36.91892
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,23.22901
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,252.37026
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.29219
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,28.49071
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,1.13263
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,36.69514
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00069
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,930.29484
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.27722
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,1.47902
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,38.39614
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,33.638
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,18.29648
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,38.87946
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.05555
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,62.82812
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,28.7369
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,158.80313
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,23.35339
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,10.63375
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1885.79427
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,20.74144
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,24.73722
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,236.02026
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,55.71298
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,2035.28765
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,101.31921

--- a/datasets/PV24_flevoland/emissions.csv
+++ b/datasets/PV24_flevoland/emissions.csv
@@ -1,49 +1,49 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,52.76245
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,13.66823
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.68491
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,2.50114
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,361.84039
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,85.0758
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.55733
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.6802
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1223.1597
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,1.61212
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.75937
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00435
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00704
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,4.13386
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,6.43358
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,265.21843
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,6.87048
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,7.33271
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,21.90196
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,6e-05
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -51,13 +51,13 @@ Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,68.49043
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.28086
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.24587
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,6.02985
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,12.69441
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.05778
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,17.86284
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00526
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,13.0204
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,10.8075
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,4.85915
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,4.10221
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.23778
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,720.41051
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.04195
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.06258
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,34.00742
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,34.86517
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,300.85986
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,174.46494

--- a/datasets/PV25_gelderland/emissions.csv
+++ b/datasets/PV25_gelderland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1685.44604
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,63.15682
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,34.93713
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,13.48029
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2706.45412
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,937.30795
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,5.76465
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,4.07249
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,4347.89526
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,19.46759
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,42.25555
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.16627
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0002
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.03707
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.04939
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,35.31698
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,33.25632
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,2744.4485
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,65.67347
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,41.54246
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,304.13852
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,15.23053
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,18.38832
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.38494
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,16.55054
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,51.15275
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,1798.95947
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,14.15845
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,17.61325
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,587.07474
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,290.17047
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,26.66177
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,87.87343
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -65,14 +65,14 @@ Industry,Other metals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.02165
 Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.09326
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,111.03732
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,51.90087
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,42.93556
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,34.99615
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,6.68073
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,4209.7848
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,43.00178
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,56.19143
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,142.41363
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,177.47955
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,901.05991
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,584.8747

--- a/datasets/PV26_utrecht/emissions.csv
+++ b/datasets/PV26_utrecht/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,181.12343
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,16.93488
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.04926
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,4.87807
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,910.45243
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,564.60186
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,3.46175
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.0311
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,1393.9092
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,3.43908
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,3.16948
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.02176
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.022
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,21.69974
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,20.18553
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,1429.63406
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,35.22183
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,22.65098
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,57.74152
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,49.1174
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.84525
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.03295
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,6.86972
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,971.90221
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,372.26776
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.44046
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.79533
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,137.99833
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,148.59464
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,44.80257
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,57.03375
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01141
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,65.19072
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,33.75913
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,24.32884
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,20.53898
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,3.86642
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,2494.92352
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,24.81221
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,32.56048
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,91.96528
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,50.6652
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,458.25967
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,105.58758

--- a/datasets/PV27_2022_noord_holland/emissions.csv
+++ b/datasets/PV27_2022_noord_holland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,87.26063
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2022,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2022,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2022,kton CO2-eq,75.66146
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.1292
+Agriculture,Non-specified,non_energetic,co2,2022,kton CO2-eq,6.16355
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2022,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2022,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2022,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2022,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2022,kton CO2-eq,918.22606
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1498.95079
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.04994
+Buildings,Non-specified,energetic,other_ghg,2022,kton CO2-eq,6.64249
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2022,kton CO2-eq,90.46196
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2022,kton CO2-eq,389.13233
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2022,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2022,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2022,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2022,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2022,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6587.86657
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,9.65908
+Energy,Electricity and heat production,energetic,other_ghg,2022,kton CO2-eq,44.84345
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,17.45674
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.39495
+Energy,Fuels production,energetic,other_ghg,2022,kton CO2-eq,0.01372
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.04903
+Energy,Fugitive emissions,non_energetic,co2,2022,kton CO2-eq,0.42813
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,46.9606
+Energy,Fugitive emissions,non_energetic,other_ghg,2022,kton CO2-eq,41.81578
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2022,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2022,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2022,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,3469.64805
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,80.14554
+Households,Non-specified,energetic,other_ghg,2022,kton CO2-eq,54.1172
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2022,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,2022,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2022,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2022,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,45.795
+Industry,Aluminium,non_energetic,other_ghg,2022,kton CO2-eq,0.05835
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,38.39875
+Industry,Chemicals,non_energetic,co2,2022,kton CO2-eq,11.68267
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,1.00418
+Industry,Chemicals,non_energetic,other_ghg,2022,kton CO2-eq,2.42561
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2022,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2277.00147
+Industry,Fertilizers,non_energetic,other_ghg,2022,kton CO2-eq,0.03979
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2022,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2022,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2022,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2022,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2022,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7391.09854
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,33.28916
+Industry,Non-specified,energetic,other_ghg,2022,kton CO2-eq,15.84974
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,98.94562
+Industry,Other,non_energetic,co2,2022,kton CO2-eq,83.3231
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,44.09669
+Industry,Other,non_energetic,other_ghg,2022,kton CO2-eq,146.43944
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2022,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2022,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2022,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,39.80325
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.09503
 Industry,Refineries,energetic,other_ghg,2022,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2022,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01364
 Industry,Steel,non_energetic,co2,2022,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2022,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2022,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2022,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2022,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,146.88441
+Other,Indirect emissions,non_energetic,co2,2022,kton CO2-eq,75.67281
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2022,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2022,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2022,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2022,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2022,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,66.87498
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,46.59827
+Other,Other transportation,energetic,other_ghg,2022,kton CO2-eq,20.07185
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,4131.1435
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,44.88679
+Transport,Non-specified,energetic,other_ghg,2022,kton CO2-eq,48.59123
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,68.6032
+Waste,Non-specified,non_energetic,co2,2022,kton CO2-eq,124.73934
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,95.75848
+Waste,Non-specified,non_energetic,other_ghg,2022,kton CO2-eq,406.83782

--- a/datasets/PV27_noord_holland/emissions.csv
+++ b/datasets/PV27_noord_holland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,87.26063
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,83.50712
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,8.1292
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.35392
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,906.81828
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1498.95079
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.04994
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.83731
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6587.86657
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,9.65908
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,44.02417
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,17.45674
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.39495
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00823
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.04903
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.38496
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,46.9606
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,44.03351
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,3469.64805
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,80.14554
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,46.997
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,45.795
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,38.39875
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,12.18611
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,1.00418
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,2.08848
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2277.00147
+Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.03976
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,7391.09854
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,33.28916
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,12.66967
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,98.94562
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,84.15032
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,44.09669
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,142.29319
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,39.80325
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.09503
 Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.01364
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,146.88441
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,71.84284
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,66.87498
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,46.59827
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,17.23911
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,4131.1435
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,44.88679
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,49.39322
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,68.6032
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,129.5422
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,95.75848
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,389.98028

--- a/datasets/PV28_zuid_holland/emissions.csv
+++ b/datasets/PV28_zuid_holland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,194.15449
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,516.17038
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,7.02459
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,6.09846
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,966.88092
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1674.05228
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,10.24601
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,6.83027
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,9304.04228
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,36.20833
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,38.67194
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,3.88083
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,7.09207
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.11274
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.06516
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.82579
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,62.23101
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,59.91354
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,4263.59202
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,102.31831
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,57.92573
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,146.34488
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,188.48507
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,18.99459
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,27.66383
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,92.36372
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,12.49947
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4870.76278
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,21.06005
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,34.81652
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,283.54605
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,116.51107
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,52.43984
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,155.73778
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,9004.85044
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,32.22182
+Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,88.04124
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.20694
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.11092
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,195.18199
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,92.57371
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,72.84092
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,61.49402
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,21.09753
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,5261.22219
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,56.25232
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,64.78865
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,124.48637
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,108.83363
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,127.13164
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,131.79034

--- a/datasets/PV29_zeeland/emissions.csv
+++ b/datasets/PV29_zeeland/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,85.3783
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,27.08842
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,1.90298
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.95795
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,351.84444
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,182.41183
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.19653
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.69752
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,2517.32185
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,10.66722
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.01095
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,108.83033
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,9.49572
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,4.93062
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.00733
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.00615
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,6.97151
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,5.61515
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,624.50202
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,13.87279
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,8.6506
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,43.30614
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,232.72867
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.88714
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,37.04997
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,7.56405
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,2534.13953
+Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,88.14345
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,6151.52609
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,1.7961
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.93298
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,9.25668
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,11.31747
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,5.6184
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,28.46482
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -66,13 +66,13 @@ Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Refineries,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Refineries,energetic,co2,1990,kton CO2-eq,826.4524
+Industry,Refineries,energetic,other_ghg,1990,kton CO2-eq,3.50748
+Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.01533
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.00776
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,21.95813
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,9.43265
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,8.19466
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,6.91813
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,1.08032
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,823.48498
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,8.69794
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,10.51504
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,87.11616
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,22.38574
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,699.56712
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,89.34236

--- a/datasets/PV30_noord_brabant/emissions.csv
+++ b/datasets/PV30_noord_brabant/emissions.csv
@@ -1,63 +1,63 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,2397.48248
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,164.33376
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,37.94178
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,10.08073
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,2958.09909
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,1197.14048
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,7.8043
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,5.4714
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,6786.33366
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,29.20473
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,45.296
 Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
 Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.00039
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.04501
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0575
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,43.02595
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,38.00273
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,3315.86451
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,78.94509
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,49.91871
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,502.25166
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,204.03259
+Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,19.91564
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,11.5164
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,24.30031
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,166.24643
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00139
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,4365.86171
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,22.10649
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,3.63498
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,280.41977
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,285.373
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,36.746
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,110.73289
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.18341
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,134.8422
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,63.79437
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,145.48359
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,49.26675
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,9.76416
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,4204.25872
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,45.01334
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,65.05069
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,459.01726
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,135.80928
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3934.1653
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,471.4868

--- a/datasets/PV31_limburg/emissions.csv
+++ b/datasets/PV31_limburg/emissions.csv
@@ -1,66 +1,66 @@
 etm_sector,etm_subsector,use,ghg,year,unit,value
-Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,co2,1990,kton CO2-eq,1354.27508
 Agriculture,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,energetic,other_ghg,2023,kton CO2-eq,107.17182
+Agriculture,Non-specified,non_energetic,co2,1990,kton CO2-eq,11.74827
+Agriculture,Non-specified,non_energetic,co2,2023,kton CO2-eq,3.62289
 Agriculture,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,0.0
+Agriculture,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,851.97635
+Buildings,Non-specified,energetic,co2,1990,kton CO2-eq,601.88084
+Buildings,Non-specified,energetic,other_ghg,1990,kton CO2-eq,4.16616
+Buildings,Non-specified,energetic,other_ghg,2023,kton CO2-eq,2.16638
+Bunkers,International aviation,energetic,co2,1990,kton CO2-eq,4604.35501
+Bunkers,International aviation,energetic,other_ghg,1990,kton CO2-eq,35.03174
+Bunkers,International aviation,energetic,other_ghg,2023,kton CO2-eq,77.41099
+Bunkers,International navigation,energetic,co2,1990,kton CO2-eq,34944.30987
+Bunkers,International navigation,energetic,other_ghg,1990,kton CO2-eq,328.83136
+Bunkers,International navigation,energetic,other_ghg,2023,kton CO2-eq,474.73962
 Energy,CCUS,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,CCUS,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fuels production,energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0
+Energy,Electricity and heat production,energetic,co2,1990,kton CO2-eq,3816.25665
+Energy,Electricity and heat production,energetic,other_ghg,1990,kton CO2-eq,14.35332
+Energy,Electricity and heat production,energetic,other_ghg,2023,kton CO2-eq,0.15604
+Energy,Fuels production,energetic,co2,1990,kton CO2-eq,12.41192
+Energy,Fuels production,energetic,other_ghg,1990,kton CO2-eq,0.0415
 Energy,Fuels production,energetic,other_ghg,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Energy,Fugitive emissions,non_energetic,co2,1990,kton CO2-eq,19.83312
+Energy,Fugitive emissions,non_energetic,co2,2023,kton CO2-eq,0.01786
+Energy,Fugitive emissions,non_energetic,other_ghg,1990,kton CO2-eq,43.17742
+Energy,Fugitive emissions,non_energetic,other_ghg,2023,kton CO2-eq,16.32054
 Energy,Hydrogen production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Hydrogen production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,co2,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Energy,Methanol production,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Households,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
+Households,Non-specified,energetic,co2,1990,kton CO2-eq,1762.67125
+Households,Non-specified,energetic,other_ghg,1990,kton CO2-eq,40.65939
+Households,Non-specified,energetic,other_ghg,2023,kton CO2-eq,22.97451
 Industry,Aluminium,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Aluminium,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Aluminium,non_energetic,other_ghg,1990,kton CO2-eq,844.7186
 Industry,Aluminium,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,co2,1990,kton CO2-eq,88.86802
 Industry,Chemicals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Chemicals,non_energetic,other_ghg,1990,kton CO2-eq,457.92964
+Industry,Chemicals,non_energetic,other_ghg,2023,kton CO2-eq,379.13114
 Industry,Fertilizers,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Fertilizers,non_energetic,other_ghg,1990,kton CO2-eq,1471.25567
 Industry,Fertilizers,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Food,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Food,non_energetic,other_ghg,1990,kton CO2-eq,0.00181
 Industry,Food,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Industry,Non-specified,energetic,co2,1990,kton CO2-eq,8794.68232
+Industry,Non-specified,energetic,other_ghg,1990,kton CO2-eq,15.64202
+Industry,Non-specified,energetic,other_ghg,2023,kton CO2-eq,14.63304
+Industry,Other,non_energetic,co2,1990,kton CO2-eq,992.52094
+Industry,Other,non_energetic,co2,2023,kton CO2-eq,336.99876
+Industry,Other,non_energetic,other_ghg,1990,kton CO2-eq,4720.72182
+Industry,Other,non_energetic,other_ghg,2023,kton CO2-eq,43.67414
 Industry,Other metals,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Other metals,non_energetic,co2,2023,kton CO2-eq,0.0
-Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,0.0
+Industry,Other metals,non_energetic,other_ghg,1990,kton CO2-eq,7e-05
 Industry,Other metals,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Paper,non_energetic,co2,2023,kton CO2-eq,0.0
@@ -72,7 +72,7 @@ Industry,Refineries,energetic,other_ghg,2023,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,co2,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Refineries,non_energetic,other_ghg,2023,kton CO2-eq,0.0
-Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.0
+Industry,Steel,non_energetic,co2,1990,kton CO2-eq,0.29299
 Industry,Steel,non_energetic,co2,2023,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 Industry,Steel,non_energetic,other_ghg,2023,kton CO2-eq,0.0
@@ -82,18 +82,18 @@ LULUCF,Emissions,non_energetic,other_ghg,1990,kton CO2-eq,0.0
 LULUCF,Emissions,non_energetic,other_ghg,2023,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,1990,kton CO2-eq,0.0
 LULUCF,Removals,non_energetic,co2,2023,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,0.0
-Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,0.0
+Other,Indirect emissions,non_energetic,co2,1990,kton CO2-eq,67.98693
+Other,Indirect emissions,non_energetic,co2,2023,kton CO2-eq,27.41618
 Other,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
 Other,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Other,Other transportation,energetic,co2,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,0.0
-Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,0.0
-Transport,Non-specified,energetic,co2,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,0.0
-Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,0.0
-Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,0.0
+Other,Other transportation,energetic,co2,1990,kton CO2-eq,25.37238
+Other,Other transportation,energetic,other_ghg,1990,kton CO2-eq,21.41996
+Other,Other transportation,energetic,other_ghg,2023,kton CO2-eq,3.13997
+Transport,Non-specified,energetic,co2,1990,kton CO2-eq,1977.30902
+Transport,Non-specified,energetic,other_ghg,1990,kton CO2-eq,22.09415
+Transport,Non-specified,energetic,other_ghg,2023,kton CO2-eq,25.38341
+Waste,Non-specified,non_energetic,co2,1990,kton CO2-eq,368.46314
+Waste,Non-specified,non_energetic,co2,2023,kton CO2-eq,59.97852
+Waste,Non-specified,non_energetic,other_ghg,1990,kton CO2-eq,3702.93737
+Waste,Non-specified,non_energetic,other_ghg,2023,kton CO2-eq,207.60926


### PR DESCRIPTION
#### Context
This PR updates the emissions.csv files to Dutch regional dataset, imported from ETDataset as result of the Dutch regional data pipeline. 

#### Implemented changes
Data pipeline related:
- New data pipeline added for Dutch regional datasets. Emissieregistratie is used as source applies and conversion steps are applied to generate the required CSV format. 
- Automatic validation is done in the data pipeline.
- Intermediate emissions.csv are exported for manual checks.
- README added
- Restructering of folders in the tools/emissions folder

#### Related

Goes with:
- https://github.com/quintel/etdataset/pull/1097
- https://github.com/quintel/etsource/pull/3465
- https://github.com/quintel/etmodel/pull/4763

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
