### PR TITLE
Remove duplicate input for biodiesel share in rail mix

### DIFF
--- a/inputs/demand/transport/transport_passenger/transport_passenger_train/transport_rail_mixer_diesel_biodiesel_share.ad
+++ b/inputs/demand/transport/transport_passenger/transport_passenger_train/transport_rail_mixer_diesel_biodiesel_share.ad
@@ -1,9 +1,0 @@
-- query = UPDATE( INPUT_SLOTS(V(transport_rail_mixer_diesel),biodiesel), conversion, DIVIDE(USER_INPUT(),100))
-- share_group = transport_rail_diesel
-- priority = 0
-- max_value = 100.0
-- min_value = 0.0
-- start_value_gql = present:V(transport_rail_mixer_diesel,biodiesel_input_conversion) * 100
-- step_value = 0.1
-- unit = %
-- update_period = future


### PR DESCRIPTION
#### Context
In https://github.com/quintel/etsource/commit/6c97cc0df2f1f66dcb74978dc6977798e5e682fe the inputs for Transport fuels were moved from Supply to Demand in the frontend. They were also moved in the backend. One input however turns out not to be moved, but to be copied: `transport_rail_mixer_diesel_biodiesel_share`.

This means there was a duplicate input `etsource/inputs/demand/transport/transport_fuels/transport_rail_fuels/transport_rail_mixer_diesel_biodiesel_share` and in `etsource/inputs/demand/transport/transport_passenger/transport_passenger_train/transport_rail_mixer_diesel_biodiesel_share`.

#### Implemented changes
I have aligned with the other transport fuel mixes and removed `etsource/inputs/demand/transport/transport_passenger/transport_passenger_train/transport_rail_mixer_diesel_biodiesel_share`.

#### Related

@aaccensi perhaps we should add a spec on ETSource that checks for duplicate inputs?

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
