### PR TITLE
Add new inputs for external coupling to CTM

### DIFF
--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_aluminium_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_aluminium_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_aluminium_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_aluminium_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_chemicals_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_chemicals_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_fertilizers_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_fertilizers_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_food_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_food_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_food_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_food_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_non_specified_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_non_specified_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_metals_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_metals_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_metals_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_metals_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_other_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_paper_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_paper_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_paper_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_paper_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_refineries_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_refineries_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_refineries_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_refineries_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_steel_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_steel_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_steel_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_industry_steel_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_industry]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_waste_non_specified_non_energetic_co2.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_waste_non_specified_non_energetic_co2.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_waste]

--- a/inputs/emissions/greenhouse_gases/direct_emissions/emissions_waste_non_specified_non_energetic_other_ghg.ad
+++ b/inputs/emissions/greenhouse_gases/direct_emissions/emissions_waste_non_specified_non_energetic_other_ghg.ad
@@ -18,3 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
+- disabled_by_couplings = [external_model_industry, emissions_waste]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_aluminium_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_aluminium_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_aluminium_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_aluminium_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_aluminium_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_aluminium_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_aluminium_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_aluminium_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_aluminium_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_aluminium_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_chemicals_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_chemicals_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_chemicals_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_chemicals_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_chemicals_non_energetic_other_ghg.ad
@@ -18,4 +18,4 @@
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_fertilizers_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_fertilizers_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_fertilizers_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_fertilizers_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_fertilizers_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_food_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_food_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_food_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_food_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_food_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_food_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_food_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_food_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_food_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_food_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_non_specified_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_non_specified_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_non_specified_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_non_specified_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_non_specified_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_metals_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_metals_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_other_metals_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_other_metals_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_other_metals_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_metals_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_metals_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_other_metals_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_other_metals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_other_metals_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_other_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_other_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_other_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_other_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_other_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_other_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_other_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_paper_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_paper_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_paper_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_paper_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_paper_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_paper_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_paper_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_paper_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_paper_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_paper_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_refineries_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_refineries_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_refineries_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_refineries_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_refineries_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_refineries_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_refineries_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_refineries_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_refineries_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_refineries_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_steel_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_steel_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_steel_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_steel_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_steel_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_steel_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_industry/external_coupling_emissions_industry_steel_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(industry_steel_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(industry_steel_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(industry_steel_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_industry]

--- a/inputs/modules/external_coupling/emissions_waste/external_coupling_emissions_waste_non_specified_non_energetic_co2.ad
+++ b/inputs/modules/external_coupling/emissions_waste/external_coupling_emissions_waste_non_specified_non_energetic_co2.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(waste_non_specified_non_energetic_co2),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(waste_non_specified_non_energetic_co2, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(waste_non_specified_non_energetic_co2, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_waste]

--- a/inputs/modules/external_coupling/emissions_waste/external_coupling_emissions_waste_non_specified_non_energetic_other_ghg.ad
+++ b/inputs/modules/external_coupling/emissions_waste/external_coupling_emissions_waste_non_specified_non_energetic_other_ghg.ad
@@ -3,7 +3,7 @@
 
 - query =
     UPDATE(
-      MV(industry_chemicals_non_energetic_other_ghg),
+      MV(waste_non_specified_non_energetic_other_ghg),
       preset_demand,
       PRODUCT(USER_INPUT(), MILLIONS)
     )
@@ -11,11 +11,11 @@
 - max_value_gql =
     present:MAX(
       Q(max_value_dataset_derived_direct_emissions),
-      PRODUCT(DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS), 1.5)
+      PRODUCT(DIVIDE(MV(waste_non_specified_non_energetic_other_ghg, demand), MILLIONS), 1.5)
     )
 - min_value = 0.0
-- start_value_gql = present:DIVIDE(MV(industry_chemicals_non_energetic_other_ghg, demand), MILLIONS)
+- start_value_gql = present:DIVIDE(MV(waste_non_specified_non_energetic_other_ghg, demand), MILLIONS)
 - step_value = 0.1
 - unit = kT
 - update_period = future
-- disabled_by_couplings = [external_model_industry, emissions_industry]
+- coupling_groups = [external_model_industry, emissions_waste]


### PR DESCRIPTION

#### Context
The end results of emissions in industry and waste in the ETM coupled to the CTM, is not in agreement with the end result of emissions in the CTM alone. Therefore, new external coupling inputs are created such that the resulting emissions of the CTM can be entered directly into the ETM. 

#### Implemented changes
- Create new external coupling inputs for the emissions of industry and waste. 
- Add the correct coupling groups to the new inputs.
- Edit the original emissions inputs to include the coupling group in `disabled by coupling` .

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
