### PR TITLE
Update the transport nodes of electric bus, car and motorcycle.

### DIFF
--- a/graphs/energy/nodes/transport/transport_bus_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_bus_using_electricity.converter.ad
@@ -1,5 +1,5 @@
 - output.loss = elastic
-- output.passenger_kms = 2.8361075544174135
+- output.passenger_kms = 1.763043
 - groups = [
     direct_emissions, inheritable_nou, application_group, passenger_transport, mv_net_demand,
     wacc_proven_tech

--- a/graphs/energy/nodes/transport/transport_car_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_car_using_electricity.converter.ad
@@ -1,5 +1,5 @@
 - output.loss = elastic
-- output.passenger_kms = 2.0422269584645436
+- output.passenger_kms = 1.6375
 - groups = [
     direct_emissions, inheritable_nou, application_group, passenger_transport, lv_net_demand,
     wacc_proven_tech

--- a/graphs/energy/nodes/transport/transport_motorcycle_using_electricity.converter.ad
+++ b/graphs/energy/nodes/transport/transport_motorcycle_using_electricity.converter.ad
@@ -1,6 +1,6 @@
 - use = energetic
 - output.loss = elastic
-- output.passenger_kms = 9.104792424818495
+- output.passenger_kms = 2.567705
 - groups = [direct_emissions, application_group, passenger_transport, mv_net_demand]
 - free_co2_factor = 0.0
 - merit_order.group = electric_bikes


### PR DESCRIPTION
#### Context
Some of the current ETM transport efficiencies are not in agreement with the STREAM reports by CE Delft.
We want to update the transport efficiencies of electric passenger vehicles that deviate substantially.

#### Implemented changes
Update the transport efficiencies in the nodes of:
- electric transport: bus, car, motorcycle

#### Related
Goes with pull [#1106](https://github.com/quintel/etdataset/pull/1106)

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
