### PR TITLE
Heat new households improvement

### DIFF
--- a/inputs/demand/households/households_number/new_residences_total/households_number_of_residences_new.ad
+++ b/inputs/demand/households/households_number/new_residences_total/households_number_of_residences_new.ad
@@ -3,8 +3,11 @@
 # are updated based on the new total number of residences.
 # New number of residences is subsequently distributed across the 4 residence types using
 # the share inputs for new residences.
+#
+# The heat demand per new residence is set equal to present heat demand of the residences from 2005-present of that type.
+# This heat demand per unit is calculated by dividing the preset_demand by the nr. of units.
 # Finally the total number of units and useful heat demand are updated for all 4 types.
-
+#
 # Priorities of related inputs are set as follows:
 # - 4: shares of new residences
 # - 3: number of new buildings & number of buildings demolished
@@ -25,50 +28,38 @@
 
     share_new_apartments = DIVIDE(INPUT_VALUE(households_share_of_apartments), 100.0);
     number_new_apartments = PRODUCT(share_new_apartments, number_of_new_units_future);
-    typical_heat_new_apartments_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_apartments_future)});
-    typical_heat_2005_present_apartments_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_apartments_2005_present)});
-    ratio_2005_present_new_apartments = DIVIDE(typical_heat_new_apartments_present, typical_heat_2005_present_apartments_present);
 
     total_heat_demand_apartments_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_apartments_2005_present, preset_demand)});
     number_of_apartments_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_apartments_2005_present)});
     actual_heat_2005_present_apartments_present = DIVIDE(total_heat_demand_apartments_2005_present, number_of_apartments_2005_present);
-    actual_heat_new_apartments = PRODUCT(ratio_2005_present_new_apartments, actual_heat_2005_present_apartments_present);
+    actual_heat_new_apartments = actual_heat_2005_present_apartments_present;
     total_heat_demand_apartments_new = PRODUCT(number_new_apartments, actual_heat_new_apartments);
 
     share_new_detached = DIVIDE(INPUT_VALUE(households_share_of_detached), 100.0);
     number_new_detached = PRODUCT(share_new_detached, number_of_new_units_future);
-    typical_heat_new_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_detached_houses_future)});
-    typical_heat_2005_present_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_detached_houses_2005_present)});
-    ratio_2005_present_new_detached = DIVIDE(typical_heat_new_detached_present, typical_heat_2005_present_detached_present);
 
     total_heat_demand_detached_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_detached_houses_2005_present, preset_demand)});
     number_of_detached_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_detached_houses_2005_present)});
     actual_heat_2005_present_detached_present = DIVIDE(total_heat_demand_detached_2005_present, number_of_detached_2005_present);
-    actual_heat_new_detached = PRODUCT(ratio_2005_present_new_detached, actual_heat_2005_present_detached_present);
+    actual_heat_new_detached = actual_heat_2005_present_detached_present;
     total_heat_demand_detached_new = PRODUCT(number_new_detached, actual_heat_new_detached);
 
     share_new_semi_detached = DIVIDE(INPUT_VALUE(households_share_of_semi_detached), 100.0);
     number_new_semi_detached = PRODUCT(share_new_semi_detached, number_of_new_units_future);
-    typical_heat_new_semi_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future)});
-    typical_heat_2005_present_semi_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_semi_detached_houses_2005_present)});
-    ratio_2005_present_new_semi_detached = DIVIDE(typical_heat_new_semi_detached_present, typical_heat_2005_present_semi_detached_present);
 
     total_heat_demand_semi_detached_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_semi_detached_houses_2005_present, preset_demand)});
     number_of_semi_detached_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_semi_detached_houses_2005_present)});
     actual_heat_2005_present_semi_detached_present = DIVIDE(total_heat_demand_semi_detached_2005_present, number_of_semi_detached_2005_present);
-    actual_heat_new_semi_detached = PRODUCT(ratio_2005_present_new_semi_detached, actual_heat_2005_present_semi_detached_present);
+    actual_heat_new_semi_detached = actual_heat_2005_present_semi_detached_present;
     total_heat_demand_semi_detached_new = PRODUCT(number_new_semi_detached, actual_heat_new_semi_detached);
 
     share_new_terraced = DIVIDE(INPUT_VALUE(households_share_of_terraced), 100.0);
     number_new_terraced = PRODUCT(share_new_terraced, number_of_new_units_future);
-    typical_heat_new_terraced_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_terraced_houses_future)});
-    typical_heat_2005_present_terraced_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_terraced_houses_2005_present)});
-    ratio_2005_present_new_terraced = DIVIDE(typical_heat_new_terraced_present, typical_heat_2005_present_terraced_present);
 
     total_heat_demand_terraced_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_terraced_houses_2005_present, preset_demand)});
     number_of_terraced_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_terraced_houses_2005_present)});
     actual_heat_2005_present_terraced_present = DIVIDE(total_heat_demand_terraced_2005_present, number_of_terraced_2005_present);
-    actual_heat_new_terraced = PRODUCT(ratio_2005_present_new_terraced, actual_heat_2005_present_terraced_present);
+    actual_heat_new_terraced = actual_heat_2005_present_terraced_present;
     total_heat_demand_terraced_new = PRODUCT(number_new_terraced, actual_heat_new_terraced);
 
     EACH(

--- a/inputs/demand/households/households_number/new_residences_total/households_number_of_residences_new.ad
+++ b/inputs/demand/households/households_number/new_residences_total/households_number_of_residences_new.ad
@@ -31,36 +31,36 @@
 
     total_heat_demand_apartments_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_apartments_2005_present, preset_demand)});
     number_of_apartments_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_apartments_2005_present)});
-    actual_heat_2005_present_apartments_present = DIVIDE(total_heat_demand_apartments_2005_present, number_of_apartments_2005_present);
-    actual_heat_new_apartments = actual_heat_2005_present_apartments_present;
-    total_heat_demand_apartments_new = PRODUCT(number_new_apartments, actual_heat_new_apartments);
+    heat_demand_per_residence_apartments_2005_present = DIVIDE(total_heat_demand_apartments_2005_present, number_of_apartments_2005_present);
+    heat_demand_per_residence_apartments_new = heat_demand_per_residence_apartments_2005_present;
+    total_heat_demand_apartments_new = PRODUCT(number_new_apartments, heat_demand_per_residence_apartments_new);
 
     share_new_detached = DIVIDE(INPUT_VALUE(households_share_of_detached), 100.0);
     number_new_detached = PRODUCT(share_new_detached, number_of_new_units_future);
 
     total_heat_demand_detached_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_detached_houses_2005_present, preset_demand)});
     number_of_detached_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_detached_houses_2005_present)});
-    actual_heat_2005_present_detached_present = DIVIDE(total_heat_demand_detached_2005_present, number_of_detached_2005_present);
-    actual_heat_new_detached = actual_heat_2005_present_detached_present;
-    total_heat_demand_detached_new = PRODUCT(number_new_detached, actual_heat_new_detached);
+    heat_demand_per_residence_detached_2005_present = DIVIDE(total_heat_demand_detached_2005_present, number_of_detached_2005_present);
+    heat_demand_per_residence_detached_new = heat_demand_per_residence_detached_2005_present;
+    total_heat_demand_detached_new = PRODUCT(number_new_detached, heat_demand_per_residence_detached_new);
 
     share_new_semi_detached = DIVIDE(INPUT_VALUE(households_share_of_semi_detached), 100.0);
     number_new_semi_detached = PRODUCT(share_new_semi_detached, number_of_new_units_future);
 
     total_heat_demand_semi_detached_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_semi_detached_houses_2005_present, preset_demand)});
     number_of_semi_detached_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_semi_detached_houses_2005_present)});
-    actual_heat_2005_present_semi_detached_present = DIVIDE(total_heat_demand_semi_detached_2005_present, number_of_semi_detached_2005_present);
-    actual_heat_new_semi_detached = actual_heat_2005_present_semi_detached_present;
-    total_heat_demand_semi_detached_new = PRODUCT(number_new_semi_detached, actual_heat_new_semi_detached);
+    heat_demand_per_residence_semi_detached_2005_present = DIVIDE(total_heat_demand_semi_detached_2005_present, number_of_semi_detached_2005_present);
+    heat_demand_per_residence_semi_detached_new = heat_demand_per_residence_semi_detached_2005_present;
+    total_heat_demand_semi_detached_new = PRODUCT(number_new_semi_detached, heat_demand_per_residence_semi_detached_new);
 
     share_new_terraced = DIVIDE(INPUT_VALUE(households_share_of_terraced), 100.0);
     number_new_terraced = PRODUCT(share_new_terraced, number_of_new_units_future);
 
     total_heat_demand_terraced_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_terraced_houses_2005_present, preset_demand)});
     number_of_terraced_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_terraced_houses_2005_present)});
-    actual_heat_2005_present_terraced_present = DIVIDE(total_heat_demand_terraced_2005_present, number_of_terraced_2005_present);
-    actual_heat_new_terraced = actual_heat_2005_present_terraced_present;
-    total_heat_demand_terraced_new = PRODUCT(number_new_terraced, actual_heat_new_terraced);
+    heat_demand_per_residence_terraced_2005_present = DIVIDE(total_heat_demand_terraced_2005_present, number_of_terraced_2005_present);
+    heat_demand_per_residence_terraced_new = heat_demand_per_residence_terraced_2005_present;
+    total_heat_demand_terraced_new = PRODUCT(number_new_terraced, heat_demand_per_residence_terraced_new);
 
     EACH(
       UPDATE(V(households_useful_demand_for_hot_water_after_solar_heater), number_of_units, total_number_of_units_future),

--- a/inputs/demand/households/households_number/new_residences_total/households_number_of_residences_new.ad
+++ b/inputs/demand/households/households_number/new_residences_total/households_number_of_residences_new.ad
@@ -25,31 +25,51 @@
 
     share_new_apartments = DIVIDE(INPUT_VALUE(households_share_of_apartments), 100.0);
     number_new_apartments = PRODUCT(share_new_apartments, number_of_new_units_future);
-    typical_heat_new_apartments_future = QUERY_FUTURE(-> { AREA(typical_useful_demand_for_space_heating_apartments_future)});
-    typical_surface_area_per_unit_apartments = 84.0916691776263;
-    typical_heat_demand_per_unit_apartments = PRODUCT(typical_heat_new_apartments_future, typical_surface_area_per_unit_apartments);
-    total_heat_demand_apartments_new = PRODUCT(number_new_apartments, typical_heat_demand_per_unit_apartments, MJ_PER_KWH);
+    typical_heat_new_apartments_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_apartments_future)});
+    typical_heat_2005_present_apartments_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_apartments_2005_present)});
+    ratio_2005_present_new_apartments = DIVIDE(typical_heat_new_apartments_present, typical_heat_2005_present_apartments_present);
+
+    total_heat_demand_apartments_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_apartments_2005_present, preset_demand)});
+    number_of_apartments_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_apartments_2005_present)});
+    actual_heat_2005_present_apartments_present = DIVIDE(total_heat_demand_apartments_2005_present, number_of_apartments_2005_present);
+    actual_heat_new_apartments = PRODUCT(ratio_2005_present_new_apartments, actual_heat_2005_present_apartments_present);
+    total_heat_demand_apartments_new = PRODUCT(number_new_apartments, actual_heat_new_apartments);
 
     share_new_detached = DIVIDE(INPUT_VALUE(households_share_of_detached), 100.0);
     number_new_detached = PRODUCT(share_new_detached, number_of_new_units_future);
-    typical_heat_new_detached_future = QUERY_FUTURE(-> { AREA(typical_useful_demand_for_space_heating_detached_houses_future)});
-    typical_surface_area_per_unit_detached = 224.001485938283;
-    typical_heat_demand_per_unit_detached = PRODUCT(typical_heat_new_detached_future, typical_surface_area_per_unit_detached);
-    total_heat_demand_detached_new = PRODUCT(number_new_detached, typical_heat_demand_per_unit_detached, MJ_PER_KWH);
+    typical_heat_new_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_detached_houses_future)});
+    typical_heat_2005_present_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_detached_houses_2005_present)});
+    ratio_2005_present_new_detached = DIVIDE(typical_heat_new_detached_present, typical_heat_2005_present_detached_present);
+
+    total_heat_demand_detached_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_detached_houses_2005_present, preset_demand)});
+    number_of_detached_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_detached_houses_2005_present)});
+    actual_heat_2005_present_detached_present = DIVIDE(total_heat_demand_detached_2005_present, number_of_detached_2005_present);
+    actual_heat_new_detached = PRODUCT(ratio_2005_present_new_detached, actual_heat_2005_present_detached_present);
+    total_heat_demand_detached_new = PRODUCT(number_new_detached, actual_heat_new_detached);
 
     share_new_semi_detached = DIVIDE(INPUT_VALUE(households_share_of_semi_detached), 100.0);
     number_new_semi_detached = PRODUCT(share_new_semi_detached, number_of_new_units_future);
-    typical_heat_new_semi_detached_future = QUERY_FUTURE(-> { AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future)});
-    typical_surface_area_per_unit_semi_detached = 147.709471392282;
-    typical_heat_demand_per_unit_semi_detached = PRODUCT(typical_heat_new_semi_detached_future, typical_surface_area_per_unit_semi_detached);
-    total_heat_demand_semi_detached_new = PRODUCT(number_new_semi_detached, typical_heat_demand_per_unit_semi_detached, MJ_PER_KWH);
+    typical_heat_new_semi_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_semi_detached_houses_future)});
+    typical_heat_2005_present_semi_detached_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_semi_detached_houses_2005_present)});
+    ratio_2005_present_new_semi_detached = DIVIDE(typical_heat_new_semi_detached_present, typical_heat_2005_present_semi_detached_present);
+
+    total_heat_demand_semi_detached_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_semi_detached_houses_2005_present, preset_demand)});
+    number_of_semi_detached_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_semi_detached_houses_2005_present)});
+    actual_heat_2005_present_semi_detached_present = DIVIDE(total_heat_demand_semi_detached_2005_present, number_of_semi_detached_2005_present);
+    actual_heat_new_semi_detached = PRODUCT(ratio_2005_present_new_semi_detached, actual_heat_2005_present_semi_detached_present);
+    total_heat_demand_semi_detached_new = PRODUCT(number_new_semi_detached, actual_heat_new_semi_detached);
 
     share_new_terraced = DIVIDE(INPUT_VALUE(households_share_of_terraced), 100.0);
     number_new_terraced = PRODUCT(share_new_terraced, number_of_new_units_future);
-    typical_heat_new_terraced_future = QUERY_FUTURE(-> { AREA(typical_useful_demand_for_space_heating_terraced_houses_future)});
-    typical_surface_area_per_unit_terraced = 130.419159051538;
-    typical_heat_demand_per_unit_terraced = PRODUCT(typical_heat_new_terraced_future, typical_surface_area_per_unit_terraced);
-    total_heat_demand_terraced_new = PRODUCT(number_new_terraced, typical_heat_demand_per_unit_terraced, MJ_PER_KWH);
+    typical_heat_new_terraced_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_terraced_houses_future)});
+    typical_heat_2005_present_terraced_present = QUERY_PRESENT(-> {AREA(typical_useful_demand_for_space_heating_terraced_houses_2005_present)});
+    ratio_2005_present_new_terraced = DIVIDE(typical_heat_new_terraced_present, typical_heat_2005_present_terraced_present);
+
+    total_heat_demand_terraced_2005_present = QUERY_PRESENT(->{V(households_useful_demand_for_space_heating_terraced_houses_2005_present, preset_demand)});
+    number_of_terraced_2005_present = QUERY_PRESENT(-> {AREA(present_number_of_terraced_houses_2005_present)});
+    actual_heat_2005_present_terraced_present = DIVIDE(total_heat_demand_terraced_2005_present, number_of_terraced_2005_present);
+    actual_heat_new_terraced = PRODUCT(ratio_2005_present_new_terraced, actual_heat_2005_present_terraced_present);
+    total_heat_demand_terraced_new = PRODUCT(number_new_terraced, actual_heat_new_terraced);
 
     EACH(
       UPDATE(V(households_useful_demand_for_hot_water_after_solar_heater), number_of_units, total_number_of_units_future),


### PR DESCRIPTION
#### Context
The previous calculation method used a kWh/m2 and m2/residence value to calculate the heat demand of new houses. This deviated from the method for existing houses and resulted in much higher heat demands than expected for new houses. To compensate this, the start value for heat demand for new houses is set equal to heat demand of the most recent existing building of that type.

This was not done for the heat demand per non-residential building since this 'issue' arise there.

#### Implemented changes
- Set heat demand for new residences equal to heat demand of residences from 2005-present

#### Related
This branch was created from the one below, which PR is still in review. That branch contains the new chart for residential heat demand.

Goes with pull requests:
- https://github.com/quintel/etsource/pull/3479

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
